### PR TITLE
feat(merchant): per-merchant catalogs + CSV bootstrap (Phases 0-3)

### DIFF
--- a/mcp-server/app/catalog_ingestion.py
+++ b/mcp-server/app/catalog_ingestion.py
@@ -152,33 +152,45 @@ class CatalogNormalizer:
         limit: int = 100,
         dry_run: bool = False,
         force: bool = False,
+        product_model=None,
+        enriched_model=None,
+        strategy: str = STRATEGY,
     ) -> Dict[str, int]:
         """
-        Process up to `limit` products and write normalized output to
-        products_enriched under strategy='normalizer_v1'.
+        Process up to `limit` products and write normalized output to the
+        per-merchant enriched table under ``strategy``.
 
-        The raw `products` table is NEVER mutated by this method.
+        The raw products table is NEVER mutated by this method.
 
         Args:
-            db:       SQLAlchemy session.
-            limit:    Maximum number of products to process.
-            dry_run:  If True, print results but do not write to DB.
-            force:    If True, re-normalize products that already have a row
-                      under this strategy (UPSERT overwrites).
+            db:              SQLAlchemy session.
+            limit:           Maximum number of products to process.
+            dry_run:         If True, print results but do not write to DB.
+            force:           If True, re-normalize products that already have
+                             a row under this strategy (UPSERT overwrites).
+            product_model:   Optional per-merchant Product ORM class from
+                             ``make_product_model(merchant_id)``. Defaults to
+                             the module-level ``Product`` (default merchant).
+            enriched_model:  Same idea for ``ProductEnriched``.
+            strategy:        Strategy label written to the enriched row.
+                             Normalizer output is versioned by this label so
+                             A/B comparisons are just different labels.
 
         Returns:
             {"normalized": N, "skipped": N, "failed": N}
         """
         from app.models import Product, ProductEnriched  # local import to avoid circular deps
+        product_model = product_model or Product
+        enriched_model = enriched_model or ProductEnriched
 
-        # Find products that don't yet have a normalizer_v1 row (unless forcing).
-        q = db.query(Product)
+        # Find products that don't yet have a row under this strategy (unless forcing).
+        q = db.query(product_model)
         if not force:
             already_done = (
-                db.query(ProductEnriched.product_id)
-                .filter(ProductEnriched.strategy == STRATEGY)
+                db.query(enriched_model.product_id)
+                .filter(enriched_model.strategy == strategy)
             )
-            q = q.filter(~Product.product_id.in_(already_done))
+            q = q.filter(~product_model.product_id.in_(already_done))
 
         products = q.limit(limit).all()
 
@@ -207,9 +219,9 @@ class CatalogNormalizer:
                     "normalized_description": normalized,
                     "normalized_at": datetime.now(timezone.utc).isoformat(),
                 }
-                stmt = pg_insert(ProductEnriched).values(
+                stmt = pg_insert(enriched_model).values(
                     product_id=product.product_id,
-                    strategy=STRATEGY,
+                    strategy=strategy,
                     attributes=payload,
                     model=MODEL,
                 )
@@ -230,7 +242,7 @@ class CatalogNormalizer:
             logger.info(
                 "batch_normalize_done",
                 extra={
-                    "strategy": STRATEGY,
+                    "strategy": strategy,
                     "normalized": normalized_count,
                     "skipped": skipped_count,
                     "failed": failed_count,

--- a/mcp-server/app/endpoints.py
+++ b/mcp-server/app/endpoints.py
@@ -205,7 +205,18 @@ async def search_products(
     """
     request_id = str(uuid.uuid4())
     start_time = time.time()
-    
+
+    # Per-merchant ORM routing.
+    #
+    # Rebind the module-level ``Product`` name inside this function so every
+    # ``db.query(Product)`` / ``Product.<col>`` call below targets the merchant's
+    # own ``merchants.products_<id>`` table. Non-default merchants never carry
+    # rows in the default table, and search would silently return [] without
+    # this hop. KG/vector retrieval for non-default merchants is Phase 4.
+    from app.models import make_product_model as _make_product_model
+    _mid_from_req = (request.filters or {}).get("merchant_id") if request.filters else None
+    Product = _make_product_model(_mid_from_req) if _mid_from_req else _make_product_model("default")  # noqa: F811
+
     # PROTOCOL MAPPING LOG
     logger.info("protocol_mapping", "SearchProducts request received", {
         "request_id": request_id,

--- a/mcp-server/app/endpoints.py
+++ b/mcp-server/app/endpoints.py
@@ -213,9 +213,26 @@ async def search_products(
     # own ``merchants.products_<id>`` table. Non-default merchants never carry
     # rows in the default table, and search would silently return [] without
     # this hop. KG/vector retrieval for non-default merchants is Phase 4.
+    #
+    # The F811 noqa is intentional: the rebind *replaces* the module-level
+    # ``Product`` import for this function's scope only.
     from app.models import make_product_model as _make_product_model
     _mid_from_req = (request.filters or {}).get("merchant_id") if request.filters else None
-    Product = _make_product_model(_mid_from_req) if _mid_from_req else _make_product_model("default")  # noqa: F811
+    try:
+        Product = _make_product_model(_mid_from_req or "default")  # noqa: F811
+    except ValueError as _slug_err:
+        # A client posted filters.merchant_id that doesn't match the slug
+        # grammar. Fall back to default with a WARN rather than surfacing
+        # the internal ValueError as a 500. The happy path (agent-initiated
+        # search) already validates the slug at MerchantAgent.__init__; this
+        # only fires on direct POSTs to /api/search-products with malformed
+        # payload.
+        logger.warning(
+            "invalid_merchant_id_fallback_to_default",
+            "Bad merchant_id in filters, falling back to default",
+            {"merchant_id": _mid_from_req, "error": str(_slug_err)},
+        )
+        Product = _make_product_model("default")  # noqa: F811
 
     # PROTOCOL MAPPING LOG
     logger.info("protocol_mapping", "SearchProducts request received", {

--- a/mcp-server/app/endpoints.py
+++ b/mcp-server/app/endpoints.py
@@ -2629,8 +2629,8 @@ def get_product(
     logger.info("processing_step", "Step 2: Querying PostgreSQL database", {
         "request_id": request_id,
         "step": "postgresql_query",
-        "query": f"SELECT * FROM merchants.products_default WHERE id = '{request.product_id}'",
-        "tables": ["merchants.products_default", "prices", "inventory"],
+        "query": f"SELECT * FROM {Product.__table__.schema}.{Product.__tablename__} WHERE id = '{request.product_id}'",
+        "tables": [f"{Product.__table__.schema}.{Product.__tablename__}", "prices", "inventory"],
         "joins": ["products.price_info", "products.inventory_info"]
     })
     

--- a/mcp-server/app/ingestion/__init__.py
+++ b/mcp-server/app/ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""CSV ingest and per-merchant DDL helpers."""

--- a/mcp-server/app/ingestion/csv_loader.py
+++ b/mcp-server/app/ingestion/csv_loader.py
@@ -26,9 +26,13 @@ Any unrecognised column lands in ``attributes`` via
 Reserved keys — CSV must NOT carry these (produced by enrichment):
     normalized_description, normalized_at
 
-We strip reserved keys with a warning so a typo in one row doesn't torpedo
-an entire load. The disjoint-keys invariant asserted by
-``enriched_reader.combine_raw_and_enriched`` depends on this.
+These are the keys written by ``app.catalog_ingestion`` (strategy
+``normalizer_v1``) — the source of truth lives there. We strip with a
+warning so a typo in one row doesn't torpedo an entire load. The
+disjoint-keys invariant asserted by
+``enriched_reader.combine_raw_and_enriched`` depends on this. When a
+new enrichment strategy lands that writes additional keys, extend
+``RESERVED_ENRICHMENT_KEYS``.
 
 Failure mode
 ------------
@@ -39,10 +43,12 @@ fails the partial batch rolls back.
 
 Re-ingest
 ---------
-This loader does not upsert. Calling it twice on the same merchant_id is a
-user error — the operator must drop the catalog first
-(``ingestion.schema.drop_merchant_catalog``, gated on ALLOW_MERCHANT_DROP=1)
-and re-bootstrap.
+This loader does not upsert. We probe the target table up front and raise
+``MerchantAlreadyBootstrapped`` if rows already exist, pointing the operator
+at ``ingestion.schema.drop_merchant_catalog`` (gated on
+``ALLOW_MERCHANT_DROP=1``) as the escape hatch. Failing fast before the
+parse runs beats letting the insert hit a Postgres ``UniqueViolation`` at
+commit time with a stack-trace message that doesn't name the fix.
 """
 from __future__ import annotations
 
@@ -57,9 +63,19 @@ from app.product_schema import ProductSchema
 
 logger = logging.getLogger(__name__)
 
+
+class MerchantAlreadyBootstrapped(RuntimeError):
+    """Raised when the target merchant table is non-empty at load time."""
+
+
 # Keys produced by enrichment strategies. If the raw CSV carries any of
 # these, ``combine_raw_and_enriched`` would raise at read time because raw
-# and enriched must own disjoint key sets.
+# and enriched must own disjoint key sets. Keep this list in sync with the
+# output shape of each strategy in ``app.catalog_ingestion`` (today only
+# ``normalizer_v1`` — writes ``normalized_description`` and
+# ``normalized_at``). When a new strategy lands, extend this set before
+# merging so the disjoint-keys invariant can't be silently violated by a
+# CSV row.
 RESERVED_ENRICHMENT_KEYS: Set[str] = {
     "normalized_description",
     "normalized_at",
@@ -117,7 +133,23 @@ def load_csv_into_merchant(
     """Parse ``filepath`` and insert rows into ``product_model``'s table.
 
     Returns a summary ``{"parsed", "inserted", "rejected", "reserved_stripped"}``.
+
+    Raises ``MerchantAlreadyBootstrapped`` if the target table already has
+    rows — calling the loader twice on the same merchant is a user error.
+    The operator should
+    ``ALLOW_MERCHANT_DROP=1 drop_merchant_catalog(merchant_id, conn)``
+    and re-bootstrap.
     """
+    existing = db.query(product_model).limit(1).count()
+    if existing:
+        raise MerchantAlreadyBootstrapped(
+            f"merchant {merchant_id!r} already has rows in "
+            f"{product_model.__table__.schema}.{product_model.__tablename__}; "
+            "drop the catalog first via "
+            "`ALLOW_MERCHANT_DROP=1 python -c \"from app.ingestion.schema "
+            "import drop_merchant_catalog\"` and re-run bootstrap."
+        )
+
     raw_rows = parse_csv(
         filepath,
         product_type=product_type,
@@ -166,7 +198,8 @@ def load_csv_into_merchant(
         # (e.g. "Electronics") from its product_type→category map. The search
         # path filters with a case-sensitive equality check, so we lowercase
         # here to match the agent's default-domain filter (e.g. "electronics").
-        # Callers passing a CSV `category` column should already be lowercase.
+        # Temporary workaround — follow-up issue #45 moves the normalisation
+        # into ProductSchema / the search filter so every caller benefits.
         category_norm = (row["category"] or "").strip().lower() or None
         instance = product_model(
             product_id=pid,

--- a/mcp-server/app/ingestion/csv_loader.py
+++ b/mcp-server/app/ingestion/csv_loader.py
@@ -1,0 +1,199 @@
+"""
+CSV → per-merchant Postgres loader.
+
+Reads a product CSV and inserts into ``merchants.products_<merchant_id>`` via
+the merchant's ORM model. Column parsing and type coercion are delegated to
+``app.csv_importer.parse_csv`` so we don't fork alias/coercion logic.
+
+CSV column contract
+-------------------
+Required (validated by ProductSchema):
+    title, product_type (or --product-type fallback), price
+
+Optional top-level columns (become ORM attributes):
+    id (UUID — auto-generated if missing), brand, image_url/imageurl,
+    rating, rating_count, source, link, ref_id
+
+Optional spec columns (go into ``attributes`` JSONB):
+    description, color, weight_*, dimensions, release_year,
+    cpu, gpu, ram_gb, storage_gb, screen_size, resolution, battery_life_hours,
+    os, megapixels, sensor_type, genre, format, author, pages, publisher,
+    body_style, fuel_type, mileage, year, transmission, drivetrain, engine.
+
+Any unrecognised column lands in ``attributes`` via
+``ProductSchema.extra_attributes``.
+
+Reserved keys — CSV must NOT carry these (produced by enrichment):
+    normalized_description, normalized_at
+
+We strip reserved keys with a warning so a typo in one row doesn't torpedo
+an entire load. The disjoint-keys invariant asserted by
+``enriched_reader.combine_raw_and_enriched`` depends on this.
+
+Failure mode
+------------
+Best-effort. Rows that fail ProductSchema validation or collide on product_id
+are logged and skipped — the load returns a summary dict with counts so the
+operator can inspect rejects. ``commit`` happens once at the end; if commit
+fails the partial batch rolls back.
+
+Re-ingest
+---------
+This loader does not upsert. Calling it twice on the same merchant_id is a
+user error — the operator must drop the catalog first
+(``ingestion.schema.drop_merchant_catalog``, gated on ALLOW_MERCHANT_DROP=1)
+and re-bootstrap.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Dict, Optional, Set
+
+from sqlalchemy.orm import Session
+
+from app.csv_importer import parse_csv
+from app.product_schema import ProductSchema
+
+logger = logging.getLogger(__name__)
+
+# Keys produced by enrichment strategies. If the raw CSV carries any of
+# these, ``combine_raw_and_enriched`` would raise at read time because raw
+# and enriched must own disjoint key sets.
+RESERVED_ENRICHMENT_KEYS: Set[str] = {
+    "normalized_description",
+    "normalized_at",
+}
+
+# CSV headers that map to the Postgres primary key. Not aliased by
+# csv_importer (which maps product_id/sku/asin → ref_id), so we handle
+# them here.
+_ID_HEADERS: Set[str] = {"id", "uuid", "product_uuid"}
+
+
+def _strip_reserved_keys(raw: Dict[str, Any], merchant_id: str) -> int:
+    """Remove reserved-enrichment keys from a parsed row. Returns count removed."""
+    stripped = 0
+    extras = raw.get("extra_attributes")
+    if isinstance(extras, dict):
+        for k in list(extras.keys()):
+            if k in RESERVED_ENRICHMENT_KEYS:
+                logger.warning(
+                    "csv_stripped_reserved_key merchant=%s key=%s title=%s",
+                    merchant_id, k, raw.get("title"),
+                )
+                extras.pop(k)
+                stripped += 1
+    for k in list(raw.keys()):
+        if k in RESERVED_ENRICHMENT_KEYS:
+            logger.warning(
+                "csv_stripped_reserved_key merchant=%s key=%s title=%s",
+                merchant_id, k, raw.get("title"),
+            )
+            raw.pop(k)
+            stripped += 1
+    return stripped
+
+
+def _extract_id(raw: Dict[str, Any]) -> Optional[str]:
+    """Pull a CSV-supplied UUID out of parsed row (bucketed into extra_attributes)."""
+    extras = raw.get("extra_attributes") or {}
+    for header in _ID_HEADERS:
+        if header in extras:
+            return str(extras.pop(header))
+    return None
+
+
+def load_csv_into_merchant(
+    filepath: str,
+    *,
+    db: Session,
+    product_model,
+    merchant_id: str,
+    product_type: str,
+    source: str,
+    col_map: Optional[Dict[str, str]] = None,
+) -> Dict[str, int]:
+    """Parse ``filepath`` and insert rows into ``product_model``'s table.
+
+    Returns a summary ``{"parsed", "inserted", "rejected", "reserved_stripped"}``.
+    """
+    raw_rows = parse_csv(
+        filepath,
+        product_type=product_type,
+        source=source,
+        col_map=col_map,
+    )
+
+    inserted = 0
+    rejected = 0
+    reserved_stripped = 0
+    seen_ids: Set[str] = set()
+
+    for raw in raw_rows:
+        reserved_stripped += _strip_reserved_keys(raw, merchant_id)
+
+        pid_raw = _extract_id(raw) or str(uuid.uuid4())
+        try:
+            pid = uuid.UUID(str(pid_raw))
+        except (ValueError, TypeError):
+            logger.warning("csv_invalid_uuid merchant=%s id=%s", merchant_id, pid_raw)
+            rejected += 1
+            continue
+
+        pid_str = str(pid)
+        if pid_str in seen_ids:
+            logger.warning(
+                "csv_duplicate_product_id merchant=%s id=%s — skipped",
+                merchant_id, pid_str,
+            )
+            rejected += 1
+            continue
+        seen_ids.add(pid_str)
+
+        try:
+            schema = ProductSchema(**raw)
+        except Exception as exc:
+            logger.warning(
+                "csv_schema_validation_failed merchant=%s title=%s err=%s",
+                merchant_id, raw.get("title"), exc,
+            )
+            rejected += 1
+            continue
+
+        row = schema.to_product_row(product_id=pid_str)
+        # `ProductSchema.to_product_row` returns category capitalized
+        # (e.g. "Electronics") from its product_type→category map. The search
+        # path filters with a case-sensitive equality check, so we lowercase
+        # here to match the agent's default-domain filter (e.g. "electronics").
+        # Callers passing a CSV `category` column should already be lowercase.
+        category_norm = (row["category"] or "").strip().lower() or None
+        instance = product_model(
+            product_id=pid,
+            name=row["title"],
+            category=category_norm,
+            product_type=row["product_type"],
+            brand=row["brand"],
+            price_value=row["price"],
+            image_url=row["imageurl"],
+            rating=row["rating"],
+            rating_count=row["rating_count"],
+            source=row["source"],
+            link=row["link"],
+            ref_id=row["ref_id"],
+            attributes=row["attributes"],
+            merchant_id=merchant_id,
+        )
+        db.add(instance)
+        inserted += 1
+
+    db.commit()
+
+    summary = {
+        "parsed": len(raw_rows),
+        "inserted": inserted,
+        "rejected": rejected,
+        "reserved_stripped": reserved_stripped,
+    }
+    logger.info("csv_load_complete merchant=%s %s", merchant_id, summary)
+    return summary

--- a/mcp-server/app/ingestion/schema.py
+++ b/mcp-server/app/ingestion/schema.py
@@ -9,6 +9,11 @@ Both are cloned from the default merchant's tables via ``LIKE ... INCLUDING
 ALL``. The FK from enriched → raw is re-added explicitly because LIKE does
 not copy foreign keys.
 
+Prerequisite: migrations 002 and 003 must have run — the clone reads from
+``merchants.products_default`` / ``merchants.products_enriched_default``
+as the template, and ``create_merchant_catalog`` raises a bare Postgres
+"relation does not exist" if those tables aren't there yet.
+
 All identifiers that interpolate the merchant_id are built via
 ``psycopg2.sql.Identifier`` after ``validate_merchant_id`` has matched the
 merchant id against the slug regex in ``app.merchant_agent``. Merchant ids

--- a/mcp-server/app/ingestion/schema.py
+++ b/mcp-server/app/ingestion/schema.py
@@ -1,0 +1,118 @@
+"""
+Per-merchant DDL helpers.
+
+Each merchant gets a pair of tables inside the shared `merchants` schema:
+    merchants.products_<id>           (raw catalog)
+    merchants.products_enriched_<id>  (derived attributes per strategy)
+
+Both are cloned from the default merchant's tables via ``LIKE ... INCLUDING
+ALL``. The FK from enriched → raw is re-added explicitly because LIKE does
+not copy foreign keys.
+
+All identifiers that interpolate the merchant_id are built via
+``psycopg2.sql.Identifier`` after ``validate_merchant_id`` has matched the
+merchant id against the slug regex in ``app.merchant_agent``. Merchant ids
+reach this module from the registry, not from raw user input, but we still
+validate defensively.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from psycopg2 import sql
+
+from app.merchant_agent import validate_merchant_id
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = "merchants"
+_TEMPLATE_RAW = "products_default"
+_TEMPLATE_ENRICHED = "products_enriched_default"
+
+
+def _raw_table(merchant_id: str) -> str:
+    return f"products_{merchant_id}"
+
+
+def _enriched_table(merchant_id: str) -> str:
+    return f"products_enriched_{merchant_id}"
+
+
+def _fk_name(merchant_id: str) -> str:
+    return f"fk_products_enriched_{merchant_id}_product_id"
+
+
+def create_merchant_catalog(merchant_id: str, conn: Any) -> None:
+    """Create ``merchants.products_<id>`` and ``merchants.products_enriched_<id>``.
+
+    Clones both from the default merchant's tables via LIKE INCLUDING ALL and
+    re-adds the enriched → raw FK (LIKE does not copy foreign keys). Idempotent
+    — safe to re-run on an already-bootstrapped merchant.
+
+    ``conn`` is a psycopg2 connection. Callers holding a SQLAlchemy engine can
+    obtain one via ``engine.raw_connection()``.
+    """
+    merchant_id = validate_merchant_id(merchant_id)
+
+    raw = sql.Identifier(_SCHEMA, _raw_table(merchant_id))
+    enriched = sql.Identifier(_SCHEMA, _enriched_table(merchant_id))
+    template_raw = sql.Identifier(_SCHEMA, _TEMPLATE_RAW)
+    template_enriched = sql.Identifier(_SCHEMA, _TEMPLATE_ENRICHED)
+    fk_name = _fk_name(merchant_id)
+
+    with conn.cursor() as cur:
+        cur.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {schema}").format(
+            schema=sql.Identifier(_SCHEMA),
+        ))
+
+        cur.execute(sql.SQL(
+            "CREATE TABLE IF NOT EXISTS {raw} (LIKE {template} INCLUDING ALL)"
+        ).format(raw=raw, template=template_raw))
+
+        cur.execute(sql.SQL(
+            "CREATE TABLE IF NOT EXISTS {enriched} (LIKE {template} INCLUDING ALL)"
+        ).format(enriched=enriched, template=template_enriched))
+
+        # LIKE INCLUDING ALL does not copy FK constraints. Re-add so dropping
+        # a raw row cascades through enriched. ALTER TABLE ... ADD CONSTRAINT
+        # IF NOT EXISTS is not available across all supported Postgres versions,
+        # so probe pg_constraint first.
+        cur.execute(
+            "SELECT 1 FROM pg_constraint WHERE conname = %s",
+            (fk_name,),
+        )
+        if not cur.fetchone():
+            cur.execute(sql.SQL(
+                "ALTER TABLE {enriched} ADD CONSTRAINT {fk_name} "
+                "FOREIGN KEY (product_id) REFERENCES {raw}(id) ON DELETE CASCADE"
+            ).format(
+                enriched=enriched,
+                fk_name=sql.Identifier(fk_name),
+                raw=raw,
+            ))
+
+    conn.commit()
+    logger.info("created_merchant_catalog merchant_id=%s", merchant_id)
+
+
+def drop_merchant_catalog(merchant_id: str, conn: Any) -> None:
+    """Drop both per-merchant tables. Gated on ``ALLOW_MERCHANT_DROP=1``."""
+    if os.environ.get("ALLOW_MERCHANT_DROP", "") != "1":
+        raise PermissionError(
+            "drop_merchant_catalog disabled. Set ALLOW_MERCHANT_DROP=1 to enable."
+        )
+    merchant_id = validate_merchant_id(merchant_id)
+    if merchant_id == "default":
+        # The default merchant is the clone template. Dropping it would break
+        # create_merchant_catalog for every future merchant.
+        raise ValueError("refusing to drop the default merchant's catalog")
+
+    raw = sql.Identifier(_SCHEMA, _raw_table(merchant_id))
+    enriched = sql.Identifier(_SCHEMA, _enriched_table(merchant_id))
+    with conn.cursor() as cur:
+        cur.execute(sql.SQL("DROP TABLE IF EXISTS {t} CASCADE").format(t=enriched))
+        cur.execute(sql.SQL("DROP TABLE IF EXISTS {t} CASCADE").format(t=raw))
+    conn.commit()
+    logger.info("dropped_merchant_catalog merchant_id=%s", merchant_id)

--- a/mcp-server/app/merchant_agent.py
+++ b/mcp-server/app/merchant_agent.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
@@ -19,6 +20,30 @@ from app.models import Product
 from app.schemas import SearchProductsRequest
 
 logger = logging.getLogger(__name__)
+
+# Merchant id slug grammar. Narrow so it is always safe to splice into an
+# identifier position in SQL once it has matched. Client-supplied slug only —
+# callers never pass raw user input through these helpers; ingress validates
+# at the endpoint before routing into the registry.
+MERCHANT_ID_RE = re.compile(r"^[a-z][a-z0-9_]{1,31}$")
+
+
+def validate_merchant_id(merchant_id: str) -> str:
+    if not isinstance(merchant_id, str) or not MERCHANT_ID_RE.fullmatch(merchant_id):
+        raise ValueError(
+            f"invalid merchant_id {merchant_id!r}: must match {MERCHANT_ID_RE.pattern}"
+        )
+    return merchant_id
+
+
+def merchant_catalog_table(merchant_id: str) -> str:
+    """Fully-qualified raw catalog table for this merchant."""
+    return f"merchants.products_{validate_merchant_id(merchant_id)}"
+
+
+def merchant_enriched_table(merchant_id: str) -> str:
+    """Fully-qualified enriched catalog table for this merchant."""
+    return f"merchants.products_enriched_{validate_merchant_id(merchant_id)}"
 
 # Translate agent slot vocabulary → KG scoring-flag vocabulary.
 # Two naming conventions arrive depending on the upstream path:
@@ -47,8 +72,18 @@ class MerchantAgent:
         merchant_id: str,
         domain: str,
     ) -> None:
-        self.merchant_id = merchant_id
+        self.merchant_id = validate_merchant_id(merchant_id)
         self.domain = domain
+        self._catalog_table = merchant_catalog_table(self.merchant_id)
+        self._enriched_table = merchant_enriched_table(self.merchant_id)
+
+    def catalog_table(self) -> str:
+        """Return fully-qualified raw catalog table name for this merchant."""
+        return self._catalog_table
+
+    def enriched_table(self) -> str:
+        """Return fully-qualified enriched catalog table name for this merchant."""
+        return self._enriched_table
 
     # ------------------------------------------------------------------
     # Search

--- a/mcp-server/app/merchant_agent.py
+++ b/mcp-server/app/merchant_agent.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session
 
 from app.contract import Offer, StructuredQuery
 from app.endpoints import search_products
-from app.models import Product
+from app.models import Product, make_enriched_model, make_product_model
 from app.schemas import SearchProductsRequest
 
 logger = logging.getLogger(__name__)
@@ -76,6 +76,11 @@ class MerchantAgent:
         self.domain = domain
         self._catalog_table = merchant_catalog_table(self.merchant_id)
         self._enriched_table = merchant_enriched_table(self.merchant_id)
+        # Per-merchant ORM models. Cached on the instance so downstream
+        # retrieval paths that take a model argument don't need to re-enter
+        # the factory.
+        self._product_model = make_product_model(self.merchant_id)
+        self._enriched_model = make_enriched_model(self.merchant_id)
 
     def catalog_table(self) -> str:
         """Return fully-qualified raw catalog table name for this merchant."""
@@ -84,6 +89,107 @@ class MerchantAgent:
     def enriched_table(self) -> str:
         """Return fully-qualified enriched catalog table name for this merchant."""
         return self._enriched_table
+
+    @property
+    def product_model(self):
+        return self._product_model
+
+    @property
+    def enriched_model(self):
+        return self._enriched_model
+
+    # ------------------------------------------------------------------
+    # Bootstrap
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_csv(
+        cls,
+        path: str,
+        *,
+        merchant_id: str,
+        domain: str,
+        product_type: str,
+        strategy: str = "normalizer_v1",
+        source: Optional[str] = None,
+        col_map: Optional[Dict[str, str]] = None,
+        normalize_limit: int = 1000,
+        skip_enrichment: bool = False,
+    ) -> "MerchantAgent":
+        """Bootstrap a new merchant from a CSV file.
+
+        Pipeline (synchronous for this PR — issue #42 tracks UI progress):
+          1. Validate ``merchant_id`` against the slug grammar.
+          2. Create per-merchant tables via ``create_merchant_catalog``.
+          3. Load CSV rows into the merchant's raw table.
+          4. Run ``CatalogNormalizer`` scoped to this merchant's tables.
+          5. Register the agent in the in-memory merchant registry so
+             ``/merchant/<id>/search`` routes here.
+
+        Large catalogs will block; callers should budget accordingly. Async
+        ingest with progress reporting is intentionally deferred — that work
+        belongs with the #42 UI counterpart, not this PR.
+        """
+        merchant_id = validate_merchant_id(merchant_id)
+
+        # Local imports to avoid load-time cycles. ``app.main`` imports
+        # merchant_agent; ingestion.* imports from merchant_agent too.
+        from app.database import SessionLocal
+        from app.ingestion.schema import create_merchant_catalog
+        from app.ingestion.csv_loader import load_csv_into_merchant
+        from app.catalog_ingestion import CatalogNormalizer
+
+        session = SessionLocal()
+        engine = session.get_bind()
+        session.close()
+
+        raw_conn = engine.raw_connection()
+        try:
+            create_merchant_catalog(merchant_id, raw_conn)
+        finally:
+            raw_conn.close()
+
+        agent = cls(merchant_id=merchant_id, domain=domain)
+
+        db = SessionLocal()
+        try:
+            load_summary = load_csv_into_merchant(
+                path,
+                db=db,
+                product_model=agent.product_model,
+                merchant_id=merchant_id,
+                product_type=product_type,
+                source=source or f"csv:{merchant_id}",
+                col_map=col_map,
+            )
+        finally:
+            db.close()
+        logger.info("from_csv_loaded merchant=%s summary=%s", merchant_id, load_summary)
+
+        if not skip_enrichment:
+            db = SessionLocal()
+            try:
+                normalizer = CatalogNormalizer()
+                enrich_summary = normalizer.batch_normalize(
+                    db,
+                    limit=normalize_limit,
+                    product_model=agent.product_model,
+                    enriched_model=agent.enriched_model,
+                    strategy=strategy,
+                )
+                logger.info(
+                    "from_csv_enriched merchant=%s summary=%s",
+                    merchant_id, enrich_summary,
+                )
+            finally:
+                db.close()
+
+        # In-memory registry only — on restart, the operator re-runs bootstrap
+        # to re-register. Tables persist in Postgres so data is not lost.
+        from app import main as app_main
+        app_main.merchants[merchant_id] = agent
+        logger.info("merchant_registered id=%s domain=%s", merchant_id, domain)
+        return agent
 
     # ------------------------------------------------------------------
     # Search
@@ -157,18 +263,19 @@ class MerchantAgent:
     # ------------------------------------------------------------------
 
     def health(self, db: Session) -> dict:
+        _Product = self._product_model
         if self.merchant_id == "default":
             from sqlalchemy import or_
-            catalog_q = db.query(Product).filter(
-                or_(Product.merchant_id.is_(None), Product.merchant_id == "default")
+            catalog_q = db.query(_Product).filter(
+                or_(_Product.merchant_id.is_(None), _Product.merchant_id == "default")
             )
         else:
-            catalog_q = db.query(Product).filter(Product.merchant_id == self.merchant_id)
+            catalog_q = db.query(_Product).filter(_Product.merchant_id == self.merchant_id)
 
         catalog_size = catalog_q.count()
 
         from sqlalchemy import func
-        max_created = catalog_q.with_entities(func.max(Product.created_at)).scalar()
+        max_created = catalog_q.with_entities(func.max(_Product.created_at)).scalar()
 
         # Vector index mtime (best-effort)
         vector_index_mtime = None

--- a/mcp-server/app/models.py
+++ b/mcp-server/app/models.py
@@ -115,6 +115,7 @@ class _ProductProperties:
 
     @property
     def subcategory(self):
+        """Supabase has no subcategory column; return None."""
         return None
 
     @property

--- a/mcp-server/app/models.py
+++ b/mcp-server/app/models.py
@@ -8,81 +8,105 @@ Postgres is authoritative for:
 - Inventory (stock levels)
 - Carts and cart items
 - Orders and checkout state
-"""
 
-from sqlalchemy import Column, String, Integer, DateTime, ForeignKey, Text, Index, UniqueConstraint, Numeric, BigInteger, SmallInteger
-from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY, UUID as PG_UUID, JSONB as PG_JSONB
-from sqlalchemy.orm import relationship
+Per-merchant catalogs live in the `merchants` schema as
+``merchants.products_<id>`` + ``merchants.products_enriched_<id>``. The
+``Product`` / ``ProductEnriched`` module-level classes are the default
+merchant's mapping, kept as stable import names for the call sites that
+haven't been threaded through ``make_product_model(merchant_id)`` yet.
+"""
+from typing import Any, Dict
+
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    SmallInteger,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY  # noqa: F401  (re-exported)
+from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.sql import func
+
 from app.database import Base
 
+_SCHEMA = "merchants"
 
-class Product(Base):
-    """
-    Product catalog — maps to `merchants.products_default`.
 
-    Per the interim design (CLAUDE.md: "Merchant agent is generic; each uploaded
-    catalog is isolated"), the default merchant's catalog lives in the `merchants`
-    schema, cloned from `public.products`. Reads go through this model; the raw
-    `public.products` table stays frozen as the reference catalog.
+# ---------------------------------------------------------------------------
+# Column definitions — returned fresh per call so every per-merchant model
+# gets its own Column instances (SQLAlchemy binds a Column to one Table).
+# ---------------------------------------------------------------------------
 
-    Issue #38 tracks the long-term target of one schema per merchant.
+def _product_columns() -> Dict[str, Any]:
+    return dict(
+        # Supabase uses 'id' (UUID); Python attribute stays `product_id`.
+        product_id=Column("id", PG_UUID(as_uuid=True), primary_key=True, index=True),
+        # Supabase uses 'title'; Python attribute stays `name`.
+        name=Column("title", Text, nullable=True, index=True),
+        category=Column(String(100), index=True),
+        brand=Column(String(100)),
+        source=Column(String(100), index=True),
+        # Supabase stores price in dollars directly on the products row.
+        price_value=Column("price", Numeric, nullable=True),
+        # Supabase uses 'imageurl' (no underscore).
+        image_url=Column("imageurl", Text, nullable=True),
+        product_type=Column(String(50), index=True),
+        series=Column(String(255), nullable=True),
+        model=Column(String(255), nullable=True),
+        link=Column(Text, nullable=True),
+        rating=Column(Numeric, nullable=True),
+        rating_count=Column(BigInteger, nullable=True),
+        ref_id=Column(String(255), nullable=True),
+        variant=Column(String(255), nullable=True),
+        inventory=Column(BigInteger, nullable=True),
+        release_year=Column(SmallInteger, nullable=True),
+        delivery_promise=Column(Text, nullable=True),
+        return_policy=Column(Text, nullable=True),
+        warranty=Column(Text, nullable=True),
+        promotions_discounts=Column(Text, nullable=True),
+        merchant_product_url=Column(Text, nullable=True),
+        attributes=Column(PG_JSONB, nullable=True),
+        # Per-merchant scoping column (NULL = legacy/default catalog).
+        merchant_id=Column(String, nullable=True, index=True),
+        created_at=Column(DateTime(timezone=True), server_default=func.now()),
+        updated_at=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
+    )
 
-    Column('db_name', ...) maps the underlying column names to Python attribute
-    names so existing code continues to work without changes.
-    """
-    __tablename__ = "products_default"
-    __table_args__ = {"extend_existing": True, "schema": "merchants"}
 
-    # Primary identifier — Supabase uses 'id' (UUID), we keep attribute name 'product_id'
-    product_id = Column("id", PG_UUID(as_uuid=True), primary_key=True, index=True)
+def _enriched_columns(raw_table_fqn: str) -> Dict[str, Any]:
+    return dict(
+        product_id=Column(
+            PG_UUID(as_uuid=True),
+            ForeignKey(f"{raw_table_fqn}.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        strategy=Column(Text, primary_key=True),
+        attributes=Column(PG_JSONB, nullable=False, default=dict),
+        model=Column(Text, nullable=True),
+        updated_at=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
+    )
 
-    # Basic product information — Supabase uses 'title', we keep attribute name 'name'
-    name = Column("title", Text, nullable=True, index=True)
-    category = Column(String(100), index=True)
-    brand = Column(String(100))
-    source = Column(String(100), index=True)
 
-    # Supabase has price directly on products (decimal dollars, not cents)
-    price_value = Column("price", Numeric, nullable=True)
+# ---------------------------------------------------------------------------
+# Mixin: compatibility @property helpers shared by every per-merchant model.
+# Lives on a non-mapped mixin so the factory can combine it with fresh
+# column dicts at each call site.
+# ---------------------------------------------------------------------------
 
-    # Supabase uses 'imageurl' (no underscore)
-    image_url = Column("imageurl", Text, nullable=True)
+class _ProductProperties:
+    """Backwards-compatible accessors for fields that live inside ``attributes``."""
 
-    # Product type for filtering (laptop, book, etc.)
-    product_type = Column(String(50), index=True)
-
-    # Supabase columns that exist
-    series = Column(String(255), nullable=True)
-    model = Column(String(255), nullable=True)
-    link = Column(Text, nullable=True)
-    rating = Column(Numeric, nullable=True)
-    rating_count = Column(BigInteger, nullable=True)
-    ref_id = Column(String(255), nullable=True)
-    variant = Column(String(255), nullable=True)
-    inventory = Column(BigInteger, nullable=True)
-    release_year = Column(SmallInteger, nullable=True)
-    delivery_promise = Column(Text, nullable=True)
-    return_policy = Column(Text, nullable=True)
-    warranty = Column(Text, nullable=True)
-    promotions_discounts = Column(Text, nullable=True)
-    merchant_product_url = Column(Text, nullable=True)
-    attributes = Column(PG_JSONB, nullable=True)  # JSONB with product specs
-
-    # Per-merchant catalog scope (NULL = default/shared catalog)
-    merchant_id = Column(String, nullable=True, index=True)
-
-    # Metadata
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
-
-    # Compatibility properties for code that expects old field names
     @property
     def description(self):
-        """Return the raw scraped description from attributes JSON.
+        """Raw scraped description from attributes JSON.
 
-        The normalized form lives in merchants.products_enriched_default under
-        strategy='normalizer_v1' and is read via enriched_reader.hydrate_batch
+        The normalized form lives in ``products_enriched_<id>`` under
+        strategy='normalizer_v1' and is read via ``enriched_reader.hydrate_batch``
         in the merchant-agent search path — not from the raw attributes here.
         """
         if self.attributes and isinstance(self.attributes, dict):
@@ -91,7 +115,6 @@ class Product(Base):
 
     @property
     def subcategory(self):
-        """Supabase has no subcategory column; return None."""
         return None
 
     @property
@@ -131,47 +154,113 @@ class Product(Base):
         return None
 
 
-class ProductEnriched(Base):
+# ---------------------------------------------------------------------------
+# Default-merchant mapped classes.
+#
+# Built via ``type()`` from the same column-dict factory used by
+# ``make_product_model`` / ``make_enriched_model`` so every per-merchant
+# model shares a single column definition. Call sites that haven't been
+# threaded through the factory yet import these names directly.
+# ---------------------------------------------------------------------------
+
+Product = type(
+    "Product",
+    (_ProductProperties, Base),
+    {
+        "__tablename__": "products_default",
+        "__table_args__": {"extend_existing": True, "schema": _SCHEMA},
+        **_product_columns(),
+    },
+)
+
+ProductEnriched = type(
+    "ProductEnriched",
+    (Base,),
+    {
+        "__tablename__": "products_enriched_default",
+        "__table_args__": {"extend_existing": True, "schema": _SCHEMA},
+        **_enriched_columns(f"{_SCHEMA}.products_default"),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Factories.
+# ---------------------------------------------------------------------------
+
+_product_model_cache: Dict[str, Any] = {"default": Product}
+_enriched_model_cache: Dict[str, Any] = {"default": ProductEnriched}
+
+
+def _validate(merchant_id: str) -> str:
+    # Lazy import — ``app.merchant_agent`` top-level imports
+    # ``app.endpoints``, which top-level imports this module. Importing
+    # merchant_agent at module load would create a cycle.
+    from app.merchant_agent import validate_merchant_id
+    return validate_merchant_id(merchant_id)
+
+
+def make_product_model(merchant_id: str):
+    """Return the SQLAlchemy Product model mapped to ``merchants.products_<id>``.
+
+    Cached per merchant_id — repeated calls return the same class so
+    SQLAlchemy's metadata stays consistent under server reload.
     """
-    Derived attributes per (product, strategy). The raw `products` table is the
-    golden source and is never mutated by enrichment — enrichers write here.
-
-    A `strategy` is a named recipe (e.g. 'normalizer_v1', 'soft_tags_heuristic_v1',
-    'llm_extract_gpt4o_mini'). Multiple strategies can coexist for the same product
-    so A/B comparisons and merchant simulations are just different strategy labels.
-    """
-    __tablename__ = "products_enriched_default"
-    __table_args__ = {"extend_existing": True, "schema": "merchants"}
-
-    product_id = Column(
-        PG_UUID(as_uuid=True),
-        ForeignKey("merchants.products_default.id", ondelete="CASCADE"),
-        primary_key=True,
-    )
-    strategy = Column(Text, primary_key=True)
-    attributes = Column(PG_JSONB, nullable=False, default=dict)
-    model = Column(Text, nullable=True)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    cached = _product_model_cache.get(merchant_id)
+    if cached is not None:
+        return cached
+    merchant_id = _validate(merchant_id)
+    attrs = {
+        "__tablename__": f"products_{merchant_id}",
+        "__table_args__": {"extend_existing": True, "schema": _SCHEMA},
+        **_product_columns(),
+    }
+    cls = type(f"Product_{merchant_id}", (_ProductProperties, Base), attrs)
+    _product_model_cache[merchant_id] = cls
+    return cls
 
 
-# Stub classes for code that imports Price/Inventory/Cart/CartItem/Order
-# These tables don't exist in Supabase — stubs prevent import errors
+def make_enriched_model(merchant_id: str):
+    """Return the SQLAlchemy ProductEnriched model for this merchant."""
+    cached = _enriched_model_cache.get(merchant_id)
+    if cached is not None:
+        return cached
+    merchant_id = _validate(merchant_id)
+    raw_fqn = f"{_SCHEMA}.products_{merchant_id}"
+    attrs = {
+        "__tablename__": f"products_enriched_{merchant_id}",
+        "__table_args__": {"extend_existing": True, "schema": _SCHEMA},
+        **_enriched_columns(raw_fqn),
+    }
+    cls = type(f"ProductEnriched_{merchant_id}", (Base,), attrs)
+    _enriched_model_cache[merchant_id] = cls
+    return cls
+
+
+# ---------------------------------------------------------------------------
+# Stub classes for code that imports Price/Inventory/Cart/CartItem/Order.
+# These tables don't exist in Supabase — stubs prevent import errors.
+# ---------------------------------------------------------------------------
 
 class Price:
-    """Stub — Supabase stores price directly on products table."""
+    """Stub — Supabase stores price directly on products."""
     pass
 
+
 class Inventory:
-    """Stub — Supabase stores inventory directly on products table."""
+    """Stub — Supabase stores inventory directly on products."""
     pass
+
 
 class Cart:
     """Stub — cart table in Supabase has different schema."""
     pass
 
+
 class CartItem:
     """Stub — not used in Supabase."""
     pass
+
 
 class Order:
     """Stub — not used in Supabase."""

--- a/mcp-server/app/tools/supabase_product_store.py
+++ b/mcp-server/app/tools/supabase_product_store.py
@@ -27,6 +27,27 @@ from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger("mcp.supabase_product_store")
 
+
+# ---------------------------------------------------------------------------
+# Catalog table resolution
+#
+# The raw SQL paths below are per-merchant scoped. Resolution always goes
+# through `merchant_catalog_table(...)` in `app.merchant_agent`, which
+# regex-validates the merchant id before interpolation — the value is never
+# spliced into SQL without that check. Imports are local so this module stays
+# importable during app startup before app.merchant_agent has finished loading.
+# ---------------------------------------------------------------------------
+
+def _catalog_table_for(merchant_id: Optional[str]) -> str:
+    from app.merchant_agent import merchant_catalog_table
+    return merchant_catalog_table(merchant_id or "default")
+
+
+def _resolve_catalog_table(filters: Optional[Dict[str, Any]]) -> str:
+    mid = (filters or {}).get("merchant_id") if isinstance(filters, dict) else None
+    return _catalog_table_for(mid if isinstance(mid, str) and mid else None)
+
+
 # ---------------------------------------------------------------------------
 # Singleton store (lazy-init)
 # ---------------------------------------------------------------------------
@@ -639,6 +660,8 @@ class _SQLAlchemyProductStore:
         filters: Dict[str, Any],
         limit: int = 100,
         exclude_ids: Optional[List[str]] = None,
+        *,
+        table_name: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """
         Progressive filter relaxation — mirrors SupabaseProductStore's 5-step approach.
@@ -647,10 +670,16 @@ class _SQLAlchemyProductStore:
           2. drop price floor (price_min only)
           3. drop brand
           4. drop both brand and price floor
+
+        `table_name` (optional): fully-qualified raw catalog table for the
+        merchant scope. When omitted, we derive it from `filters["merchant_id"]`
+        via `merchant_catalog_table(...)` so the call-site can stay thin.
         """
         if self._engine is None:
             logger.error("SQLAlchemy engine not available")
             return []
+
+        table_name = table_name or _resolve_catalog_table(filters)
 
         # Parse prices once — shared across relaxation steps
         price_min = _parse_price(filters.get("price_min_cents"), filters.get("price_min"))
@@ -686,6 +715,7 @@ class _SQLAlchemyProductStore:
                 limit=limit,
                 exclude_ids=exclude_ids,
                 drop_os=step["drop_os"],
+                table_name=table_name,
             )
             if rows:
                 logger.info(
@@ -704,6 +734,8 @@ class _SQLAlchemyProductStore:
         limit: int,
         exclude_ids: Optional[List[str]],
         drop_os: bool = False,
+        *,
+        table_name: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Execute one SQL query + Python-side spec filtering pass."""
         import json as _json
@@ -778,7 +810,8 @@ class _SQLAlchemyProductStore:
         fetch_limit = min(limit * 8, 800)
         # ORDER BY id (index scan) is ~25x faster than ORDER BY RANDOM() (full table sort).
         # Python-side shuffle at line ~839 provides the randomisation instead.
-        sql = sa_text(f"SELECT * FROM merchants.products_default WHERE {where} ORDER BY id LIMIT :fetch_limit")
+        resolved_table = table_name or _resolve_catalog_table(filters)
+        sql = sa_text(f"SELECT * FROM {resolved_table} WHERE {where} ORDER BY id LIMIT :fetch_limit")
         params["fetch_limit"] = fetch_limit
 
         try:
@@ -865,20 +898,36 @@ class _SQLAlchemyProductStore:
         random.shuffle(filtered)
         return filtered[:limit]
 
-    def get_by_id(self, product_id: str) -> Optional[Dict[str, Any]]:
+    def get_by_id(
+        self,
+        product_id: str,
+        *,
+        table_name: Optional[str] = None,
+        merchant_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         if self._engine is None:
             return None
         try:
             from sqlalchemy import text as sa_text
+            resolved_table = table_name or _catalog_table_for(merchant_id)
             with self._engine.connect() as conn:
-                result = conn.execute(sa_text("SELECT * FROM merchants.products_default WHERE id = :id LIMIT 1"), {"id": product_id})
+                result = conn.execute(
+                    sa_text(f"SELECT * FROM {resolved_table} WHERE id = :id LIMIT 1"),
+                    {"id": product_id},
+                )
                 row = result.fetchone()
                 return SupabaseProductStore._row_to_dict(dict(row._mapping)) if row else None
         except Exception as e:
             logger.error(f"get_by_id (SQLAlchemy) failed: {e}")
             return None
 
-    def get_by_ids(self, product_ids: List[str]) -> List[Dict[str, Any]]:
+    def get_by_ids(
+        self,
+        product_ids: List[str],
+        *,
+        table_name: Optional[str] = None,
+        merchant_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
         """Fetch multiple products by ID in one query, preserving caller order.
 
         Uses _row_to_dict so spec parsing (_parse_specs_from_title, brand
@@ -890,9 +939,10 @@ class _SQLAlchemyProductStore:
             from sqlalchemy import text as sa_text
             params = {f"id{i}": pid for i, pid in enumerate(product_ids)}
             placeholders = ", ".join(f":id{i}" for i in range(len(product_ids)))
+            resolved_table = table_name or _catalog_table_for(merchant_id)
             with self._engine.connect() as conn:
                 result = conn.execute(
-                    sa_text(f"SELECT * FROM merchants.products_default WHERE id IN ({placeholders})"),
+                    sa_text(f"SELECT * FROM {resolved_table} WHERE id IN ({placeholders})"),
                     params,
                 )
                 rows = result.fetchall()

--- a/scripts/bootstrap_merchant.py
+++ b/scripts/bootstrap_merchant.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Bootstrap a new merchant from a CSV file.
+
+Thin CLI over ``MerchantAgent.from_csv``. Creates per-merchant tables in the
+``merchants`` schema, loads the CSV, runs the normalizer, and registers the
+agent in the in-memory registry (the registry is process-local — see issue
+#42 for the UI counterpart that will hold a durable registration).
+
+Usage:
+  python scripts/bootstrap_merchant.py \\
+      --csv fixture.csv \\
+      --merchant acme \\
+      --domain electronics \\
+      --product-type laptop
+
+Re-ingest:
+  The loader rejects duplicate product_ids. To re-ingest the same merchant,
+  first drop the catalog via
+      ALLOW_MERCHANT_DROP=1 python -c \\
+          "from app.ingestion.schema import drop_merchant_catalog; ..."
+  and then re-run this script. See ARCHITECTURE.md for the rationale.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "mcp-server"))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(_ROOT / ".env")
+except ImportError:
+    pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Bootstrap a merchant from a CSV.")
+    parser.add_argument("--csv", required=True, help="Path to the CSV file.")
+    parser.add_argument("--merchant", dest="merchant_id", required=True,
+                        help="Merchant slug. Must match [a-z][a-z0-9_]{1,31}.")
+    parser.add_argument("--domain", required=True,
+                        help="Domain label the agent claims, e.g. 'electronics'.")
+    parser.add_argument("--product-type", required=True,
+                        help="Default product_type for rows missing the column.")
+    parser.add_argument("--source", default=None,
+                        help="Source label for rows. Defaults to 'csv:<merchant>'.")
+    parser.add_argument("--strategy", default="normalizer_v1",
+                        help="Enrichment strategy label (default normalizer_v1).")
+    parser.add_argument("--normalize-limit", type=int, default=1000,
+                        help="Max products to enrich synchronously (default 1000).")
+    parser.add_argument("--skip-enrichment", action="store_true",
+                        help="Create tables and load CSV but skip LLM enrichment.")
+    args = parser.parse_args()
+
+    from app.merchant_agent import MerchantAgent
+
+    agent = MerchantAgent.from_csv(
+        args.csv,
+        merchant_id=args.merchant_id,
+        domain=args.domain,
+        product_type=args.product_type,
+        strategy=args.strategy,
+        source=args.source,
+        normalize_limit=args.normalize_limit,
+        skip_enrichment=args.skip_enrichment,
+    )
+
+    print(json.dumps({
+        "merchant_id": agent.merchant_id,
+        "domain": agent.domain,
+        "catalog_table": agent.catalog_table(),
+        "enriched_table": agent.enriched_table(),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bootstrap_merchant.py
+++ b/scripts/bootstrap_merchant.py
@@ -15,11 +15,20 @@ Usage:
       --product-type laptop
 
 Re-ingest:
-  The loader rejects duplicate product_ids. To re-ingest the same merchant,
-  first drop the catalog via
-      ALLOW_MERCHANT_DROP=1 python -c \\
-          "from app.ingestion.schema import drop_merchant_catalog; ..."
-  and then re-run this script. See ARCHITECTURE.md for the rationale.
+  The loader raises MerchantAlreadyBootstrapped if the target table has
+  rows. To re-ingest the same merchant, drop the catalog first:
+
+      ALLOW_MERCHANT_DROP=1 python -c "
+      import os
+      from sqlalchemy import create_engine
+      from app.ingestion.schema import drop_merchant_catalog
+      eng = create_engine(os.environ['DATABASE_URL'])
+      conn = eng.raw_connection()
+      try: drop_merchant_catalog('<merchant-id>', conn)
+      finally: conn.close()
+      "
+
+  then re-run this script.
 """
 
 import argparse

--- a/scripts/run_normalizer.py
+++ b/scripts/run_normalizer.py
@@ -6,10 +6,11 @@ Runs description normalization and writes to products_enriched under
 strategy='normalizer_v1'. Raw products table is never mutated.
 
 Usage:
-  python scripts/run_normalizer.py                 # up to 200 products
-  python scripts/run_normalizer.py --dry-run       # print, no DB writes
+  python scripts/run_normalizer.py                           # default merchant, up to 200
+  python scripts/run_normalizer.py --dry-run
   python scripts/run_normalizer.py --limit 50
-  python scripts/run_normalizer.py --force         # re-normalize existing rows (UPSERT)
+  python scripts/run_normalizer.py --force                   # UPSERT existing rows
+  python scripts/run_normalizer.py --merchant-id acme        # scope to one merchant
 """
 
 import argparse
@@ -27,14 +28,32 @@ except ImportError:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Normalize product catalog via LLM (writes to products_enriched).")
+    parser = argparse.ArgumentParser(
+        description="Normalize product catalog via LLM (writes to products_enriched).",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Print results without writing.")
     parser.add_argument("--limit", type=int, default=200, help="Max products to process (default 200).")
-    parser.add_argument("--force", action="store_true", help="Re-normalize products that already have a normalizer_v1 row.")
+    parser.add_argument(
+        "--force", action="store_true",
+        help="Re-normalize products that already have a row under this strategy.",
+    )
+    parser.add_argument(
+        "--merchant-id", default="default",
+        help="Merchant to normalize. Defaults to 'default'.",
+    )
+    parser.add_argument(
+        "--strategy", default=None,
+        help="Strategy label to write. Defaults to normalizer_v1.",
+    )
     args = parser.parse_args()
 
     from app.catalog_ingestion import CatalogNormalizer, STRATEGY
     from app.database import SessionLocal
+    from app.models import make_enriched_model, make_product_model
+
+    strategy = args.strategy or STRATEGY
+    product_model = make_product_model(args.merchant_id)
+    enriched_model = make_enriched_model(args.merchant_id)
 
     db = SessionLocal()
     try:
@@ -44,12 +63,15 @@ def main() -> int:
             limit=args.limit,
             dry_run=args.dry_run,
             force=args.force,
+            product_model=product_model,
+            enriched_model=enriched_model,
+            strategy=strategy,
         )
     finally:
         db.close()
 
     print(
-        f"\nstrategy={STRATEGY}  "
+        f"\nmerchant={args.merchant_id}  strategy={strategy}  "
         f"normalized={result['normalized']}  "
         f"skipped={result['skipped']}  "
         f"failed={result['failed']}"


### PR DESCRIPTION
## Summary

Phases 0–3 of the merchant-agent v2 refactor. Closes the loop on
ingesting a new merchant from a CSV end-to-end:

1. **Phase 0** — raw SQL paths read the merchant's table from filters
2. **Phase 1** — DDL helper clones per-merchant tables from the default
3. **Phase 2** — ORM model factories + cached per-merchant models on the agent
4. **Phase 3** — `MerchantAgent.from_csv` + `scripts/bootstrap_merchant.py`, synchronous enrichment

Issue #42 tracks the UI counterpart. Phases 4–6 (per-merchant KG + vector, search-cache keying, docs) are explicitly **not** in this PR — see the "Not in this PR" section below.

## What changed

- `app.merchant_agent`: `validate_merchant_id` + `merchant_catalog_table` helpers (regex-validated slug grammar, single splice site). `MerchantAgent.catalog_table()` / `enriched_table()` / `product_model` / `enriched_model` accessors. `MerchantAgent.from_csv(...)` classmethod. `health()` scopes through the per-merchant model.
- `app.tools.supabase_product_store`: the three raw SQL sites accept an optional `table_name`, falling back to `_resolve_catalog_table(filters)`.
- `app.endpoints.search_products`: shadows module-level `Product` with `make_product_model(filters["merchant_id"])` so non-default merchants hit their own table. `get_product` log strings derive the table name from the model.
- `app.ingestion.schema`: `create_merchant_catalog` / `drop_merchant_catalog` using `psycopg2.sql.Identifier`. `LIKE INCLUDING ALL` from the default tables; enriched→raw FK re-added explicitly.
- `app.ingestion.csv_loader`: parses CSV via existing `csv_importer.parse_csv`, inserts via per-merchant ORM model, rejects reserved enrichment keys with a warning (strip, not hard-fail).
- `app.models`: `_product_columns()` / `_enriched_columns()` helpers; `make_product_model` / `make_enriched_model` factories cached per id; default `Product` / `ProductEnriched` built through the same helpers. `_ProductProperties` mixin holds the `description` / `color` / `gpu_*` compatibility accessors.
- `app.catalog_ingestion.batch_normalize` gains `product_model` / `enriched_model` / `strategy` kwargs. `scripts/run_normalizer.py --merchant-id` wires them.
- `scripts/bootstrap_merchant.py`: thin CLI over `MerchantAgent.from_csv`.

## Test plan

Hard invariants checked at HEAD and at every commit:

- [x] `POST /merchant/search` (no id) still returns 3 laptops
  ```
  curl -s -X POST -H 'Content-Type: application/json' \
    -d '{"domain":"electronics","hard_filters":{"product_type":"laptop","price_max":1500},"soft_preferences":{},"user_context":{},"top_k":3}' \
    http://localhost:8001/merchant/search | jq '.[].product.name'
  ```
- [x] `GET /merchant/default/health` reports `catalog_size=51277`
- [x] `grep -rn "merchants.products_default" mcp-server/app/` returns only docstring/comment references; the literal does not appear in SQL outside the model's `__tablename__`/FK target.
- [x] Offer / ProductSummary keys unchanged (additive only): Offer keys stay `{merchant_id, product_id, score, score_breakdown, product, rationale}`.

Phase-specific acceptance (all observed during development):

- [x] **Phase 0**: default golden path unchanged. Raw SQL parameterised; `filters["merchant_id"]` threads through `_resolve_catalog_table`.
- [x] **Phase 1**: `create_merchant_catalog("acme", conn)` creates `merchants.products_acme` + `merchants.products_enriched_acme` with FK; idempotent on re-run; `drop_merchant_catalog` requires `ALLOW_MERCHANT_DROP=1` and refuses to drop `default`; invalid slug raises `ValueError`.
- [x] **Phase 2**: `MerchantAgent("acme", "electronics")` caches `_product_model` / `_enriched_model`; agent search against empty `merchants.products_acme` returns `[]`.
- [x] **Phase 3**: `./scripts/bootstrap_merchant.py --csv acme.csv --merchant acme --domain electronics --product-type laptop --skip-enrichment` →
  - 4 rows in `merchants.products_acme` with `merchant_id='acme'`, category `'electronics'` (lowercased by the loader);
  - in-process `agent.search(...)` for acme returns the 4 CSV rows;
  - default search returns its own laptops, no cross-merchant bleed (set intersection empty);
  - `combine_raw_and_enriched({}, enriched)` does not raise on acme data;
  - `agent.health()` reports `catalog_size=4`;
  - `scripts/run_normalizer.py --merchant-id acme --limit 2` writes to `merchants.products_enriched_acme` (strategy `normalizer_v1`), verifiable via join.

How to verify locally:

```
# default path (must always hold)
curl -s -X POST -H 'Content-Type: application/json' \
  -d '{"domain":"electronics","hard_filters":{"product_type":"laptop","price_max":1500},"soft_preferences":{},"user_context":{},"top_k":3}' \
  http://localhost:8001/merchant/search | jq '.[].product.name'

# acme bootstrap (with DATABASE_URL loaded)
./scripts/bootstrap_merchant.py --csv /tmp/acme.csv --merchant acme \
  --domain electronics --product-type laptop --skip-enrichment

# verify separation
psql "$DATABASE_URL" -c "SELECT count(*), 'acme' FROM merchants.products_acme UNION ALL \
SELECT count(*), 'default' FROM merchants.products_default;"
```

## Open questions answered

1. **CSV column contract** — `title`, `product_type` (or `--product-type` fallback), `price` required. `id` (any of `id`/`uuid`/`product_uuid` → Postgres UUID) optional — auto-generated if missing. `brand`, `image_url`/`imageurl`, `rating`, `rating_count`, `source`, `link`, `ref_id` mapped to top-level columns. Spec fields mapped to `attributes` JSONB via `ProductSchema`. Unknown columns bucket into `ProductSchema.extra_attributes`. **Reserved keys:** `normalized_description`, `normalized_at` — stripped with a warning (strip, not reject, so one bad row doesn't torpedo a load).
2. **Merchant id** — client-supplied slug, validated against `^[a-z][a-z0-9_]{1,31}$`. Chosen over server UUID because the slug appears in table names and URL paths — readable IDs make debugging easier.
3. **Registered-merchant persistence** — in-memory only for this PR. Tables persist in Postgres; on process restart the operator re-runs bootstrap to re-register. Follow-up if needed.
4. **Failure mode on partial CSV parse** — best-effort + reject log. Schema validation failures and duplicate product_ids are logged and skipped; the load returns `{parsed, inserted, rejected, reserved_stripped}`. CSVs from merchants are messy; all-or-nothing is too punishing during onboarding.
5. **Re-ingest** — rejected. Operator must `ALLOW_MERCHANT_DROP=1 drop_merchant_catalog(...)` before re-running bootstrap. Upsert semantics are ambiguous when enriched rows exist — simpler to force intentional teardown.

## Not in this PR (flag for reviewer)

- **Phase 4** — per-(merchant, strategy) KG + vector index. Non-default merchants currently fall through to SQL-only retrieval in `search_products` (KG / vector paths gated on available indices).
- **Phase 5** — merchant-aware search cache key.
- **Phase 6** — cleanup + docs.
- **#42** — async CSV ingest + UI progress.
- **Teardown flows** — drop merchant / re-ingest / re-enrich tooling beyond the gated `drop_merchant_catalog` helper.
- **Threading `db.query(Product)` everywhere** — only `endpoints.search_products` and `MerchantAgent.health` are merchant-aware so far. Other call sites (`endpoints.get_product` product_id lookups at lines ~2632 / ~2867 / ~2875 / ~3070, `supabase_cart.py`) still read the default table. Enumerated so we can sweep them in a follow-up.
- **Case mismatch on `category`** — `ProductSchema.to_product_row` capitalises `"electronics" → "Electronics"`; search filters are case-sensitive. Worked around in `csv_loader` by lowercasing at insert time. Proper fix (lowercasing in `ProductSchema` or case-insensitive filter) is a separate change.

Issue #42 is the UI counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)