### PR TITLE
fix(search): preserve KG candidate order through SQL filter

### DIFF
--- a/mcp-server/app/endpoints.py
+++ b/mcp-server/app/endpoints.py
@@ -1233,6 +1233,19 @@ async def search_products(
     if candidate_ids:
         # Filter by candidate IDs (already filtered by category if specified)
         db_query = db_query.filter(Product.product_id.in_(candidate_ids))
+        # Preserve candidate order through the SQL hop. KG (and vector)
+        # return product_ids sorted by relevance score; ``IN (...)`` discards
+        # that order and Postgres returns rows in plan order, so the KG's
+        # good_for_ml / use-case / text-match boosts become invisible in the
+        # final result. Re-impose the candidate order via a CASE expression
+        # so offer[0] is the highest-scored candidate. Short-term fix;
+        # issue #34 tracks plumbing real per-product scores through the
+        # Offer contract, after which this ORDER BY can go.
+        from sqlalchemy import case
+        _rank_map = {pid: i for i, pid in enumerate(candidate_ids)}
+        db_query = db_query.order_by(
+            case(_rank_map, value=Product.product_id, else_=len(candidate_ids))
+        )
     elif effective_search_query and len(effective_search_query) >= 3:
         # Fallback to keyword search (already filtered by category if specified)
         # Use normalized query and expanded terms for better matching


### PR DESCRIPTION
## Summary

`endpoints.search_products` filters by KG candidate_ids via SQL `IN (...)` which discards input order. Postgres returns rows in plan order, so the KG's `relevance_score` (use-case flag boosts, text match, connectivity) never survives to `offer[0]`. Users asking e.g. "good laptop for machine learning under 2000" were getting a $269 refurb Dell as best pick, with ML-grade workstations demoted.

Fix: re-impose candidate order at the SQL layer with a `CASE product_id WHEN ... THEN rank` expression. 13-line patch in `endpoints.py:1233`.

## Why this regressed

On `main`, `agent/chat_endpoint._search_ecommerce_products` did a post-fetch Python sort via `kg_id_to_idx`. Commit `6e2aef3` on `refactor/merchant-agent-v2` removed that sort on the premise that offers "arrive pre-ranked from /merchant/search" — but `/merchant/search` had no ORDER BY either. This PR restores the behaviour without re-adding the shopping-agent → merchant-internals import that `6e2aef3` was trying to break (the re-sort now happens *inside* the merchant endpoint).

## Before / after

With `use_case: machine_learning`, `price_max: 2000`:

Before (no ORDER BY):
```
$269 Recertified - DELL - Intel i7 - Latitude 5590
$265 Recertified - DELL - Intel i7 - Latitude 5490
$272 Recertified - DELL - Intel i7 - Latitude 74
$889 HP - Intel i7 13th Gen - Intel Iris XE Graphics
$298 Recertified - DELL - Intel i7 6th Gen - Integrated
```

After (KG order preserved):
```
$1760 HP ZBook Firefly G10 A 14" Mobile Workstation
$1316 HP ZBook 8 G1i 16" Mobile Workstation Intel Core Ultra 7
$1400 HP ZBook Firefly G11 16" Mobile Workstation Intel Core Ultra
$269  Recertified - DELL - Intel i7 - Latitude 5590
$265  Recertified - DELL - Intel i7 - Latitude 5490
```

## Test plan

- [x] Default golden path `POST /merchant/search` (no merchant_id) still returns 3 laptops under $1500.
- [x] ML query returns ML-grade workstations first (see before/after above).
- [x] No change when KG is unavailable or returns no candidates (the `order_by` only runs inside the `if candidate_ids:` branch).
- [x] `Offer.score` unchanged (still positional `1.0 - i/n`) — #34 tracks that follow-up.

## Long-term plan

Issue #34 — expose per-product KG score through `Offer.score` / `Offer.score_breakdown`. When the contract carries the rank forward, this temporary SQL `ORDER BY case(...)` becomes redundant and is removed. Comment on #34 has been updated to reflect this short-term patch vs. the long-term plan.

## Not in this PR

- Populating `Offer.score_breakdown` — issue #34.
- Fixing the KG's query text (`_build_kg_search_query` still only passes subcategory+brand+"laptop", not ML-keyword-rich text) — the current `good_for_ml` *flag* boost is enough to rescue ranking for now, but a richer query would surface more candidates. Separate concern.
- Tightening `endpoints.py:1711-1731`'s permissive `or_()` use_cases filter to require the flag truthy (would also help, but flag coverage is sparse — 5 System76 laptops out of ~50k — and going strict would empty many result sets without a KG-coverage backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)