### PR TITLE
fix: session memory and preference updates (exam Q2) - Zihan

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,105 @@ curl -X POST http://localhost:8001/chat \
   -d '{"message": "I need an SUV under 30k"}'
 ```
 
+## Reproducing take-home exam results (Q1 / Q2 branches)
+
+The exam work lives on two **standalone** branches (each is based on `main` and can be merged or reviewed independently):
+
+| Branch | Topic | Primary tests |
+|--------|--------|----------------|
+| `q1-exclusion-zihan` | Brand exclusion & negated specs | `agent/tests/test_brand_exclusion.py` |
+| `q2-exclusion-zihan` | Session memory & preference updates | `agent/tests/test_session_memory.py` |
+
+**What you are reproducing:** these branches are validated with **unit tests** that mock LLM calls and assert on `UniversalAgent` filters and `get_search_filters()` output. They do **not** print full product recommendation payloads from the database—getting “raw” recommender rows requires a running backend with `DATABASE_URL` and hitting `/chat` or `scripts/test_demo_queries.py` against a live URL.
+
+### Prerequisites
+
+- Python 3.10+ and a virtualenv (same as [Quick Start](#quick-start) above).
+- Install dependencies from the repo root:
+
+```bash
+pip install -r requirements.txt
+pip install -r mcp-server/requirements.txt
+```
+
+- Set `OPENAI_API_KEY` in `.env` (tests mock most LLM calls, but imports may still expect the env to exist).
+
+The agent imports `app.*` from `mcp-server/`, so **`PYTHONPATH` must include `mcp-server`** when running pytest from the repository root.
+
+### Q1 branch (`q1-exclusion-zihan`) — brand exclusion
+
+```bash
+git fetch origin
+git checkout q1-exclusion-zihan
+```
+
+**Run the dedicated test file (16 tests):**
+
+```bash
+# macOS / Linux
+export PYTHONPATH=mcp-server
+python -m pytest agent/tests/test_brand_exclusion.py -v
+```
+
+```powershell
+# Windows PowerShell
+$env:PYTHONPATH = "mcp-server"
+python -m pytest agent/tests/test_brand_exclusion.py -v
+```
+
+**Optional — full agent test suite** (to check for regressions among existing tests):
+
+```bash
+export PYTHONPATH=mcp-server
+python -m pytest agent/tests/ -v
+```
+
+**Optional — demo queries against a running API** (needs credentials + server; exercises end-to-end search, not just unit mocks):
+
+```bash
+export PYTHONPATH=mcp-server
+python scripts/test_demo_queries.py --group "brand_exclusion" --verbose
+# Add --url https://your-backend.example/chat if not localhost
+```
+
+### Q2 branch (`q2-exclusion-zihan`) — session memory
+
+```bash
+git fetch origin
+git checkout q2-exclusion-zihan
+```
+
+**Run the dedicated test file (15 tests):**
+
+```bash
+export PYTHONPATH=mcp-server
+python -m pytest agent/tests/test_session_memory.py -v
+```
+
+```powershell
+# Windows PowerShell
+$env:PYTHONPATH = "mcp-server"
+python -m pytest agent/tests/test_session_memory.py -v
+```
+
+**Optional — full agent test suite:**
+
+```bash
+export PYTHONPATH=mcp-server
+python -m pytest agent/tests/ -v
+```
+
+### Expected outcome
+
+- **Q1:** `16 passed` for `test_brand_exclusion.py` (plus the rest of `agent/tests/` should still pass if you run the full suite on that branch).
+- **Q2:** `15 passed` for `test_session_memory.py` (same note for the full suite).
+
+If you see `ModuleNotFoundError: No module named 'app'`, `PYTHONPATH` is not set to `mcp-server` from the repo root.
+
+### Merge order (if you apply both)
+
+Merge **`q1-exclusion-zihan` into `main` first**, then merge or rebase **`q2-exclusion-zihan`**, because both touch `agent/prompts.py` and `agent/universal_agent.py`.
+
 ## How It Works
 
 ### The Universal Agent Pipeline

--- a/agent/chat_endpoint.py
+++ b/agent/chat_endpoint.py
@@ -529,7 +529,7 @@ async def process_chat(request: ChatRequest) -> ChatResponse:
     session.question_count = agent_state["question_count"]
     if agent_state["domain"]:
         session_manager.set_active_domain(session_id, agent_state["domain"])
-    session_manager.update_filters(session_id, agent.get_search_filters())
+    session_manager.update_filters(session_id, agent.get_search_filters(), replace=True)
     session_manager._persist(session_id)
 
     response_type = agent_response.get("response_type")
@@ -2300,7 +2300,7 @@ async def _handle_post_recommendation(
         session.agent_filters = agent_state["filters"]
         session.agent_questions_asked = agent_state["questions_asked"]
         session.agent_history = agent_state["history"]
-        session_manager.update_filters(session_id, search_filters)
+        session_manager.update_filters(session_id, search_filters, replace=True)
         session_manager._persist(session_id)
 
         if active_domain == "vehicles":

--- a/agent/interview/session_manager.py
+++ b/agent/interview/session_manager.py
@@ -387,12 +387,24 @@ class InterviewSessionManager:
         except Exception:
             pass  # Neo4j optional
     
-    def update_filters(self, session_id: str, filters: Dict[str, Any]) -> None:
-        """Update filters for a session."""
+    def update_filters(self, session_id: str, filters: Dict[str, Any], replace: bool = False) -> None:
+        """Update filters for a session.
+
+        When *replace* is True the existing explicit_filters are fully replaced
+        by the incoming dict (minus None / underscore-prefixed keys).  This
+        prevents stale keys like ``good_for_ml=True`` from persisting after the
+        user switches use-case.  Default is merge (backward-compatible).
+        """
         session = self.get_session(session_id)
-        for key, value in filters.items():
-            if value is not None and not key.startswith("_"):
-                session.explicit_filters[key] = value
+        if replace:
+            session.explicit_filters = {
+                k: v for k, v in filters.items()
+                if v is not None and not k.startswith("_")
+            }
+        else:
+            for key, value in filters.items():
+                if value is not None and not key.startswith("_"):
+                    session.explicit_filters[key] = value
         self._persist(session_id)
 
     def set_active_domain(self, session_id: str, domain: str) -> None:

--- a/agent/prompts.py
+++ b/agent/prompts.py
@@ -90,14 +90,27 @@ EXTRACTION RULES:
              "we hate mac" → excluded_brands="Apple"
              "steer clear of Lenovo" → excluded_brands="Lenovo"
 
-4. OS requirements ("Windows 10", "Linux only", "must have macOS"):
+4. CONTRADICTION / CORRECTION — the current user message ALWAYS overrides conversation
+   history. When the user corrects, revises, or contradicts a prior preference, extract
+   ONLY the NEW value from the current message. Do NOT re-extract the old value from
+   previous turns in the conversation.
+   - History: "I need something for machine learning" → Current: "Actually it's just for
+     email and Netflix" → extract use_case="general" or use_case="casual". Do NOT extract
+     use_case="machine learning" or good_for_ml.
+   - History: "budget $800" → Current: "make it under $600" → extract budget="under600".
+     Do NOT also extract budget="under800".
+   - Signals that a prior preference is revoked: "actually", "instead", "forget that",
+     "never mind", "changed my mind", "on second thought", "scratch that", "no wait".
+   When you see these signals, disregard contradicted slots from conversation history.
+
+5. OS requirements ("Windows 10", "Linux only", "must have macOS"):
    → slot_name="os", value="Windows 10" etc.
 
-5. For slots with ALLOWED VALUES, map the user's words to the closest allowed value exactly.
+6. For slots with ALLOWED VALUES, map the user's words to the closest allowed value exactly.
 
-6. Only extract what is explicitly stated or clearly inferable. Do NOT guess.
+7. Only extract what is explicitly stated or clearly inferable. Do NOT guess.
 
-7. For budget, PRESERVE the direction keyword in the value string:
+8. For budget, PRESERVE the direction keyword in the value string:
    - "over $1000", "above $1000", "more than $1000", "at least $1000", "minimum $1000", "starting from $1000" → value="over1000"
    - "under $1000", "below $1000", "less than $1000", "up to $1000", "max $1000" → value="under1000"
    - "$1000-$2000", "between $1000 and $2000" → value="1000-2000"
@@ -220,6 +233,21 @@ Classify the user's intent into ONE of these categories:
    Examples: "tell me more about the first one", "compare these", "add to cart", "rate these"
 
 5. "other" — Greeting, off-topic, or unclear intent.
+
+IMPORTANT — use ONLY these canonical slot names in updated_criteria (never aliases):
+  budget (not "price", "max_price", "price_range", "cost")
+  brand
+  use_case
+  min_ram_gb (not "ram", "memory")
+  screen_size (not "display", "screen")
+  min_storage_gb
+  gpu_tier
+  os
+  color
+  excluded_brands
+
+When the user corrects a previously set value (e.g. "make it under $600" when budget was $800),
+output the NEW value with the canonical slot name so the old value is properly overwritten.
 
 Current domain: {domain}
 Current filters: {filters}

--- a/agent/tests/test_session_memory.py
+++ b/agent/tests/test_session_memory.py
@@ -1,0 +1,396 @@
+"""
+Unit tests for session memory and preference management (Question 2).
+
+Covers the 3 failure scenarios:
+A. "I want a Dell laptop under $800" → "Actually, make it under $600" → stale budget
+B. Gaming laptop turns 1-3 → "forget the gaming specs" → specs persist
+C. "machine learning" → "Actually just email and Netflix" → ML use case persists
+
+Tests run without DB or OpenAI credentials by mocking LLM calls.
+"""
+
+import os
+import re
+import pytest
+from unittest.mock import patch, MagicMock
+
+os.environ.setdefault("OPENAI_API_KEY", "test-dummy-key-for-unit-tests")
+
+from agent.universal_agent import (
+    UniversalAgent,
+    ExtractedCriteria,
+    SlotValue,
+    RefinementClassification,
+    _SLOT_NAME_ALIASES,
+)
+from agent.domain_registry import get_domain_schema
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_agent(session_id="test-mem", domain="laptops", filters=None):
+    """Create a UniversalAgent pre-configured for the laptops domain."""
+    agent = UniversalAgent(session_id=session_id)
+    agent.domain = domain
+    if filters:
+        agent.filters = dict(filters)
+    return agent
+
+
+def _mock_extraction(criteria_list, wants_recs=True):
+    """Build a mock ExtractedCriteria return value."""
+    items = [SlotValue(slot_name=k, value=v) for k, v in criteria_list]
+    return ExtractedCriteria(
+        criteria=items,
+        reasoning="test",
+        is_impatient=False,
+        wants_recommendations=wants_recs,
+    )
+
+
+def _mock_openai_parse(mock_parsed):
+    """Create a MagicMock that mimics the OpenAI beta.chat.completions.parse response."""
+    mock_choice = MagicMock()
+    mock_choice.message.parsed = mock_parsed
+    mock_completion = MagicMock()
+    mock_completion.choices = [mock_choice]
+    return mock_completion
+
+
+# ===========================================================================
+# Scenario A — Budget update not applied
+# ===========================================================================
+
+class TestBudgetOverwriteInterviewPath:
+    """When the user says 'actually under $600' mid-interview, the old
+    budget='under800' must be overwritten, not kept."""
+
+    def test_budget_overwrite_via_extract_criteria(self):
+        agent = _make_agent(filters={"budget": "under800", "brand": "Dell"})
+        schema = get_domain_schema("laptops")
+
+        mock_parsed = _mock_extraction([("budget", "under600")], wants_recs=True)
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            agent._extract_criteria("Actually, make it under $600", schema)
+
+        assert agent.filters["budget"] == "under600", \
+            "budget should be overwritten to under600"
+        sf = agent.get_search_filters()
+        assert sf.get("price_max_cents") == 60000, \
+            f"price_max_cents should be 60000, got {sf.get('price_max_cents')}"
+
+    def test_budget_cleared_by_soft_reset_when_dollar_present(self):
+        """'actually' + '$600' should clear old budget before extraction."""
+        agent = _make_agent(filters={"budget": "under800", "brand": "Dell"})
+        agent.domain = "laptops"
+
+        # Simulate the preference reset logic from process_message
+        message = "Actually, make it under $600"
+        msg_lower = message.lower()
+
+        _PREF_RESET_PHRASES = (
+            "changed my mind", "change my mind", "actually", "instead show",
+            "show me instead", "forget that", "never mind", "nevermind",
+            "scratch that", "different brand", "switch to", "go with",
+        )
+        _soft_reset = any(p in msg_lower for p in _PREF_RESET_PHRASES) and agent.domain
+
+        assert _soft_reset, "'actually' should trigger soft reset"
+
+        _has_budget_signal = re.search(
+            r'(?:under|below|over|above|less than|at most|budget|'
+            r'max|up\s+to|starting)\s*\$?\s*\d',
+            msg_lower,
+        ) or re.search(r'\$\s*\d', msg_lower)
+
+        assert _has_budget_signal, "dollar amount should be detected"
+
+        if _soft_reset and _has_budget_signal and "budget" in agent.filters:
+            agent.filters.pop("budget", None)
+
+        assert "budget" not in agent.filters, \
+            "old budget should be cleared before LLM extraction"
+
+
+class TestBudgetOverwriteRefinementPath:
+    """process_refinement must normalise slot names so 'price' → 'budget'."""
+
+    def test_refinement_normalises_price_to_budget(self):
+        agent = _make_agent(filters={"budget": "under800", "brand": "Dell"})
+
+        mock_parsed = RefinementClassification(
+            intent="refine_filters",
+            updated_criteria=[SlotValue(slot_name="price", value="under600")],
+            reasoning="user wants cheaper",
+        )
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            result = agent.process_refinement("Actually, make it under $600")
+
+        assert agent.filters.get("budget") == "under600", \
+            f"'price' should be normalised to 'budget'; got filters={agent.filters}"
+        assert "price" not in agent.filters, \
+            "'price' key should not exist after normalisation"
+
+    def test_refinement_normalises_max_price_to_budget(self):
+        agent = _make_agent(filters={"budget": "under800"})
+
+        mock_parsed = RefinementClassification(
+            intent="refine_filters",
+            updated_criteria=[SlotValue(slot_name="max_price", value="600")],
+            reasoning="budget correction",
+        )
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            agent.process_refinement("make it under $600")
+
+        assert agent.filters.get("budget") == "600", \
+            "'max_price' should be normalised to 'budget'"
+
+    def test_refinement_normalises_ram_to_min_ram_gb(self):
+        agent = _make_agent(filters={"min_ram_gb": "8"})
+
+        mock_parsed = RefinementClassification(
+            intent="refine_filters",
+            updated_criteria=[SlotValue(slot_name="ram", value="16")],
+            reasoning="user wants more RAM",
+        )
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            agent.process_refinement("I need 16GB RAM")
+
+        assert agent.filters.get("min_ram_gb") == "16", \
+            "'ram' should be normalised to 'min_ram_gb'"
+
+
+# ===========================================================================
+# Scenario B — Gaming specs not cleared on intent shift
+# ===========================================================================
+
+class TestGamingSpecsClearedOnForget:
+    """'Forget the gaming specs' must clear min_ram_gb, gpu_tier,
+    use_case, and good_for_gaming — not just brand/use_case."""
+
+    def test_hard_reset_clears_gaming_specs(self):
+        agent = _make_agent(filters={
+            "use_case": "gaming",
+            "min_ram_gb": "16",
+            "gpu_tier": "dedicated",
+            "screen_size": "15.6",
+            "budget": "under1500",
+            "good_for_gaming": True,
+        })
+
+        schema = get_domain_schema("laptops")
+        mock_parsed = _mock_extraction([("budget", "under600")], wants_recs=False)
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            agent.process_message("forget the gaming specs, I'm on a tight budget under $600")
+
+        assert agent.filters.get("use_case") is None, "use_case should be cleared"
+        assert agent.filters.get("min_ram_gb") is None, "min_ram_gb should be cleared"
+        assert agent.filters.get("gpu_tier") is None, "gpu_tier should be cleared"
+        assert agent.filters.get("screen_size") is None, "screen_size should be cleared"
+        assert agent.filters.get("good_for_gaming") is None, "good_for_gaming should be cleared"
+
+    def test_hard_reset_preserves_brand(self):
+        """Brand is a soft slot but should still be cleared on hard reset."""
+        agent = _make_agent(filters={
+            "brand": "ASUS",
+            "use_case": "gaming",
+            "min_ram_gb": "16",
+            "budget": "under1500",
+        })
+
+        schema = get_domain_schema("laptops")
+        mock_parsed = _mock_extraction([("budget", "under600")], wants_recs=False)
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            agent.process_message("forget the gaming specs, basic laptop please")
+
+        assert agent.filters.get("brand") is None, "brand should be cleared on hard reset"
+        assert agent.filters.get("min_ram_gb") is None, "min_ram_gb should be cleared"
+
+    def test_no_more_gaming_triggers_hard_reset(self):
+        agent = _make_agent(filters={
+            "use_case": "gaming",
+            "good_for_gaming": True,
+            "min_ram_gb": "32",
+        })
+
+        schema = get_domain_schema("laptops")
+        mock_parsed = _mock_extraction([("use_case", "general")], wants_recs=False)
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            agent.process_message("no more gaming, just something simple")
+
+        assert agent.filters.get("good_for_gaming") is None
+        assert agent.filters.get("min_ram_gb") is None
+
+
+# ===========================================================================
+# Scenario C — Contradictory use case not resolved
+# ===========================================================================
+
+class TestUseCaseContradictionClearsGoodFor:
+    """When use_case changes from ML to email, stale good_for_ml must be removed."""
+
+    def test_good_for_ml_cleared_on_use_case_change(self):
+        agent = _make_agent(filters={
+            "use_case": "machine learning",
+            "good_for_ml": True,
+            "min_ram_gb": "32",
+            "budget": "under2000",
+        })
+        schema = get_domain_schema("laptops")
+
+        mock_parsed = _mock_extraction([("use_case", "general")], wants_recs=False)
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            agent._extract_criteria("Actually it's just for email and Netflix", schema)
+
+        assert agent.filters.get("good_for_ml") is None, \
+            "good_for_ml should be cleared when use_case changes"
+        assert agent.filters["use_case"] == "general", \
+            "use_case should be updated to 'general'"
+        sf = agent.get_search_filters()
+        assert sf.get("good_for_ml") is not True, \
+            "search_filters should not contain good_for_ml"
+
+    def test_good_for_gaming_cleared_when_use_case_becomes_school(self):
+        agent = _make_agent(filters={
+            "use_case": "gaming",
+            "good_for_gaming": True,
+        })
+        schema = get_domain_schema("laptops")
+
+        mock_parsed = _mock_extraction([("use_case", "school")], wants_recs=False)
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            agent._extract_criteria("Actually this is for school work", schema)
+
+        assert agent.filters.get("good_for_gaming") is None
+        assert agent.filters["use_case"] == "school"
+
+    def test_multiple_good_for_flags_cleared(self):
+        agent = _make_agent(filters={
+            "use_case": "creative",
+            "good_for_creative": True,
+            "good_for_web_dev": True,
+        })
+        schema = get_domain_schema("laptops")
+
+        mock_parsed = _mock_extraction([("use_case", "gaming")], wants_recs=False)
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            agent._extract_criteria("Actually I want a gaming laptop", schema)
+
+        assert agent.filters.get("good_for_creative") is None
+        assert agent.filters.get("good_for_web_dev") is None
+        assert agent.filters["use_case"] == "gaming"
+
+
+# ===========================================================================
+# No-regression: soft reset should NOT wipe unrelated slots
+# ===========================================================================
+
+class TestSoftResetPreservesUnrelated:
+    """'Actually' + new brand must not wipe budget or RAM."""
+
+    def test_soft_reset_keeps_budget_and_ram(self):
+        agent = _make_agent(filters={
+            "brand": "Dell",
+            "use_case": "school",
+            "budget": "under800",
+            "min_ram_gb": "16",
+        })
+        schema = get_domain_schema("laptops")
+
+        mock_parsed = _mock_extraction([("brand", "HP")], wants_recs=False)
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            agent.process_message("Actually, show me HP instead")
+
+        assert agent.filters.get("budget") == "under800", \
+            "budget should survive a soft reset"
+        assert agent.filters.get("min_ram_gb") == "16", \
+            "min_ram_gb should survive a soft reset"
+        assert agent.filters.get("brand") == "HP", \
+            "brand should be updated to HP"
+
+    def test_soft_reset_clears_old_use_case_but_keeps_screen_size(self):
+        agent = _make_agent(filters={
+            "use_case": "gaming",
+            "screen_size": "15.6",
+            "budget": "under1000",
+        })
+        schema = get_domain_schema("laptops")
+
+        mock_parsed = _mock_extraction([("use_case", "school")], wants_recs=False)
+        mock_completion = _mock_openai_parse(mock_parsed)
+
+        with patch.object(agent.client.beta.chat.completions, "parse", return_value=mock_completion):
+            agent.process_message("Actually this is for school")
+
+        assert agent.filters.get("use_case") == "school"
+        assert agent.filters.get("screen_size") == "15.6", \
+            "screen_size should survive a soft reset (not a hard reset phrase)"
+        assert agent.filters.get("budget") == "under1000"
+
+
+# ===========================================================================
+# Replace-mode update_filters
+# ===========================================================================
+
+class TestReplaceModeUpdateFilters:
+    """session_manager.update_filters(replace=True) should remove stale keys."""
+
+    def _make_sm(self, session_id, explicit_filters):
+        from agent.interview.session_manager import InterviewSessionManager, InterviewSessionState
+        sm = InterviewSessionManager.__new__(InterviewSessionManager)
+        sm.sessions = {}
+        sm._agent_cache = None
+        state = InterviewSessionState()
+        state.explicit_filters = dict(explicit_filters)
+        sm.sessions[session_id] = state
+        return sm, state
+
+    def test_replace_removes_stale_good_for_ml(self):
+        sm, state = self._make_sm("test-replace", {
+            "good_for_ml": True,
+            "price_max_cents": 200000,
+            "brand": "Dell",
+        })
+
+        with patch.object(sm, "_persist"):
+            sm.update_filters("test-replace", {"price_max_cents": 60000}, replace=True)
+
+        assert state.explicit_filters == {"price_max_cents": 60000}, \
+            f"replace=True should fully replace; got {state.explicit_filters}"
+
+    def test_merge_preserves_existing_keys(self):
+        sm, state = self._make_sm("test-merge", {
+            "good_for_ml": True,
+            "price_max_cents": 200000,
+        })
+
+        with patch.object(sm, "_persist"):
+            sm.update_filters("test-merge", {"price_max_cents": 60000}, replace=False)
+
+        assert state.explicit_filters["price_max_cents"] == 60000
+        assert state.explicit_filters.get("good_for_ml") is True, \
+            "merge mode should preserve keys not in new_filters"

--- a/agent/universal_agent.py
+++ b/agent/universal_agent.py
@@ -561,21 +561,57 @@ class UniversalAgent:
             return response
 
         # ── "Changed my mind" preference reset ──────────────────────────────────
-        # If the user signals a preference change mid-session (same domain), clear
-        # soft slot values (brand, use_case) so the new preference fully replaces the
-        # old one.  Budget and RAM are kept (user hasn't said they changed those).
+        # Two tiers:
+        #   1. Soft reset — clears brand / use_case level preferences.
+        #   2. Hard reset — triggered by explicit "forget the specs/gaming" phrases,
+        #      clears soft slots PLUS hardware spec slots and good_for_* flags so
+        #      the user can pivot from e.g. a gaming build to a basic laptop.
         _PREF_RESET_PHRASES = (
             "changed my mind", "change my mind", "actually", "instead show",
             "show me instead", "forget that", "never mind", "nevermind",
             "scratch that", "different brand", "switch to", "go with",
         )
+        _SPEC_RESET_PHRASES = (
+            "forget the gaming", "forget gaming", "forget the specs", "forget specs",
+            "drop the specs", "drop specs", "no more gaming", "no gaming",
+            "start simple", "keep it simple", "basic laptop", "just basic",
+            "forget the ml", "forget ml", "forget machine learning",
+            "different use case", "completely different",
+        )
+        _soft_slots = {"brand", "use_case", "color", "os", "product_subtype"}
+        _hard_reset_slots = {
+            "min_ram_gb", "gpu_tier", "min_storage_gb", "screen_size",
+            "min_screen_size", "max_screen_size", "min_battery_hours",
+            "good_for_gaming", "good_for_ml", "good_for_creative", "good_for_web_dev",
+        }
         msg_lower_chk = message.lower()
-        if any(p in msg_lower_chk for p in _PREF_RESET_PHRASES) and self.domain:
-            # Clear only the soft preferences — keep hard constraints (budget, RAM, screen_size)
-            _soft_slots = {"brand", "use_case", "color", "os", "product_subtype"}
+
+        _hard_reset = any(p in msg_lower_chk for p in _SPEC_RESET_PHRASES) and self.domain
+        _soft_reset = any(p in msg_lower_chk for p in _PREF_RESET_PHRASES) and self.domain
+
+        if _hard_reset:
+            _all_clear = _soft_slots | _hard_reset_slots
+            for slot in _all_clear:
+                self.filters.pop(slot, None)
+            logger.info(f"Hard preference reset — cleared soft + spec slots: {_all_clear}")
+        elif _soft_reset:
             for slot in _soft_slots:
                 self.filters.pop(slot, None)
-            logger.info(f"Preference reset detected — cleared soft slots: {_soft_slots}")
+            logger.info(f"Soft preference reset — cleared soft slots: {_soft_slots}")
+
+        # Budget-aware reset: when a soft/hard reset phrase co-occurs with a new
+        # dollar amount or "under/over $X", clear the old budget so the LLM
+        # extraction on this turn can set it cleanly (no stale $800 competing
+        # with the new $600).
+        if (_soft_reset or _hard_reset) and self.domain:
+            _has_budget_signal = re.search(
+                r'(?:under|below|over|above|less than|at most|budget|'
+                r'max|up\s+to|starting)\s*\$?\s*\d',
+                msg_lower_chk,
+            ) or re.search(r'\$\s*\d', msg_lower_chk)
+            if _has_budget_signal and "budget" in self.filters:
+                self.filters.pop("budget", None)
+                logger.info("Budget cleared alongside preference reset (new budget detected in message)")
 
         # 2. Extract Criteria (Schema-Driven) with IDSS signals
         schema = get_domain_schema(self.domain)
@@ -943,6 +979,19 @@ class UniversalAgent:
                     raw_brand = new_filters["brand"].strip()
                     new_filters["brand"] = _BRAND_VALUE_ALIASES.get(raw_brand.lower(), raw_brand)
                 logger.info(f"Extracted filters (normalised): {new_filters}")
+                # Remove None values before merging
+                new_filters = {k: v for k, v in new_filters.items() if v is not None}
+
+                # When use_case changes, clear stale good_for_* flags from previous
+                # turns so contradictory tags (e.g. good_for_ml from turn 1) don't
+                # persist when the user pivots to "email and Netflix".
+                if "use_case" in new_filters:
+                    _stale_gf = [k for k in self.filters if k.startswith("good_for_")]
+                    if _stale_gf:
+                        for k in _stale_gf:
+                            del self.filters[k]
+                        logger.info(f"Cleared stale good_for_* flags on use_case change: {_stale_gf}")
+
                 self.filters.update(new_filters)
                 # If user explicitly chose a brand, remove it from excluded_brands (mind change)
                 if "brand" in new_filters:
@@ -1641,10 +1690,14 @@ Write the recommendation message."""}
             logger.info(f"Refinement classification: intent={result.intent}, reasoning={result.reasoning}")
 
             if result.intent == "refine_filters":
-                # Merge updated criteria into existing filters
+                # Normalise slot names so "price"→"budget", "ram"→"min_ram_gb", etc.
+                # Without this, a refinement like "make it under $600" may create a
+                # stale duplicate key instead of overwriting the existing "budget" slot.
+                domain_aliases = _SLOT_NAME_ALIASES.get(self.domain or "", {})
                 for item in result.updated_criteria:
-                    self.filters[item.slot_name] = item.value
-                    logger.info(f"Refinement updated filter: {item.slot_name}={item.value}")
+                    canonical = domain_aliases.get(item.slot_name, item.slot_name)
+                    self.filters[canonical] = item.value
+                    logger.info(f"Refinement updated filter: {canonical}={item.value} (raw slot: {item.slot_name})")
                 self.history.append({"role": "user", "content": message})
                 schema = get_domain_schema(self.domain)
                 return self._handoff_to_search(schema)
@@ -1664,8 +1717,10 @@ Write the recommendation message."""}
                 self.filters = {}
                 self.questions_asked = []
                 self.question_count = 0
+                domain_aliases = _SLOT_NAME_ALIASES.get(self.domain or "", {})
                 for item in result.updated_criteria:
-                    self.filters[item.slot_name] = item.value
+                    canonical = domain_aliases.get(item.slot_name, item.slot_name)
+                    self.filters[canonical] = item.value
                 self.history.append({"role": "user", "content": message})
                 schema = get_domain_schema(self.domain)
                 return self._handoff_to_search(schema)


### PR DESCRIPTION
Adds tiered preference resets, budget-aware clearing when the user revises price, clearing stale good_for_* on use_case changes, canonical slot names in post-rec refinement, and replace-mode session filter updates so old keys do not linger.

What this fixes:
Multi-turn chats were easy to get wrong: budget stuck on an old number, gaming specs hanging around after someone said “forget that”, refinement messages writing `price` instead of `budget`, and session state keeping keys that should have been replaced. This PR is meant to make preference updates feel closer to talking to a human.

Changes:
- **Prompt:** one rule focused on contradictions—the *current* message wins when it disagrees with earlier turns. Post-rec refinement prompt nudges canonical slot names (`budget` not `price`, etc.).
- **`UniversalAgent`:** tiered “changed my mind” handling (soft vs “forget the gaming specs”), clear budget when a reset phrase appears with a new dollar amount, clear stale `good_for_*` when `use_case` changes, and normalize refinement slot names so we don’t get duplicate keys.
- **Session layer:** `InterviewSessionManager.update_filters(..., replace=True)` and the chat endpoint passes search filters in replace mode so old keys don’t accumulate across turns.
- **Tests:** `agent/tests/test_session_memory.py` (15 tests).

How to verify
```powershell
$env:PYTHONPATH = "mcp-server"
python -m pytest agent/tests/test_session_memory.py -v
