### PR TITLE
Interim merchant isolation: drop direct-search fallback + new merchants schema

### DIFF
--- a/agent/chat_endpoint.py
+++ b/agent/chat_endpoint.py
@@ -4203,7 +4203,6 @@ async def _search_ecommerce_products(
     TTL: 5 min (CACHE_TTL_SEARCH env var or default 300 s).
     """
     from app.formatters import format_product
-    from app.tools.supabase_product_store import get_product_store
     from app.cache import cache_client as _cc
 
     # Normalise category / product_type defaults
@@ -4225,16 +4224,14 @@ async def _search_ecommerce_products(
         {**search_filters, "_excl": _excl_key}, category, page=1, limit=limit
     )
     _cached = _cc.get_search_results(_cache_key)
-    _used_mcp_search = False
     if _cached is not None:
         logger.info("search_ecommerce_cache_hit", f"Agent search cache HIT ({len(_cached)} items)", {})
         product_dicts = _cached
-    elif os.environ.get("USE_MCP_SEARCH", "1") != "0":
-        # Merchant-agent path (default): POST a StructuredQuery to the
-        # merchant's /merchant/search endpoint and unpack the returned
-        # list[Offer]. Per ARCHITECTURE.md this is the ONLY surface the
-        # shopping agent uses — no imports from merchant internals.
-        # Set USE_MCP_SEARCH=0 to fall back to the direct-to-Supabase path.
+    else:
+        # Merchant-agent path: POST a StructuredQuery to the merchant's
+        # /merchant/search endpoint and unpack the returned list[Offer].
+        # Per ARCHITECTURE.md this is the ONLY surface the shopping agent
+        # uses — no imports from merchant internals.
         import httpx
         _mcp_base = os.environ.get("MCP_BASE_URL", "http://localhost:8001").rstrip("/")
         _mcp_query = _build_kg_search_query(filters, category)
@@ -4310,62 +4307,20 @@ async def _search_ecommerce_products(
                 "_merchant_score": _offer.get("score"),
                 "_merchant_id": _offer.get("merchant_id"),
             })
-        _used_mcp_search = True
-        if product_dicts:
-            _cc.set_search_results(_cache_key, product_dicts, adaptive=True)
-    else:
-        logger.info("search_ecommerce_start", "Searching products via Supabase (cache miss)", {
-            "category": category, "filters": search_filters,
-            "n_rows": n_rows, "n_per_row": n_per_row,
-        })
-        store = get_product_store()
-        product_dicts = store.search_products(
-            search_filters,
-            limit=limit,
-            exclude_ids=exclude_ids,
-        )
         if product_dicts:
             _cc.set_search_results(_cache_key, product_dicts, adaptive=True)
 
     try:
 
         if not product_dicts:
-            logger.warning("search_ecommerce_empty", "No products returned from Supabase", {
+            logger.warning("search_ecommerce_empty", "No products returned from merchant", {
                 "category": category, "filters": search_filters,
             })
             return [], []
 
-        # KG re-ranking (best-effort, non-blocking). Skipped when mcp-search
-        # already ran KG inside /api/search-products — in that case results
-        # arrive pre-ranked and re-running KG here is redundant.
+        # Offers arrive pre-ranked by the merchant's /merchant/search.
+        # Preserve that order — no re-ranking or re-sorting here.
         kg_candidate_ids: List[str] = []
-        if not _used_mcp_search:
-            try:
-                from app.kg_service import get_kg_service
-                kg = get_kg_service()
-                if kg.is_available():
-                    kg_filters = {**search_filters}
-                    search_query = _build_kg_search_query(filters, category)
-                    kg_candidate_ids, _ = kg.search_candidates(
-                        query=search_query, filters=kg_filters, limit=limit,
-                    )
-                    if kg_candidate_ids and exclude_ids:
-                        exclude_set = set(exclude_ids)
-                        kg_candidate_ids = [p for p in kg_candidate_ids if p not in exclude_set]
-            except Exception as e:
-                logger.warning("kg_search_skipped", f"KG search skipped: {e}", {"error": str(e)})
-
-        # Sort: KG-ranked first, then by price.
-        # When mcp-search already ranked server-side, preserve that order
-        # and skip the price-based fallback sort.
-        if kg_candidate_ids:
-            kg_id_to_idx = {pid: i for i, pid in enumerate(kg_candidate_ids)}
-            product_dicts.sort(key=lambda p: (
-                (0, kg_id_to_idx[p["id"]]) if p["id"] in kg_id_to_idx
-                else (1, float(p.get("price", 0) or 0))
-            ))
-        elif not _used_mcp_search:
-            product_dicts.sort(key=lambda x: float(x.get("price", 0) or 0))
 
         product_dicts = _diversify_by_brand(product_dicts)
 

--- a/agent/chat_endpoint.py
+++ b/agent/chat_endpoint.py
@@ -14,6 +14,8 @@ import os
 import re
 import uuid
 from typing import Optional, Dict, Any, List
+
+import httpx
 from pydantic import BaseModel, Field
 
 from agent.interview.session_manager import (
@@ -4232,7 +4234,6 @@ async def _search_ecommerce_products(
         # /merchant/search endpoint and unpack the returned list[Offer].
         # Per ARCHITECTURE.md this is the ONLY surface the shopping agent
         # uses — no imports from merchant internals.
-        import httpx
         _mcp_base = os.environ.get("MCP_BASE_URL", "http://localhost:8001").rstrip("/")
         _mcp_query = _build_kg_search_query(filters, category)
         # Split today's flat filter dict into hard vs soft per the contract.
@@ -4320,25 +4321,22 @@ async def _search_ecommerce_products(
 
         # Offers arrive pre-ranked by the merchant's /merchant/search.
         # Preserve that order — no re-ranking or re-sorting here.
-        kg_candidate_ids: List[str] = []
 
         product_dicts = _diversify_by_brand(product_dicts)
 
-        # Log diversity metrics so we can assess whether KG adds value over SQL alone.
-        # brand_diversity=1.0 means every recommendation is a different brand.
-        # price_spread=1.0 means huge price range (budget → premium).
+        # Log diversity metrics (brand spread + price spread). KG-usage signal
+        # is no longer available here since ranking happens merchant-side.
         _div = _compute_diversity_score(product_dicts)
         logger.info(
             "recommendation_diversity",
             f"Diversity: overall={_div['overall']:.3f} "
-            f"brands={_div['brand_diversity']:.3f} price_spread={_div['price_spread']:.3f} "
-            f"kg_used={bool(kg_candidate_ids)}",
+            f"brands={_div['brand_diversity']:.3f} price_spread={_div['price_spread']:.3f}",
             _div,
         )
 
         try:
             from app.research_compare import generate_recommendation_reasons
-            generate_recommendation_reasons(product_dicts, filters=filters, kg_candidate_ids=kg_candidate_ids)
+            generate_recommendation_reasons(product_dicts, filters=filters)
         except Exception:
             pass
 

--- a/mcp-server/app/endpoints.py
+++ b/mcp-server/app/endpoints.py
@@ -2621,8 +2621,8 @@ def get_product(
     logger.info("processing_step", "Step 2: Querying PostgreSQL database", {
         "request_id": request_id,
         "step": "postgresql_query",
-        "query": f"SELECT * FROM products WHERE product_id = '{request.product_id}'",
-        "tables": ["products", "prices", "inventory"],
+        "query": f"SELECT * FROM merchants.products_default WHERE id = '{request.product_id}'",
+        "tables": ["merchants.products_default", "prices", "inventory"],
         "joins": ["products.price_info", "products.inventory_info"]
     })
     

--- a/mcp-server/app/models.py
+++ b/mcp-server/app/models.py
@@ -19,12 +19,20 @@ from app.database import Base
 
 class Product(Base):
     """
-    Product catalog - maps to Supabase 'products' table.
-    Column('db_name', ...) maps Supabase column names to Python attribute names
-    so existing code continues to work without changes.
+    Product catalog — maps to `merchants.products_default`.
+
+    Per the interim design (CLAUDE.md: "Merchant agent is generic; each uploaded
+    catalog is isolated"), the default merchant's catalog lives in the `merchants`
+    schema, cloned from `public.products`. Reads go through this model; the raw
+    `public.products` table stays frozen as the reference catalog.
+
+    Issue #38 tracks the long-term target of one schema per merchant.
+
+    Column('db_name', ...) maps the underlying column names to Python attribute
+    names so existing code continues to work without changes.
     """
-    __tablename__ = "products"
-    __table_args__ = {"extend_existing": True}
+    __tablename__ = "products_default"
+    __table_args__ = {"extend_existing": True, "schema": "merchants"}
 
     # Primary identifier — Supabase uses 'id' (UUID), we keep attribute name 'product_id'
     product_id = Column("id", PG_UUID(as_uuid=True), primary_key=True, index=True)

--- a/mcp-server/app/tools/supabase_product_store.py
+++ b/mcp-server/app/tools/supabase_product_store.py
@@ -778,7 +778,7 @@ class _SQLAlchemyProductStore:
         fetch_limit = min(limit * 8, 800)
         # ORDER BY id (index scan) is ~25x faster than ORDER BY RANDOM() (full table sort).
         # Python-side shuffle at line ~839 provides the randomisation instead.
-        sql = sa_text(f"SELECT * FROM products WHERE {where} ORDER BY id LIMIT :fetch_limit")
+        sql = sa_text(f"SELECT * FROM merchants.products_default WHERE {where} ORDER BY id LIMIT :fetch_limit")
         params["fetch_limit"] = fetch_limit
 
         try:
@@ -871,7 +871,7 @@ class _SQLAlchemyProductStore:
         try:
             from sqlalchemy import text as sa_text
             with self._engine.connect() as conn:
-                result = conn.execute(sa_text("SELECT * FROM products WHERE id = :id LIMIT 1"), {"id": product_id})
+                result = conn.execute(sa_text("SELECT * FROM merchants.products_default WHERE id = :id LIMIT 1"), {"id": product_id})
                 row = result.fetchone()
                 return SupabaseProductStore._row_to_dict(dict(row._mapping)) if row else None
         except Exception as e:
@@ -892,7 +892,7 @@ class _SQLAlchemyProductStore:
             placeholders = ", ".join(f":id{i}" for i in range(len(product_ids)))
             with self._engine.connect() as conn:
                 result = conn.execute(
-                    sa_text(f"SELECT * FROM products WHERE id IN ({placeholders})"),
+                    sa_text(f"SELECT * FROM merchants.products_default WHERE id IN ({placeholders})"),
                     params,
                 )
                 rows = result.fetchall()

--- a/mcp-server/migrations/001_add_merchant_id.sql
+++ b/mcp-server/migrations/001_add_merchant_id.sql
@@ -1,5 +1,0 @@
--- Add merchant_id column to products (nullable so existing rows keep working)
-ALTER TABLE products ADD COLUMN IF NOT EXISTS merchant_id TEXT;
-
--- Index for per-merchant lookups
-CREATE INDEX IF NOT EXISTS idx_products_merchant_id ON products (merchant_id);

--- a/mcp-server/migrations/002_create_merchants_schema.sql
+++ b/mcp-server/migrations/002_create_merchants_schema.sql
@@ -20,10 +20,13 @@ CREATE TABLE IF NOT EXISTS merchants.products_default (
   LIKE public.products INCLUDING ALL
 );
 
+-- One-shot snapshot: copy only if the target is empty. ON CONFLICT would
+-- silently back-fill rows added to public.products between re-runs; we want
+-- strict snapshot semantics so a re-run is a no-op once initialised.
 -- Data copy runs before adding merchant_id so SELECT * column counts line up.
 INSERT INTO merchants.products_default
 SELECT * FROM public.products
-ON CONFLICT (id) DO NOTHING;
+WHERE NOT EXISTS (SELECT 1 FROM merchants.products_default);
 
 -- Per-merchant scoping column. Only present on the merchants schema — never
 -- added to public.products (see CLAUDE.md: public is the golden catalog).
@@ -51,13 +54,14 @@ BEGIN
          LIKE public.products_enriched INCLUDING ALL
        )';
 
+    -- Snapshot semantics: only populate when the target is empty.
     EXECUTE
       'INSERT INTO merchants.products_enriched_default
        SELECT e.* FROM public.products_enriched e
        WHERE EXISTS (
          SELECT 1 FROM merchants.products_default p WHERE p.id = e.product_id
        )
-       ON CONFLICT DO NOTHING';
+       AND NOT EXISTS (SELECT 1 FROM merchants.products_enriched_default)';
 
     -- LIKE ... INCLUDING ALL does NOT copy foreign keys — recreate within schema.
     IF NOT EXISTS (

--- a/mcp-server/migrations/002_create_merchants_schema.sql
+++ b/mcp-server/migrations/002_create_merchants_schema.sql
@@ -1,0 +1,77 @@
+-- Create the `merchants` schema for per-merchant catalog isolation (interim).
+--
+-- Design: each merchant's catalog lives in its own pair of tables inside a
+-- dedicated schema. The `public` schema stays frozen as the reference.
+--
+-- See CLAUDE.md "Merchant agent is generic; each uploaded catalog is isolated".
+-- Issue #38: long-term target is one schema per merchant (this design is tentative).
+-- Issue #39: CSV upload flow that bootstraps new merchants.
+--
+-- This migration is idempotent. public.* is never modified.
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS merchants;
+
+-- --------------------------------------------------------------------------
+-- merchants.products_default  — raw catalog mirror for the default merchant
+-- --------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS merchants.products_default (
+  LIKE public.products INCLUDING ALL
+);
+
+-- Data copy runs before adding merchant_id so SELECT * column counts line up.
+INSERT INTO merchants.products_default
+SELECT * FROM public.products
+ON CONFLICT (id) DO NOTHING;
+
+-- Per-merchant scoping column. Only present on the merchants schema — never
+-- added to public.products (see CLAUDE.md: public is the golden catalog).
+ALTER TABLE merchants.products_default
+  ADD COLUMN IF NOT EXISTS merchant_id TEXT;
+
+UPDATE merchants.products_default
+SET merchant_id = 'default'
+WHERE merchant_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_merchants_products_default_merchant_id
+  ON merchants.products_default (merchant_id);
+
+-- --------------------------------------------------------------------------
+-- merchants.products_enriched_default  — enrichment mirror (if source exists)
+-- --------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'products_enriched'
+  ) THEN
+    EXECUTE
+      'CREATE TABLE IF NOT EXISTS merchants.products_enriched_default (
+         LIKE public.products_enriched INCLUDING ALL
+       )';
+
+    EXECUTE
+      'INSERT INTO merchants.products_enriched_default
+       SELECT e.* FROM public.products_enriched e
+       WHERE EXISTS (
+         SELECT 1 FROM merchants.products_default p WHERE p.id = e.product_id
+       )
+       ON CONFLICT DO NOTHING';
+
+    -- LIKE ... INCLUDING ALL does NOT copy foreign keys — recreate within schema.
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'fk_products_enriched_default_product'
+    ) THEN
+      EXECUTE
+        'ALTER TABLE merchants.products_enriched_default
+           ADD CONSTRAINT fk_products_enriched_default_product
+           FOREIGN KEY (product_id)
+           REFERENCES merchants.products_default (id)
+           ON DELETE CASCADE';
+    END IF;
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Two commits on `feat/merchants-schema-interim`, targeting `refactor/merchant-agent-v2` (the old `feat/merchant-agent-class` base was merged into v2 and deleted):

1. **`refactor(shopping-agent)`** — remove the direct-Supabase fallback from `_search_ecommerce_products`. `USE_MCP_SEARCH` is gone; the shopping agent speaks the contract exclusively. Dead post-hoc KG re-rank and price sort removed — offers arrive pre-ranked from `/merchant/search`.

2. **`feat(merchant)`** — introduce a `merchants` schema and redirect the `Product` SQLAlchemy model at `merchants.products_default`. The default merchant's catalog is cloned from `public.products` (+ `public.products_enriched` when present). `public.*` stays frozen.

Plus a follow-up `fix(review)` commit addressing feedback:
- Retargeted three raw-SQL statements in `supabase_product_store.py` (search / get_by_id / get_by_ids) from unqualified `products` → `merchants.products_default`. Without this, raw-SQL reads silently resolved to `public.products` via `search_path` — same data today (clones), but invisible drift the moment writes diverge.
- Updated the `endpoints.py` log-line display string to match the real ORM target.
- Dropped the always-empty `kg_candidate_ids` variable in `chat_endpoint.py` and its stale `kg_used=False` log key (ranking happens merchant-side now). Moved `import httpx` to module top.
- Tightened `002_create_merchants_schema.sql` with `NOT EXISTS` guards on both INSERTs, so a re-run is a strict no-op instead of silently back-filling rows added to `public.*` between runs.

## Interim design

- Each merchant maps to a pair of tables: `merchants.products_<id>` / `merchants.products_enriched_<id>`.
- Tentative. The long-term target (#38) is one schema per merchant — `SET search_path = <merchant_id>` at connection time, schema-agnostic SQL, no templated table names. Chosen over that now to keep the interim step lightweight.
- CSV upload flow that bootstraps new merchants is tracked in #39.

## Required deploy step

`mcp-server/migrations/002_create_merchants_schema.sql` must be applied in Supabase before this branch runs. Already applied against the current Supabase project (51,277 rows cloned to `merchants.products_default`, all stamped `merchant_id='default'`). Idempotent, in a transaction, `public.*` untouched.

## Out of scope (known, not introduced here)

- `mcp-server/app/supabase_cart.py` still hits `public.products` via raw SQL to decrement inventory at checkout (lines 443, 465). Pre-existing CLAUDE.md violation; separate PR once the cart flow is reviewed.
- Building a per-`(merchant, strategy)` KG + vector index. Current indices were built from `public.products`; since the cloned data has the same IDs, existing indices still work for the default merchant. New merchants will need their own indices — tracked in #39.
- `MerchantAgent.from_csv()`. Design is in #39.
- Cross-merchant cache-key leak in the shopping-agent search cache — flagged as a checklist item on #39 so it's fixed before multi-merchant lands.

## Test plan

- [x] Apply `002_create_merchants_schema.sql` in Supabase; `merchants.products_default` row count matches `public.products` (51,277 == 51,277).
- [x] `GET /merchant/default/health` returns 200 with `catalog_size=51277` (previously 500'd on missing `merchant_id` column).
- [x] `POST /merchant/search` returns offers from `merchants.products_default` — verified returning 3 laptops end-to-end after the raw-SQL retarget.
- [ ] Drive one chat query end-to-end; backend logs show `search_ecommerce_start` with `"Searching via /merchant/search (StructuredQuery)"`, products returned.
- [ ] Verify `merchants.products_enriched_default` row count matches the subset of `public.products_enriched` whose `product_id` exists in `merchants.products_default` (currently both are 0 — public.products_enriched is empty until the parallel enrichment branch lands).
- [ ] Negative path: set `MCP_BASE_URL` to an unreachable host, drive a chat query, confirm empty return + `merchant_search_failed` log (previously masked by the direct-Supabase fallback).
- [x] Confirm `public.products` row count is unchanged after migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)