### PR TITLE
feat(kg): slot translation + text harvest for KG retrieval quality

### DIFF
--- a/mcp-server/app/kg_service.py
+++ b/mcp-server/app/kg_service.py
@@ -108,6 +108,10 @@ class KnowledgeGraphService:
                 params = {"limit": limit, **self._extract_filters(filters or {})}
                 if query and len(query) >= 2:
                     params["q"] = query.lower()[:50]
+                    tokens = self._tokenize_query(query)
+                    if len(tokens) >= 2:
+                        for i, tok in enumerate(tokens):
+                            params[f"q_tok_{i}"] = tok
                 result = session.run(cypher_query, params)
                 
                 product_ids = []
@@ -134,6 +138,25 @@ class KnowledgeGraphService:
             logger.error(f"KG search failed: {e}", exc_info=True)
             return [], {"error": str(e)}
     
+    @staticmethod
+    def _tokenize_query(query: str, max_tokens: int = 12) -> List[str]:
+        """Lowercase, whitespace-split, strip light punctuation, dedupe.
+
+        Only tokens ≥ 2 chars are kept; order is preserved for deterministic
+        Cypher parameter naming ($q_tok_0, $q_tok_1, …). Capped so a pathological
+        input doesn't generate a Cypher query with hundreds of CASE WHENs.
+        """
+        if not query:
+            return []
+        seen: List[str] = []
+        for raw in query.split():
+            t = raw.strip(".,;:!?\"'()[]{}").lower()
+            if len(t) >= 2 and t not in seen:
+                seen.append(t)
+                if len(seen) >= max_tokens:
+                    break
+        return seen
+
     def _build_cypher_query(
         self,
         query: str,
@@ -195,13 +218,27 @@ class KnowledgeGraphService:
                         f"CASE WHEN p.{flag} = true THEN {boost} ELSE 0 END"
                     )
 
-        # Text match is also soft: preferred but not required
+        # Text match is also soft: preferred but not required.
+        # +3 for an exact-phrase substring hit on name/description/subcategory.
+        # For multi-word queries, also give +1 per matched token so a novel
+        # whose description mentions both "fantasy" and "novel" outscores one
+        # that happens to contain just "novel". Single-token queries skip the
+        # per-token layer (it would just duplicate the phrase match).
         if query and len(query) >= 2:
             soft_score_cases.append(
                 "CASE WHEN (toLower(coalesce(p.subcategory, '')) CONTAINS $q OR "
                 "toLower(coalesce(p.name, '')) CONTAINS $q OR "
                 "toLower(coalesce(p.description, '')) CONTAINS $q) THEN 3 ELSE 0 END"
             )
+            tokens = self._tokenize_query(query)
+            if len(tokens) >= 2:
+                for i, _tok in enumerate(tokens):
+                    pname = f"q_tok_{i}"
+                    soft_score_cases.append(
+                        f"CASE WHEN (toLower(coalesce(p.subcategory, '')) CONTAINS ${pname} OR "
+                        f"toLower(coalesce(p.name, '')) CONTAINS ${pname} OR "
+                        f"toLower(coalesce(p.description, '')) CONTAINS ${pname}) THEN 1 ELSE 0 END"
+                    )
 
         if soft_score_cases:
             score_expr = " + ".join(soft_score_cases)

--- a/mcp-server/app/main.py
+++ b/mcp-server/app/main.py
@@ -1284,21 +1284,27 @@ async def merchant_search(
     if "category" not in merged_filters and query.domain:
         merged_filters["category"] = query.domain
 
-    # Translate agent slot vocabulary → KG scoring-flag vocabulary. The agent
-    # emits use_cases=["ml"]; the KG boosts good_for_ml=True on Product nodes.
-    # This mapping is merchant scoring policy, not a contract concern, so it
-    # lives here rather than in the StructuredQuery schema.
+    # Translate agent slot vocabulary → KG scoring-flag vocabulary.
+    # Two naming conventions arrive depending on the upstream path:
+    #   - "use_case"  (singular, string)  — from agent chat interview
+    #   - "use_cases" (plural,   list)    — from MCP query parser
+    # The agent schema says "machine_learning"; the MCP parser says "ml".
+    # Normalize both into the KG's good_for_* boolean flags.
     _USE_CASE_FLAG_MAP = {
         "ml": "good_for_ml",
+        "machine_learning": "good_for_ml",
         "gaming": "good_for_gaming",
         "web_dev": "good_for_web_dev",
         "creative": "good_for_creative",
         "linux": "good_for_linux",
     }
-    _use_cases = merged_filters.get("use_cases") or []
-    if isinstance(_use_cases, str):
-        _use_cases = [_use_cases]
-    for _uc in _use_cases:
+    _raw_uc = merged_filters.get("use_cases") or []
+    if isinstance(_raw_uc, str):
+        _raw_uc = [_raw_uc]
+    _single_uc = merged_filters.get("use_case")
+    if _single_uc and isinstance(_single_uc, str):
+        _raw_uc.append(_single_uc)
+    for _uc in _raw_uc:
         _flag = _USE_CASE_FLAG_MAP.get(str(_uc).lower().strip())
         if _flag:
             merged_filters[_flag] = True

--- a/mcp-server/app/main.py
+++ b/mcp-server/app/main.py
@@ -1284,6 +1284,25 @@ async def merchant_search(
     if "category" not in merged_filters and query.domain:
         merged_filters["category"] = query.domain
 
+    # Translate agent slot vocabulary → KG scoring-flag vocabulary. The agent
+    # emits use_cases=["ml"]; the KG boosts good_for_ml=True on Product nodes.
+    # This mapping is merchant scoring policy, not a contract concern, so it
+    # lives here rather than in the StructuredQuery schema.
+    _USE_CASE_FLAG_MAP = {
+        "ml": "good_for_ml",
+        "gaming": "good_for_gaming",
+        "web_dev": "good_for_web_dev",
+        "creative": "good_for_creative",
+        "linux": "good_for_linux",
+    }
+    _use_cases = merged_filters.get("use_cases") or []
+    if isinstance(_use_cases, str):
+        _use_cases = [_use_cases]
+    for _uc in _use_cases:
+        _flag = _USE_CASE_FLAG_MAP.get(str(_uc).lower().strip())
+        if _flag:
+            merged_filters[_flag] = True
+
     # Agent hints via user_context:
     #  - "query": free-text for KG substring matching
     #  - "exclude_ids": products to omit (pagination / "show more" flows)

--- a/mcp-server/app/main.py
+++ b/mcp-server/app/main.py
@@ -1307,9 +1307,25 @@ async def merchant_search(
     #  - "query": free-text for KG substring matching
     #  - "exclude_ids": products to omit (pagination / "show more" flows)
     _ctx = query.user_context if isinstance(query.user_context, dict) else {}
-    text_query = _ctx.get("query")
     exclude_ids = list(_ctx.get("exclude_ids") or [])
     exclude_set = set(exclude_ids)
+
+    # Harvest text-ish values from soft_preferences so the KG's substring match
+    # sees richer signal than the agent's single-word hint ("book"/"laptop").
+    # The raw user utterance never crosses the contract boundary — if the
+    # agent didn't extract a slot, we don't invent one. This is the quality
+    # ceiling: better slot extraction (agent-side) → better merchant ranking.
+    _TEXT_HARVEST_SLOTS = ("subcategory", "brand", "genre", "style", "material", "color")
+    _parts: _List[str] = []
+    if _ctx.get("query"):
+        _parts.append(str(_ctx["query"]))
+    for _slot in _TEXT_HARVEST_SLOTS:
+        _val = query.soft_preferences.get(_slot)
+        if isinstance(_val, list):
+            _parts.extend(str(v) for v in _val if v)
+        elif isinstance(_val, str) and _val.strip().lower() not in ("", "no preference", "specific brand"):
+            _parts.append(_val)
+    text_query = " ".join(dict.fromkeys(p.strip() for p in _parts if p.strip())) or None
 
     # Over-fetch so that after server-side exclusion we can still return
     # top_k. Cap at the SearchProductsRequest upper bound (100).

--- a/mcp-server/tests/test_kg_service.py
+++ b/mcp-server/tests/test_kg_service.py
@@ -103,6 +103,50 @@ def test_build_cypher_query_no_soft_constraints_uses_connectivity():
     svc.close()
 
 
+def test_tokenize_query_basic():
+    """Whitespace-split, lowercased, deduped, ≥2 chars, trailing punctuation stripped."""
+    assert KnowledgeGraphService._tokenize_query("Fantasy Novel") == ["fantasy", "novel"]
+    assert KnowledgeGraphService._tokenize_query("") == []
+    assert KnowledgeGraphService._tokenize_query("a bb a cc") == ["bb", "cc"]
+    assert KnowledgeGraphService._tokenize_query("book, hard-cover!") == ["book", "hard-cover"]
+
+
+def test_tokenize_query_caps_and_dedupes():
+    """Dedup preserves first occurrence; cap prevents pathological expansion."""
+    assert KnowledgeGraphService._tokenize_query("ml ML Ml") == ["ml"]
+    many = " ".join(f"tok{i}" for i in range(30))
+    assert len(KnowledgeGraphService._tokenize_query(many, max_tokens=5)) == 5
+
+
+def test_build_cypher_query_multiword_adds_per_token_cases():
+    """Multi-word query emits one +1 CASE WHEN per token plus the phrase +3."""
+    svc = KnowledgeGraphService(password=None)
+    cypher = svc._build_cypher_query(
+        query="fantasy novel",
+        filters={"category": "Books"},
+        limit=10,
+    )
+    # Phrase-level match still present
+    assert "CONTAINS $q" in cypher
+    # Per-token matches present with deterministic naming
+    assert "CONTAINS $q_tok_0" in cypher
+    assert "CONTAINS $q_tok_1" in cypher
+    svc.close()
+
+
+def test_build_cypher_query_single_token_skips_per_token_layer():
+    """Single-token query → phrase match only; no redundant $q_tok_0 clauses."""
+    svc = KnowledgeGraphService(password=None)
+    cypher = svc._build_cypher_query(
+        query="laptop",
+        filters={"category": "Electronics"},
+        limit=10,
+    )
+    assert "CONTAINS $q" in cypher
+    assert "$q_tok_" not in cypher
+    svc.close()
+
+
 # ---------------------------------------------------------------------------
 # Diversity score helper (no Neo4j required)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Translate `use_case`/`use_cases` agent slots into KG `good_for_*` boolean flags, handling both singular (string) and plural (list) conventions
- Harvest text-ish soft_preferences (subcategory, brand, genre, style, material, color) into the KG text query for richer substring matching
- Tokenize Cypher text match for multi-word queries so each word matches independently
- Handle `machine_learning` → `good_for_ml` alias

## Test plan
- [ ] `POST /merchant/search` with `use_case: "gaming"` sets `good_for_gaming: true` in filters
- [ ] `POST /merchant/search` with `use_cases: ["ml", "creative"]` sets both flags
- [ ] Soft preferences like `brand: "Lenovo"` appear in the KG text query
- [ ] Multi-word queries tokenize correctly in Cypher
- [ ] `/chat` at localhost:3000 still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)