### PR TITLE
refactor(search): hoist sqlalchemy.case import + tighten kg-order comment

### DIFF
--- a/mcp-server/app/endpoints.py
+++ b/mcp-server/app/endpoints.py
@@ -13,7 +13,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from sqlalchemy.orm import Session
-from sqlalchemy import or_, and_, cast, Float
+from sqlalchemy import or_, and_, cast, Float, case
 
 from app.models import Product
 from app.schemas import (
@@ -1233,15 +1233,10 @@ async def search_products(
     if candidate_ids:
         # Filter by candidate IDs (already filtered by category if specified)
         db_query = db_query.filter(Product.product_id.in_(candidate_ids))
-        # Preserve candidate order through the SQL hop. KG (and vector)
-        # return product_ids sorted by relevance score; ``IN (...)`` discards
-        # that order and Postgres returns rows in plan order, so the KG's
-        # good_for_ml / use-case / text-match boosts become invisible in the
-        # final result. Re-impose the candidate order via a CASE expression
-        # so offer[0] is the highest-scored candidate. Short-term fix;
-        # issue #34 tracks plumbing real per-product scores through the
-        # Offer contract, after which this ORDER BY can go.
-        from sqlalchemy import case
+        # Re-impose candidate order: ``IN (...)`` drops it, so KG/vector
+        # relevance ranking would otherwise be lost. Temporary — issue #34
+        # tracks plumbing real scores through the Offer contract, after
+        # which this ORDER BY becomes redundant.
         _rank_map = {pid: i for i, pid in enumerate(candidate_ids)}
         db_query = db_query.order_by(
             case(_rank_map, value=Product.product_id, else_=len(candidate_ids))


### PR DESCRIPTION
## Summary
Follow-up cleanup to #48 (the KG-order `ORDER BY CASE ...` fix).

- Hoist `case` to the top-level `from sqlalchemy import ...` at `endpoints.py:16`; drops the in-function `from sqlalchemy import case`.
- Trim the KG-order comment from 8 lines to 4 — keeps the "why" (`IN (...)` discards order) and the #34 pointer, drops restatement.

Pure style. No behavior change.

## Test plan
- [x] `from app import endpoints` imports cleanly.
- [ ] Existing `/api/search-products` tests pass (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)