### PR TITLE
feat(vector): per-(merchant_id, strategy) FAISS index (#56)

### DIFF
--- a/evaluation/recommendations/scoring.py
+++ b/evaluation/recommendations/scoring.py
@@ -145,7 +145,10 @@ def get_embedding_for_product(
 
     if product_dict:
         from app.vector_search import get_vector_store
-        store = get_vector_store()
+        # Encoding-only path — the encoder is model-scoped, not catalog-scoped,
+        # so ask for the default merchant's store. The (default, normalizer_v1)
+        # store's encoder is the same model as every other merchant's.
+        store = get_vector_store("default", "normalizer_v1")
         # encode_product expects name, description, category, brand, metadata (attributes), product_type
         p = dict(product_dict)
         if "metadata" not in p and "attributes" in p:

--- a/mcp-server/app/endpoints.py
+++ b/mcp-server/app/endpoints.py
@@ -1202,7 +1202,14 @@ async def search_products(
     if use_vector_search:
         try:
             vector_start = time.time()
-            vector_store = get_vector_store()
+            # Scope vector retrieval to (merchant_id, strategy). Strategy
+            # defaults to normalizer_v1 (the only enricher in prod today) —
+            # MerchantAgent.search threads the real label through filters
+            # once multiple strategies coexist. See issue #56.
+            _vs_filters = filters or {}
+            _vs_merchant = _vs_filters.get("merchant_id") or "default"
+            _vs_strategy = _vs_filters.get("strategy") or "normalizer_v1"
+            vector_store = get_vector_store(_vs_merchant, _vs_strategy)
             
             # Check if index exists and is ready
             has_index = vector_store._index is not None and len(vector_store._product_ids) > 0

--- a/mcp-server/app/merchant_agent.py
+++ b/mcp-server/app/merchant_agent.py
@@ -79,10 +79,15 @@ class MerchantAgent:
         self,
         merchant_id: str,
         domain: str,
+        strategy: str = "normalizer_v1",
         kg_strategy: str = "default_v1",
     ) -> None:
         self.merchant_id = validate_merchant_id(merchant_id)
         self.domain = domain
+        # One MerchantAgent instance <=> one (merchant_id, strategy) pair.
+        # KG and vector store are keyed by that pair; two enrichment
+        # strategies in parallel = two agents. See issues #52, #56.
+        self.strategy = strategy
         self.kg_strategy = kg_strategy
         self._catalog_table = merchant_catalog_table(self.merchant_id)
         self._enriched_table = merchant_enriched_table(self.merchant_id)
@@ -159,7 +164,7 @@ class MerchantAgent:
         finally:
             raw_conn.close()
 
-        agent = cls(merchant_id=merchant_id, domain=domain)
+        agent = cls(merchant_id=merchant_id, domain=domain, strategy=strategy)
 
         db = SessionLocal()
         try:
@@ -193,6 +198,18 @@ class MerchantAgent:
                 )
             finally:
                 db.close()
+
+            # Build the per-(merchant, strategy) FAISS index off the freshly
+            # enriched catalog. Failure here is non-fatal — search still
+            # works without vector retrieval — but we log it loudly so the
+            # ingest UI can surface the degraded state. See issue #56.
+            try:
+                agent.refresh_vector_index()
+            except Exception as exc:
+                logger.warning(
+                    "from_csv_vector_index_failed merchant=%s err=%s",
+                    merchant_id, exc,
+                )
 
         # In-memory registry only — on restart, the operator re-runs bootstrap
         # to re-register. Tables persist in Postgres so data is not lost.
@@ -229,6 +246,9 @@ class MerchantAgent:
         # Thread kg_strategy through filters so endpoints.search_products can
         # pick it up at the KG call site without a new positional arg.
         merged_filters["_kg_strategy"] = self.kg_strategy
+        # Route vector retrieval to this agent's (merchant, strategy) index.
+        # endpoints.search_products reads this to pick the right FAISS file.
+        merged_filters["strategy"] = self.strategy
 
         # --- Extract exclude_ids from user_context --------------------
         _ctx = query.user_context if isinstance(query.user_context, dict) else {}
@@ -319,6 +339,60 @@ class MerchantAgent:
         return offers
 
     # ------------------------------------------------------------------
+    # Vector index build / refresh
+    # ------------------------------------------------------------------
+
+    def refresh_vector_index(self) -> int:
+        """Rebuild this merchant's FAISS index from its current catalog.
+
+        Reads raw rows from the merchant's per-tenant ``Product`` table and
+        hydrates the normalized description from its enriched sidecar (so the
+        embedding matches what search will see at read time). The resulting
+        index is written under ``data/merchants/<merchant_id>/<strategy>/``
+        and hot-swapped in the in-process store cache.
+
+        Returns the number of products indexed.
+        """
+        from app.database import SessionLocal
+        from app.vector_search import get_vector_store
+
+        _Product = self._product_model
+        _Enriched = self._enriched_model
+
+        db = SessionLocal()
+        try:
+            enriched_by_id: Dict[str, str] = {
+                row.product_id: (row.attributes or {}).get("normalized_description") or ""
+                for row in db.query(_Enriched).filter(_Enriched.strategy == self.strategy).all()
+            }
+            raw_products = db.query(_Product).all()
+
+            products_for_index: List[Dict[str, Any]] = []
+            for p in raw_products:
+                description = enriched_by_id.get(p.product_id) or (
+                    (getattr(p, "attributes", None) or {}).get("description", "") if getattr(p, "attributes", None) else ""
+                )
+                products_for_index.append({
+                    "product_id": p.product_id,
+                    "name": p.name,
+                    "description": description,
+                    "category": getattr(p, "category", None) or "",
+                    "brand": getattr(p, "brand", None) or "",
+                    "product_type": getattr(p, "product_type", None) or "",
+                    "metadata": getattr(p, "attributes", None) or {},
+                })
+        finally:
+            db.close()
+
+        store = get_vector_store(self.merchant_id, self.strategy)
+        store.build_index(products_for_index, save_index=True)
+        logger.info(
+            "vector_index_built merchant=%s strategy=%s count=%d path=%s",
+            self.merchant_id, self.strategy, len(products_for_index), store.index_path,
+        )
+        return len(products_for_index)
+
+    # ------------------------------------------------------------------
     # Health
     # ------------------------------------------------------------------
 
@@ -331,18 +405,22 @@ class MerchantAgent:
         from sqlalchemy import func
         max_created = catalog_q.with_entities(func.max(_Product.created_at)).scalar()
 
-        # Vector index mtime (best-effort)
+        # Vector index mtime — read from this merchant's own path, not the
+        # global one. A missing file means the index was never built for
+        # this (merchant, strategy) pair and search will fall back to
+        # keyword-only retrieval.
         vector_index_mtime = None
         try:
-            cache_dir = os.path.join(os.path.dirname(__file__), "..", "data", "vector_cache")
-            idx_path = os.path.join(cache_dir, "faiss_index.bin")
-            if os.path.exists(idx_path):
-                vector_index_mtime = os.path.getmtime(idx_path)
+            from app.vector_search import merchant_index_path
+            idx_path = merchant_index_path(self.merchant_id, self.strategy)
+            if idx_path.exists():
+                vector_index_mtime = idx_path.stat().st_mtime
         except Exception:
             pass
 
         return {
             "merchant_id": self.merchant_id,
+            "strategy": self.strategy,
             "catalog_size": catalog_size,
             "kg_last_update": max_created.isoformat() if max_created else None,
             "vector_index_mtime": vector_index_mtime,

--- a/mcp-server/app/vector_search.py
+++ b/mcp-server/app/vector_search.py
@@ -3,13 +3,19 @@ Universal Vector Search for MCP - All Product Types.
 
 Reuses IDSS embedding code but adapts it for universal product search.
 Supports: vehicles, e-commerce, real estate, travel, and any future product types.
+
+Storage layout is per-(merchant_id, strategy):
+    data/merchants/<merchant_id>/<strategy>/faiss.bin   # FAISS index
+    data/merchants/<merchant_id>/<strategy>/ids.pkl     # id-map sidecar
+
+One MerchantAgent instance corresponds to one (merchant_id, strategy) pair, and
+each pair owns its own FAISS index — no cross-merchant bleed at retrieval time.
 """
 
 import pickle
 from pathlib import Path
-from typing import List, Tuple, Optional, Dict, Any
+from typing import List, Tuple, Optional, Dict, Any, Tuple as _Tuple
 import numpy as np
-from datetime import datetime
 
 try:
     import faiss
@@ -28,61 +34,86 @@ from app.structured_logger import StructuredLogger
 logger = StructuredLogger("vector_search")
 
 
+# Repository-root-relative base directory for per-merchant vector indices.
+# Resolves to <mcp-server>/data/merchants/.
+_MERCHANT_DATA_ROOT = Path(__file__).parent.parent / "data" / "merchants"
+
+
+def merchant_index_dir(merchant_id: str, strategy: str) -> Path:
+    """Return the directory that owns the FAISS index for this (merchant, strategy)."""
+    return _MERCHANT_DATA_ROOT / merchant_id / strategy
+
+
+def merchant_index_path(merchant_id: str, strategy: str) -> Path:
+    """Absolute path to the FAISS index binary for this (merchant, strategy)."""
+    return merchant_index_dir(merchant_id, strategy) / "faiss.bin"
+
+
+def merchant_ids_path(merchant_id: str, strategy: str) -> Path:
+    """Absolute path to the id-map sidecar for this (merchant, strategy)."""
+    return merchant_index_dir(merchant_id, strategy) / "ids.pkl"
+
+
 class UniversalEmbeddingStore:
     """
-    Universal embedding store for all product types.
-    
-    Reuses IDSS DenseEmbeddingStore pattern but works with:
-    - Vehicles (VINs)
-    - E-commerce products (PROD-*)
-    - Real Estate (PROP-*)
-    - Travel (TRAVEL-*)
-    - Any product type
-    
+    Per-(merchant_id, strategy) embedding store.
+
     Usage:
-        store = UniversalEmbeddingStore()
+        store = UniversalEmbeddingStore(merchant_id="acme", strategy="normalizer_v1")
+        store.build_index(products)
         product_ids, scores = store.search("laptop for video editing", k=10)
     """
-    
+
     def __init__(
         self,
+        merchant_id: str,
+        strategy: str,
         model_name: str = "all-mpnet-base-v2",
         index_type: str = "Flat",
-        use_cache: bool = True
+        use_cache: bool = True,
     ):
         """
-        Initialize universal embedding store.
-        
         Args:
-            model_name: Sentence transformer model name
-            index_type: FAISS index type (Flat or IVF)
-            use_cache: Whether to use cached embeddings/index
+            merchant_id: Merchant slug. Scopes the index to this merchant's catalog.
+            strategy:    Enrichment strategy label (e.g. ``normalizer_v1``). A
+                         merchant can run multiple strategies side-by-side; each
+                         gets its own KG and vector index.
+            model_name:  Sentence transformer model name.
+            index_type:  FAISS index type (Flat or IVF).
+            use_cache:   Whether to load/save the index from disk on init.
         """
+        self.merchant_id = merchant_id
+        self.strategy = strategy
         self.model_name = model_name
         self.index_type = index_type
         self.use_cache = use_cache
-        
+
         # Lazy-loaded components
         self._encoder = None
         self._index = None
-        self._product_ids = []
-        self._product_id_to_idx = {}
-        self._product_embeddings_cache = {}  # product_id -> embedding
-        
-        # Index directory (for caching)
-        self.index_dir = Path(__file__).parent.parent / "vector_indices"
-        self.index_dir.mkdir(exist_ok=True)
-        
+        self._product_ids: List[str] = []
+        self._product_id_to_idx: Dict[str, int] = {}
+        self._product_embeddings_cache: Dict[str, np.ndarray] = {}  # product_id -> embedding
+
+        # Per-merchant index directory
+        self.index_dir = merchant_index_dir(merchant_id, strategy)
+        self.index_dir.mkdir(parents=True, exist_ok=True)
+        self.index_path = merchant_index_path(merchant_id, strategy)
+        self.ids_path = merchant_ids_path(merchant_id, strategy)
+
         logger.info("vector_store_init", "Initializing vector store", {
+            "merchant_id": merchant_id,
+            "strategy": strategy,
             "model_name": model_name,
             "index_type": index_type,
-            "use_cache": use_cache
+            "use_cache": use_cache,
+            "index_dir": str(self.index_dir),
         })
-        
+
         # Try to load existing index on initialization
         if use_cache:
             self._load_index()
-    
+
     def _get_encoder(self):
         """Lazy load sentence transformer model."""
         if self._encoder is None:
@@ -91,7 +122,7 @@ class UniversalEmbeddingStore:
                     "sentence-transformers not installed. "
                     "Run: pip install sentence-transformers"
                 )
-            
+
             logger.info("loading_encoder", f"Loading encoder: {self.model_name}", {"model": self.model_name})
             self._encoder = SentenceTransformer(self.model_name)
             embedding_dim = self._encoder.get_sentence_embedding_dimension()
@@ -99,41 +130,19 @@ class UniversalEmbeddingStore:
                 "model": self.model_name,
                 "dimension": embedding_dim
             })
-        
+
         return self._encoder
-    
+
     def encode_text(self, text: str) -> np.ndarray:
-        """
-        Encode text into dense embedding.
-        
-        Args:
-            text: Text to encode
-            
-        Returns:
-            Embedding vector (1, D)
-        """
+        """Encode text into a (1, D) embedding."""
         encoder = self._get_encoder()
         embedding = encoder.encode([text], convert_to_numpy=True)
         return embedding.astype(np.float32)
-    
+
     def encode_product(self, product: Dict[str, Any]) -> np.ndarray:
-        """
-        Encode a product into dense embedding.
-        
-        Builds text representation from product fields:
-        - name, description, category, brand
-        - metadata (type-specific attributes)
-        
-        Args:
-            product: Product dict with name, description, category, brand, metadata
-            
-        Returns:
-            Embedding vector (1, D)
-        """
-        # Build text representation
+        """Encode a product into a (1, D) embedding."""
         parts = []
-        
-        # Core fields
+
         if product.get("name"):
             parts.append(str(product["name"]))
         if product.get("description"):
@@ -142,73 +151,64 @@ class UniversalEmbeddingStore:
             parts.append(f"category: {product['category']}")
         if product.get("brand"):
             parts.append(f"brand: {product['brand']}")
-        
-        # Type-specific metadata
+
         metadata = product.get("metadata", {})
         if metadata:
-            # Add relevant metadata fields
             for key, value in metadata.items():
                 if value and isinstance(value, (str, int, float)):
                     parts.append(f"{key}: {value}")
-        
-        # Product type
+
         product_type = product.get("product_type", "")
         if product_type:
             parts.append(f"product type: {product_type}")
-        
+
         text = " ".join(parts)
-        
-        # Check cache
+
         product_id = product.get("product_id", "")
         if self.use_cache and product_id in self._product_embeddings_cache:
             return self._product_embeddings_cache[product_id]
-        
-        # Encode
+
         embedding = self.encode_text(text)
-        
-        # Cache
+
         if self.use_cache and product_id:
             self._product_embeddings_cache[product_id] = embedding
-        
+
         return embedding
-    
+
     def build_index(
         self,
         products: List[Dict[str, Any]],
         save_index: bool = True
     ) -> None:
-        """
-        Build FAISS index from products.
-        
-        Args:
-            products: List of product dicts
-            save_index: Whether to save index to disk
-        """
+        """Build FAISS index from products and optionally persist to disk."""
         if not FAISS_AVAILABLE:
             raise ImportError(
-                "faiss-cpu not installed. "
-                "Run: pip install faiss-cpu"
+                "faiss-cpu not installed. Run: pip install faiss-cpu"
             )
-        
+
         if not products:
-            logger.warning("build_index_empty", "No products provided for index building", {})
+            logger.warning("build_index_empty", "No products provided for index building", {
+                "merchant_id": self.merchant_id, "strategy": self.strategy,
+            })
             return
-        
-        logger.info("building_index", f"Building index for {len(products)} products", {"product_count": len(products)})
-        
+
+        logger.info("building_index", f"Building index for {len(products)} products", {
+            "merchant_id": self.merchant_id,
+            "strategy": self.strategy,
+            "product_count": len(products),
+        })
+
         encoder = self._get_encoder()
         embedding_dim = encoder.get_sentence_embedding_dimension()
-        
-        # Collect product texts and IDs for batch encoding
+
         product_texts = []
         product_ids = []
-        
+
         for product in products:
             product_id = product.get("product_id")
             if not product_id:
                 continue
-            
-            # Build text representation (same logic as encode_product but without encoding)
+
             parts = []
             if product.get("name"):
                 parts.append(str(product["name"]))
@@ -218,26 +218,25 @@ class UniversalEmbeddingStore:
                 parts.append(f"category: {product['category']}")
             if product.get("brand"):
                 parts.append(f"brand: {product['brand']}")
-            
+
             metadata = product.get("metadata", {})
             if metadata:
                 for key, value in metadata.items():
                     if value and isinstance(value, (str, int, float)):
                         parts.append(f"{key}: {value}")
-            
+
             product_type = product.get("product_type", "")
             if product_type:
                 parts.append(f"product type: {product_type}")
-            
+
             text = " ".join(parts)
             product_texts.append(text)
             product_ids.append(product_id)
-        
+
         if not product_texts:
             logger.warning("build_index_no_products", "No valid products found for indexing", {})
             return
-        
-        # Batch encode all products at once (much faster than one-by-one)
+
         logger.info("batch_encoding", f"Batch encoding {len(product_texts)} products", {"batch_size": len(product_texts)})
         try:
             embeddings = encoder.encode(product_texts, convert_to_numpy=True, batch_size=32, show_progress_bar=False)
@@ -246,156 +245,126 @@ class UniversalEmbeddingStore:
         except Exception as e:
             logger.error("batch_encoding_failed", f"Batch encoding failed: {e}", {"error": str(e)})
             raise
-        
-        # Cache embeddings
+
         if self.use_cache:
             for product_id, embedding in zip(product_ids, embeddings):
                 self._product_embeddings_cache[product_id] = embedding.reshape(1, -1)
-        
-        # Create FAISS index
+
         logger.info("creating_faiss_index", "Creating FAISS index", {"index_type": self.index_type, "embedding_dim": embedding_dim})
         try:
             if self.index_type.lower() == "flat":
                 index = faiss.IndexFlatL2(embedding_dim)
             else:
-                # IVF index (for large datasets)
                 nlist = min(100, len(embeddings) // 10)
                 quantizer = faiss.IndexFlatL2(embedding_dim)
                 index = faiss.IndexIVFFlat(quantizer, embedding_dim, nlist)
                 index.train(embeddings)
-            
-            # Add embeddings to index
-            logger.info("adding_to_index", f"Adding {len(embeddings)} embeddings to index", {})
+
             index.add(embeddings)
             logger.info("index_added", "Embeddings added to index", {"index_size": index.ntotal})
         except Exception as e:
             logger.error("faiss_index_failed", f"FAISS index creation failed: {e}", {"error": str(e)})
             raise
-        
-        # Store
+
         self._index = index
         self._product_ids = product_ids
         self._product_id_to_idx = {
             pid: idx for idx, pid in enumerate(product_ids)
         }
-        
+
         logger.info("index_built", f"Index built: {len(product_ids)} products", {
+            "merchant_id": self.merchant_id,
+            "strategy": self.strategy,
             "product_count": len(product_ids),
             "index_size": index.ntotal,
-            "dimension": embedding_dim
+            "dimension": embedding_dim,
         })
-        
-        # Save to disk if requested
+
         if save_index:
             self._save_index()
-    
+
     def _save_index(self):
-        """Save index to disk for future use."""
+        """Save index + id-map to the merchant's own directory."""
         if self._index is None or not self._product_ids:
             return
-        
-        model_slug = self.model_name.replace("/", "_").replace("-", "_")
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        
-        index_path = self.index_dir / f"mcp_index_{model_slug}_{timestamp}.index"
-        ids_path = self.index_dir / f"mcp_ids_{model_slug}_{timestamp}.pkl"
-        
+
         try:
-            faiss.write_index(self._index, str(index_path))
-            with open(ids_path, 'wb') as f:
+            self.index_dir.mkdir(parents=True, exist_ok=True)
+            faiss.write_index(self._index, str(self.index_path))
+            with open(self.ids_path, 'wb') as f:
                 pickle.dump(self._product_ids, f)
-            
-            logger.info("index_saved", f"Index saved to {index_path}", {
-                "index_path": str(index_path),
-                "ids_path": str(ids_path)
+
+            logger.info("index_saved", f"Index saved to {self.index_path}", {
+                "merchant_id": self.merchant_id,
+                "strategy": self.strategy,
+                "index_path": str(self.index_path),
+                "ids_path": str(self.ids_path),
             })
         except Exception as e:
             logger.error("save_index_failed", f"Failed to save index: {e}", {"error": str(e)})
-    
-    def _load_index(self, index_path: Optional[Path] = None):
-        """Load pre-computed index from disk."""
+
+    def _load_index(self) -> bool:
+        """Load the merchant's FAISS index and id-map from disk, if present."""
         if not FAISS_AVAILABLE:
             return False
-        
-        if index_path is None:
-            # Find latest index
-            model_slug = self.model_name.replace("/", "_").replace("-", "_")
-            index_files = list(self.index_dir.glob(f"mcp_index_{model_slug}_*.index"))
-            if not index_files:
-                return False
-            index_path = max(index_files, key=lambda p: p.stat().st_mtime)
-        
-        # Find corresponding IDs file
-        ids_path = index_path.with_suffix('.pkl').with_name(
-            index_path.stem.replace('index', 'ids')
-        )
-        
-        if not ids_path.exists():
+
+        if not self.index_path.exists() or not self.ids_path.exists():
             return False
-        
+
         try:
-            self._index = faiss.read_index(str(index_path))
-            with open(ids_path, 'rb') as f:
+            self._index = faiss.read_index(str(self.index_path))
+            with open(self.ids_path, 'rb') as f:
                 self._product_ids = pickle.load(f)
-            
+
             self._product_id_to_idx = {
                 pid: idx for idx, pid in enumerate(self._product_ids)
             }
-            
-            logger.info("index_loaded", f"Index loaded from {index_path}", {
-                "index_path": str(index_path),
-                "product_count": len(self._product_ids)
+
+            logger.info("index_loaded", f"Index loaded from {self.index_path}", {
+                "merchant_id": self.merchant_id,
+                "strategy": self.strategy,
+                "index_path": str(self.index_path),
+                "product_count": len(self._product_ids),
             })
             return True
         except Exception as e:
             logger.error("load_index_failed", f"Failed to load index: {e}", {"error": str(e)})
             return False
-    
+
     def search(
         self,
         query: str,
         k: int = 20,
         product_ids: Optional[List[str]] = None
     ) -> Tuple[List[str], List[float]]:
-        """
-        Search for similar products using vector similarity.
-        
-        Args:
-            query: Natural language query
-            k: Number of results to return
-            product_ids: Optional list of candidate product IDs to search within
-            
-        Returns:
-            Tuple of (product_ids, similarity_scores)
-        """
+        """Vector search against this merchant's index."""
         if not self._index:
-            # Try to load existing index
             if not self._load_index():
-                logger.warning("search_no_index", "No index available, returning empty results", {})
+                logger.warning("search_no_index", "No index available, returning empty results", {
+                    "merchant_id": self.merchant_id, "strategy": self.strategy,
+                })
                 return [], []
-        
-        # Encode query
+
         query_embedding = self.encode_text(query)
-        
-        # Search
+
         if product_ids:
-            # Search within subset
             return self._search_within_candidates(query_embedding, product_ids, k)
-        else:
-            # Search entire index
-            distances, indices = self._index.search(query_embedding, k)
-            similarities = 1.0 / (1.0 + distances[0])
-            result_ids = [self._product_ids[idx] for idx in indices[0]]
-            result_scores = similarities.tolist()
-            
-            logger.info("vector_search", f"Vector search: {len(result_ids)} results", {
-                "query": query[:100],
-                "results_count": len(result_ids),
-                "top_score": float(result_scores[0]) if result_scores else 0.0
-            })
-            
-            return result_ids, result_scores
-    
+
+        distances, indices = self._index.search(query_embedding, k)
+        similarities = 1.0 / (1.0 + distances[0])
+        result_ids = [self._product_ids[idx] for idx in indices[0]]
+        result_scores = similarities.tolist()
+
+        logger.info("vector_search", f"Vector search: {len(result_ids)} results", {
+            "merchant_id": self.merchant_id,
+            "strategy": self.strategy,
+            "query": query[:100],
+            "results_count": len(result_ids),
+            "top_score": float(result_scores[0]) if result_scores else 0.0
+        })
+
+        return result_ids, result_scores
+
     def _search_within_candidates(
         self,
         query_embedding: np.ndarray,
@@ -407,11 +376,10 @@ class UniversalEmbeddingStore:
             pid for pid in candidate_ids
             if pid in self._product_id_to_idx
         ]
-        
+
         if not valid_ids:
             return [], []
-        
-        # Compute similarities for candidates
+
         similarities = []
         for product_id in valid_ids:
             idx = self._product_id_to_idx[product_id]
@@ -419,76 +387,77 @@ class UniversalEmbeddingStore:
             distance = np.linalg.norm(query_embedding[0] - candidate_embedding)
             similarity = 1.0 / (1.0 + distance)
             similarities.append(similarity)
-        
-        # Sort by similarity
+
         sorted_pairs = sorted(
             zip(valid_ids, similarities),
             key=lambda x: x[1],
             reverse=True
         )
-        
-        # Take top k
+
         if k:
             sorted_pairs = sorted_pairs[:k]
-        
+
         result_ids = [pid for pid, _ in sorted_pairs]
         result_scores = [score for _, score in sorted_pairs]
-        
+
         return result_ids, result_scores
-    
+
     def rank_products(
         self,
         products: List[Dict[str, Any]],
         query: str
     ) -> List[Dict[str, Any]]:
-        """
-        Rank products by semantic similarity to query.
-        
-        Args:
-            products: List of product dicts
-            query: Natural language query
-            
-        Returns:
-            List of products ranked by similarity (with _vector_score added)
-        """
+        """Rank products by semantic similarity to query."""
         if not products:
             return products
-        
-        # Encode query
+
         query_embedding = self.encode_text(query)
-        
-        # Compute similarities
+
         scored_products = []
         for product in products:
             product_embedding = self.encode_product(product)
             distance = np.linalg.norm(query_embedding[0] - product_embedding[0])
             similarity = 1.0 / (1.0 + distance)
-            
+
             product_copy = product.copy()
             product_copy["_vector_score"] = float(similarity)
             scored_products.append(product_copy)
-        
-        # Sort by similarity
+
         scored_products.sort(key=lambda p: p["_vector_score"], reverse=True)
-        
+
         logger.info("products_ranked", f"Ranked {len(scored_products)} products", {
             "query": query[:100],
             "product_count": len(scored_products),
             "top_score": scored_products[0]["_vector_score"] if scored_products else 0.0
         })
-        
+
         return scored_products
 
 
-# Global instance (lazy-loaded)
-_vector_store: Optional[UniversalEmbeddingStore] = None
+# Per-(merchant_id, strategy) store cache. Each pair gets its own FAISS index
+# and its own id-map; callers that ask twice for the same pair share state.
+_vector_stores: Dict[_Tuple[str, str], UniversalEmbeddingStore] = {}
+
+DEFAULT_STRATEGY = "normalizer_v1"
 
 
-def get_vector_store() -> UniversalEmbeddingStore:
-    """Get or create global vector store instance."""
-    global _vector_store
-    
-    if _vector_store is None:
-        _vector_store = UniversalEmbeddingStore()
-    
-    return _vector_store
+def get_vector_store(
+    merchant_id: str,
+    strategy: str = DEFAULT_STRATEGY,
+) -> UniversalEmbeddingStore:
+    """Return (and cache) the vector store for a (merchant_id, strategy) pair.
+
+    Idempotent: repeat calls with the same pair return the same instance, so
+    the encoder and loaded index are reused.
+    """
+    key = (merchant_id, strategy)
+    store = _vector_stores.get(key)
+    if store is None:
+        store = UniversalEmbeddingStore(merchant_id=merchant_id, strategy=strategy)
+        _vector_stores[key] = store
+    return store
+
+
+def reset_vector_store_cache() -> None:
+    """Drop all cached stores. Used by tests that need a clean slate."""
+    _vector_stores.clear()

--- a/mcp-server/build_vector_index.py
+++ b/mcp-server/build_vector_index.py
@@ -2,12 +2,18 @@
 Build Vector Index from Database Products.
 
 This script:
-1. Loads all products from PostgreSQL
+1. Loads all products from PostgreSQL for a given merchant
 2. Generates embeddings for each product
 3. Builds FAISS index
-4. Saves index for fast similarity search
+4. Saves index into data/merchants/<merchant_id>/<strategy>/ for fast similarity search
+
+Usage:
+    python build_vector_index.py                         # default merchant, normalizer_v1
+    python build_vector_index.py --merchant acme         # acme merchant
+    python build_vector_index.py --merchant acme --strategy normalizer_v2
 """
 
+import argparse
 import sys
 import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -16,31 +22,28 @@ from dotenv import load_dotenv
 load_dotenv(os.path.join(os.path.dirname(__file__), '..', '.env'))
 
 from app.database import SessionLocal
-from app.models import Product
+from app.models import make_product_model
 from app.vector_search import UniversalEmbeddingStore
-from pathlib import Path
 
 
-def build_index():
-    """Build vector index from all products in database."""
-    
-    print("Building Vector Index for MCP Products...")
+def build_index(merchant_id: str, strategy: str):
+    """Build vector index from all products in database for a given merchant."""
+
+    print(f"Building Vector Index for merchant={merchant_id} strategy={strategy}...")
     print("=" * 60)
-    
-    # Initialize database session
+
+    Product = make_product_model(merchant_id)
     db = SessionLocal()
-    
+
     try:
-        # Get all products
         print("\nLoading products from database...")
         products = db.query(Product).all()
         print(f"   Found {len(products)} products")
-        
+
         if not products:
             print("[WARN] No products found in database. Please seed products first.")
             return
-        
-        # Convert to dict format
+
         print("\nConverting products to embedding format...")
         products_dict = []
         for product in products:
@@ -50,43 +53,38 @@ def build_index():
                 "description": product.description or "",
                 "category": product.category or "",
                 "brand": product.brand or "",
-                "product_type": "ecommerce",  # Default, could be inferred from product_id prefix
+                "product_type": "ecommerce",
                 "metadata": {}
             })
-        
+
         print(f"   Converted {len(products_dict)} products")
-        
-        # Build index
+
         print("\nBuilding FAISS index...")
-        vector_store = UniversalEmbeddingStore()
+        vector_store = UniversalEmbeddingStore(
+            merchant_id=merchant_id,
+            strategy=strategy,
+        )
         vector_store.build_index(products_dict, save_index=True)
-        
-        print(f"\n[OK] Vector index built successfully!")
+
+        print("\n[OK] Vector index built successfully!")
+        print(f"   Merchant: {merchant_id}")
+        print(f"   Strategy: {strategy}")
         print(f"   Products indexed: {len(vector_store._product_ids)}")
         print(f"   Index size: {vector_store._index.ntotal if vector_store._index else 0}")
+        print(f"   Index path: {vector_store.index_path}")
         print(f"   Model: {vector_store.model_name}")
-        print(f"   Dimension: {vector_store._encoder.get_sentence_embedding_dimension() if vector_store._encoder else 'N/A'}")
-        
-        # Test search
+
         print("\nTesting vector search...")
-        test_queries = [
-            "laptop",
-            "electronics",
-            "vehicle",
-            "travel"
-        ]
-        
-        for test_query in test_queries:
+        for test_query in ["laptop", "electronics", "vehicle", "travel"]:
             product_ids, scores = vector_store.search(test_query, k=3)
             print(f"   Query: '{test_query}'")
             print(f"   Results: {len(product_ids)} products")
             if product_ids:
                 print(f"   Top match: {product_ids[0]} (score: {scores[0]:.3f})")
-        
+
         print("\n" + "=" * 60)
         print("[OK] Vector index ready for use!")
-        print("\nThe index will be automatically used in MCP search endpoints.")
-        
+
     except Exception as e:
         print(f"\n[FAIL] Error building index: {e}")
         import traceback
@@ -96,4 +94,8 @@ def build_index():
 
 
 if __name__ == "__main__":
-    build_index()
+    parser = argparse.ArgumentParser(description="Build per-merchant vector index")
+    parser.add_argument("--merchant", default="default", help="Merchant slug")
+    parser.add_argument("--strategy", default="normalizer_v1", help="Enrichment strategy label")
+    args = parser.parse_args()
+    build_index(args.merchant, args.strategy)

--- a/mcp-server/scripts/migrate_vector_index_to_per_merchant.py
+++ b/mcp-server/scripts/migrate_vector_index_to_per_merchant.py
@@ -1,0 +1,162 @@
+"""
+Migrate the legacy global FAISS index into the per-(merchant, strategy) layout.
+
+Before this migration, ``UniversalEmbeddingStore`` wrote every merchant's
+embeddings to a single global directory:
+
+    mcp-server/vector_indices/mcp_index_<model>_<ts>.index
+    mcp-server/vector_indices/mcp_ids_<model>_<ts>.pkl
+
+and the legacy health check also probed::
+
+    mcp-server/data/vector_cache/faiss_index.bin
+
+After issue #56 the index lives under::
+
+    mcp-server/data/merchants/<merchant_id>/<strategy>/faiss.bin
+    mcp-server/data/merchants/<merchant_id>/<strategy>/ids.pkl
+
+This script copies (not moves — we keep the legacy copy until a human says
+it's safe to delete) the most recent legacy index into the default merchant's
+per-strategy directory so the default merchant's retrieval stays green while
+other merchants build their own.
+
+Usage:
+    python mcp-server/scripts/migrate_vector_index_to_per_merchant.py
+    python mcp-server/scripts/migrate_vector_index_to_per_merchant.py --dry-run
+    python mcp-server/scripts/migrate_vector_index_to_per_merchant.py --delete-legacy
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+
+DEFAULT_MERCHANT = "default"
+DEFAULT_STRATEGY = "normalizer_v1"
+
+
+def _repo_mcp_root() -> Path:
+    """mcp-server/ root, regardless of where the script runs from."""
+    return Path(__file__).resolve().parent.parent
+
+
+def _find_legacy_paths(mcp_root: Path) -> tuple[Path | None, Path | None, Path | None]:
+    """Return (latest_index_file, matching_ids_file, legacy_vector_cache_bin).
+
+    Latest index file is picked by mtime among the ``vector_indices/*.index``
+    files produced by the old ``_save_index`` path. Any of the three may be
+    ``None`` if that legacy artifact is absent.
+    """
+    legacy_dir = mcp_root / "vector_indices"
+    latest_idx: Path | None = None
+    matching_ids: Path | None = None
+
+    if legacy_dir.exists():
+        index_files = list(legacy_dir.glob("mcp_index_*.index"))
+        if index_files:
+            latest_idx = max(index_files, key=lambda p: p.stat().st_mtime)
+            candidate = legacy_dir / latest_idx.stem.replace("index", "ids")
+            candidate = candidate.with_suffix(".pkl")
+            if candidate.exists():
+                matching_ids = candidate
+
+    legacy_cache = mcp_root / "data" / "vector_cache" / "faiss_index.bin"
+    legacy_cache = legacy_cache if legacy_cache.exists() else None
+
+    return latest_idx, matching_ids, legacy_cache
+
+
+def migrate(
+    merchant_id: str = DEFAULT_MERCHANT,
+    strategy: str = DEFAULT_STRATEGY,
+    dry_run: bool = False,
+    delete_legacy: bool = False,
+) -> int:
+    mcp_root = _repo_mcp_root()
+    dest_dir = mcp_root / "data" / "merchants" / merchant_id / strategy
+    dest_index = dest_dir / "faiss.bin"
+    dest_ids = dest_dir / "ids.pkl"
+
+    legacy_idx, legacy_ids, legacy_cache = _find_legacy_paths(mcp_root)
+
+    # Prefer the timestamped vector_indices pair (it has a matching id-map).
+    source_idx: Path | None = legacy_idx
+    source_ids: Path | None = legacy_ids
+
+    # Fall back to the data/vector_cache/faiss_index.bin sentinel. It has no
+    # id-map sidecar so the destination index will be unusable at search time
+    # until ``refresh_vector_index`` is run — but we still preserve the file
+    # under the new path so ops scripts that look there keep working.
+    if source_idx is None and legacy_cache is not None:
+        source_idx = legacy_cache
+
+    if source_idx is None and source_ids is None and legacy_cache is None:
+        print(
+            f"[skip] no legacy FAISS artifacts found under {mcp_root}; "
+            "nothing to migrate."
+        )
+        return 0
+
+    print(f"Migrating legacy FAISS index to per-merchant layout:")
+    print(f"  merchant_id = {merchant_id}")
+    print(f"  strategy    = {strategy}")
+    print(f"  dest dir    = {dest_dir}")
+    if source_idx:
+        print(f"  source idx  = {source_idx}")
+    if source_ids:
+        print(f"  source ids  = {source_ids}")
+
+    if dry_run:
+        print("[dry-run] no files were copied.")
+        return 0
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    copied = 0
+    if source_idx is not None:
+        shutil.copy2(source_idx, dest_index)
+        print(f"[copied] {source_idx} -> {dest_index}")
+        copied += 1
+    if source_ids is not None:
+        shutil.copy2(source_ids, dest_ids)
+        print(f"[copied] {source_ids} -> {dest_ids}")
+        copied += 1
+
+    if delete_legacy:
+        for p in (legacy_idx, legacy_ids, legacy_cache):
+            if p is not None and p.exists():
+                p.unlink()
+                print(f"[removed legacy] {p}")
+
+    print(f"[done] {copied} file(s) migrated for ({merchant_id}, {strategy}).")
+    return copied
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--merchant", default=DEFAULT_MERCHANT)
+    parser.add_argument("--strategy", default=DEFAULT_STRATEGY)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--delete-legacy",
+        action="store_true",
+        help="Delete the legacy files after copying. Off by default so the "
+             "migration is reversible; re-run with this flag once search is "
+             "verified against the new layout.",
+    )
+    args = parser.parse_args()
+    migrate(
+        merchant_id=args.merchant,
+        strategy=args.strategy,
+        dry_run=args.dry_run,
+        delete_legacy=args.delete_legacy,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcp-server/tests/test_per_merchant_vector_index.py
+++ b/mcp-server/tests/test_per_merchant_vector_index.py
@@ -1,0 +1,238 @@
+"""
+Per-(merchant_id, strategy) vector index tests — issue #56.
+
+Covers:
+  1. Two merchants with disjoint catalogs: vector candidates from one never
+     appear in the other's search results.
+  2. Default merchant post-migration: the new layout returns the same top-k
+     set as the legacy layout for the same product set (retrieval parity).
+  3. ``get_vector_store(merchant, strategy)`` is idempotent / cached per-pair.
+
+These tests exercise the real SentenceTransformer encoder and a real FAISS
+index, matching the style of ``test_vector_search.py``. They do not require
+Postgres.
+"""
+
+import importlib.util
+import pickle
+import sys
+import os
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def _load_migration_module():
+    """Import the migration script by path (it lives outside the app package)."""
+    script_path = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "migrate_vector_index_to_per_merchant.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "migrate_vector_index_to_per_merchant", script_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+try:
+    import faiss  # noqa: F401
+    FAISS_AVAILABLE = True
+except ImportError:
+    FAISS_AVAILABLE = False
+
+from app.vector_search import (
+    UniversalEmbeddingStore,
+    get_vector_store,
+    merchant_index_dir,
+    merchant_index_path,
+    merchant_ids_path,
+    reset_vector_store_cache,
+)
+
+
+ACME_PRODUCTS = [
+    {"product_id": "ACME-001", "name": "Dell XPS 15 Laptop",
+     "description": "Powerful laptop for video editing", "category": "electronics", "brand": "Dell"},
+    {"product_id": "ACME-002", "name": "iPhone 15 Pro",
+     "description": "Premium smartphone with great camera", "category": "electronics", "brand": "Apple"},
+    {"product_id": "ACME-003", "name": "Sony WH-1000XM5 Headphones",
+     "description": "Wireless noise-cancelling over-ear headphones", "category": "electronics", "brand": "Sony"},
+]
+
+WIDGETS_PRODUCTS = [
+    {"product_id": "WID-001", "name": "Stainless Steel Water Bottle",
+     "description": "Insulated reusable water bottle", "category": "lifestyle", "brand": "EcoWare"},
+    {"product_id": "WID-002", "name": "Yoga Mat",
+     "description": "Non-slip eco-friendly yoga mat", "category": "fitness", "brand": "ZenFit"},
+    {"product_id": "WID-003", "name": "Cast Iron Skillet",
+     "description": "Pre-seasoned 12 inch cast iron cookware", "category": "kitchen", "brand": "IronChef"},
+]
+
+
+@pytest.fixture
+def clean_merchant_dirs(tmp_path, monkeypatch):
+    """Redirect the per-merchant data root into a tmp dir so test state is isolated.
+
+    Each test gets its own ``data/merchants/`` root, and the store cache is
+    reset before and after the test so no prior instance pins the old path.
+    """
+    from app import vector_search
+
+    fake_root = tmp_path / "data" / "merchants"
+    fake_root.mkdir(parents=True)
+    monkeypatch.setattr(vector_search, "_MERCHANT_DATA_ROOT", fake_root)
+
+    reset_vector_store_cache()
+    yield fake_root
+    reset_vector_store_cache()
+
+
+@pytest.mark.skipif(not FAISS_AVAILABLE, reason="faiss not installed")
+class TestPerMerchantIsolation:
+    """Two merchants, two disjoint catalogs — no cross-merchant leakage."""
+
+    def test_search_never_returns_other_merchants_products(self, clean_merchant_dirs):
+        acme = UniversalEmbeddingStore(merchant_id="acme", strategy="normalizer_v1")
+        widgets = UniversalEmbeddingStore(merchant_id="widgets", strategy="normalizer_v1")
+
+        acme.build_index(ACME_PRODUCTS, save_index=False)
+        widgets.build_index(WIDGETS_PRODUCTS, save_index=False)
+
+        acme_ids = {p["product_id"] for p in ACME_PRODUCTS}
+        widgets_ids = {p["product_id"] for p in WIDGETS_PRODUCTS}
+
+        # A query that matches items on both sides semantically.
+        for query in ("laptop", "yoga", "cookware", "smartphone"):
+            acme_hits, _ = acme.search(query, k=10)
+            widgets_hits, _ = widgets.search(query, k=10)
+
+            assert acme_hits, f"acme search for {query!r} returned nothing"
+            assert widgets_hits, f"widgets search for {query!r} returned nothing"
+            assert set(acme_hits).issubset(acme_ids), (
+                f"acme leaked: {set(acme_hits) - acme_ids}"
+            )
+            assert set(widgets_hits).issubset(widgets_ids), (
+                f"widgets leaked: {set(widgets_hits) - widgets_ids}"
+            )
+
+    def test_indices_are_written_to_distinct_directories(self, clean_merchant_dirs):
+        acme_path = merchant_index_path("acme", "normalizer_v1")
+        widgets_path = merchant_index_path("widgets", "normalizer_v1")
+        assert acme_path != widgets_path
+        # ../../<merchant>/<strategy>/faiss.bin -> merchants root via three parents
+        assert acme_path.parent.parent.parent == widgets_path.parent.parent.parent
+
+        acme = UniversalEmbeddingStore(merchant_id="acme", strategy="normalizer_v1")
+        acme.build_index(ACME_PRODUCTS, save_index=True)
+        assert acme_path.exists()
+        assert merchant_ids_path("acme", "normalizer_v1").exists()
+        # widgets side must remain untouched
+        assert not widgets_path.exists()
+
+
+@pytest.mark.skipif(not FAISS_AVAILABLE, reason="faiss not installed")
+class TestDefaultMerchantMigrationParity:
+    """After migration, (default, normalizer_v1) returns the same top-k set.
+
+    We simulate the pre-migration state by writing a legacy-layout index pair
+    into ``vector_indices/`` — bit-for-bit the same FAISS bytes a freshly
+    built store would emit — then run the migration script and confirm that
+    the new store loads the migrated files and produces identical top-k
+    ordering for a fixed query set.
+    """
+
+    def _baseline_query_results(self, products, queries, k):
+        """Build a reference index and capture top-k for each query."""
+        baseline = UniversalEmbeddingStore(
+            merchant_id="__baseline__",
+            strategy="normalizer_v1",
+            use_cache=False,
+        )
+        baseline.build_index(products, save_index=False)
+        return {q: baseline.search(q, k=k)[0] for q in queries}
+
+    def test_migration_preserves_topk(self, clean_merchant_dirs, tmp_path, monkeypatch):
+        import faiss
+        migrate_vector_index = _load_migration_module()
+
+        # Arrange: build a real FAISS index + id-map for the "default" merchant
+        # and drop it at the legacy global path the migration script scans.
+        products = ACME_PRODUCTS + WIDGETS_PRODUCTS
+        queries = ["laptop", "yoga", "headphones"]
+        baseline_topk = self._baseline_query_results(products, queries, k=3)
+
+        # Rebuild to serialize to disk under the legacy layout.
+        seed_store = UniversalEmbeddingStore(
+            merchant_id="__legacy_seed__",
+            strategy="normalizer_v1",
+            use_cache=False,
+        )
+        seed_store.build_index(products, save_index=False)
+
+        # Point the migration script at our fake mcp-server root.
+        fake_mcp_root = tmp_path / "mcp-server"
+        legacy_dir = fake_mcp_root / "vector_indices"
+        legacy_dir.mkdir(parents=True)
+        legacy_idx = legacy_dir / "mcp_index_all_mpnet_base_v2_20250101_000000.index"
+        legacy_ids = legacy_dir / "mcp_ids_all_mpnet_base_v2_20250101_000000.pkl"
+        faiss.write_index(seed_store._index, str(legacy_idx))
+        with open(legacy_ids, "wb") as f:
+            pickle.dump(seed_store._product_ids, f)
+
+        # Also redirect the new per-merchant data root to live under the same
+        # fake mcp-server so the migration can write to ``<fake>/data/merchants/``.
+        from app import vector_search as vs
+        new_root = fake_mcp_root / "data" / "merchants"
+        monkeypatch.setattr(vs, "_MERCHANT_DATA_ROOT", new_root)
+        monkeypatch.setattr(migrate_vector_index, "_repo_mcp_root", lambda: fake_mcp_root)
+
+        # Act: migrate + reset cache so the next get_vector_store picks up the
+        # freshly-copied files.
+        copied = migrate_vector_index.migrate(
+            merchant_id="default",
+            strategy="normalizer_v1",
+            dry_run=False,
+            delete_legacy=False,
+        )
+        assert copied >= 2
+        reset_vector_store_cache()
+
+        # Assert: the default merchant's new store returns the same top-k set
+        # as the baseline index (retrieval parity across the migration).
+        default_store = get_vector_store("default", "normalizer_v1")
+        for q in queries:
+            got, _ = default_store.search(q, k=3)
+            assert got == baseline_topk[q], (
+                f"top-k diverged for query={q!r}: got={got} baseline={baseline_topk[q]}"
+            )
+
+
+@pytest.mark.skipif(not FAISS_AVAILABLE, reason="faiss not installed")
+class TestGetVectorStoreCaching:
+    """get_vector_store(m, s) is idempotent per pair and distinct across pairs."""
+
+    def test_same_pair_returns_same_instance(self, clean_merchant_dirs):
+        a = get_vector_store("acme", "normalizer_v1")
+        b = get_vector_store("acme", "normalizer_v1")
+        assert a is b
+
+    def test_different_strategies_distinct(self, clean_merchant_dirs):
+        v1 = get_vector_store("acme", "normalizer_v1")
+        v2 = get_vector_store("acme", "normalizer_v2")
+        assert v1 is not v2
+
+    def test_different_merchants_distinct(self, clean_merchant_dirs):
+        acme = get_vector_store("acme", "normalizer_v1")
+        widgets = get_vector_store("widgets", "normalizer_v1")
+        assert acme is not widgets
+
+    def test_reset_cache_drops_instances(self, clean_merchant_dirs):
+        first = get_vector_store("acme", "normalizer_v1")
+        reset_vector_store_cache()
+        second = get_vector_store("acme", "normalizer_v1")
+        assert first is not second

--- a/mcp-server/tests/test_vector_search.py
+++ b/mcp-server/tests/test_vector_search.py
@@ -11,15 +11,20 @@ from unittest.mock import Mock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from app.vector_search import UniversalEmbeddingStore, get_vector_store
+from app.vector_search import UniversalEmbeddingStore, get_vector_store, reset_vector_store_cache
 
 
 class TestUniversalEmbeddingStore:
     """Test suite for Universal Embedding Store."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
-        self.store = UniversalEmbeddingStore(use_cache=False)
+        # Isolated (merchant, strategy) so no prior on-disk index bleeds in.
+        self.store = UniversalEmbeddingStore(
+            merchant_id="test_unit",
+            strategy="unit_test",
+            use_cache=False,
+        )
     
     def test_encode_text(self):
         """Test text encoding."""
@@ -159,7 +164,11 @@ class TestUniversalEmbeddingStore:
     
     def test_empty_search(self):
         """Test search with no index."""
-        store = UniversalEmbeddingStore()
+        store = UniversalEmbeddingStore(
+            merchant_id="test_unit_empty",
+            strategy="unit_test",
+            use_cache=False,
+        )
         store._index = None
         
         product_ids, scores = store.search("test", k=5)
@@ -170,7 +179,11 @@ class TestUniversalEmbeddingStore:
     def test_cache_embeddings(self):
         """Test embedding caching."""
         # Create store with caching enabled
-        store = UniversalEmbeddingStore(use_cache=True)
+        store = UniversalEmbeddingStore(
+            merchant_id="test_unit_cache",
+            strategy="unit_test",
+            use_cache=True,
+        )
         
         product = {
             "product_id": "TEST-001",
@@ -191,12 +204,24 @@ class TestUniversalEmbeddingStore:
 class TestVectorSearchIntegration:
     """Integration tests for vector search in MCP."""
     
-    def test_vector_store_singleton(self):
-        """Test that get_vector_store returns singleton."""
-        store1 = get_vector_store()
-        store2 = get_vector_store()
-        
+    def test_vector_store_cached_per_pair(self):
+        """get_vector_store(m, s) is idempotent within a (merchant, strategy) pair."""
+        reset_vector_store_cache()
+        store1 = get_vector_store("cache_test", "normalizer_v1")
+        store2 = get_vector_store("cache_test", "normalizer_v1")
+
         assert store1 is store2
+
+    def test_vector_store_distinct_across_pairs(self):
+        """Different (merchant, strategy) pairs get distinct store instances."""
+        reset_vector_store_cache()
+        acme_v1 = get_vector_store("acme", "normalizer_v1")
+        acme_v2 = get_vector_store("acme", "normalizer_v2")
+        widgets_v1 = get_vector_store("widgets", "normalizer_v1")
+
+        assert acme_v1 is not acme_v2
+        assert acme_v1 is not widgets_v1
+        assert acme_v2 is not widgets_v1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace the single global FAISS store with one per `(merchant_id, strategy)` pair. New layout: `mcp-server/data/merchants/<merchant_id>/<strategy>/faiss.bin` + `ids.pkl` sidecar.
- `get_vector_store(merchant_id, strategy)` caches per-pair so repeat calls reuse the encoder and loaded index; `reset_vector_store_cache()` drops the cache for tests.
- `MerchantAgent` now carries its `strategy`, threads it into the search filters (so `endpoints.search_products` picks the right index), rebuilds the index at the tail of `from_csv` via the new `refresh_vector_index()`, and reads `vector_index_mtime` from its own path.
- Migration script `mcp-server/scripts/migrate_vector_index_to_per_merchant.py` copies legacy `vector_indices/*.index` + `ids.pkl` (or the `data/vector_cache/faiss_index.bin` sentinel) into `data/merchants/default/normalizer_v1/`. Dry-run and `--delete-legacy` flags supported.

Closes #56.

## Test plan
- [x] `pytest tests/test_per_merchant_vector_index.py` — 7/7 green. Covers two-merchant catalog isolation, migration parity (legacy index → new layout returns identical top-k), and `get_vector_store` caching across pairs.
- [x] `pytest tests/test_vector_search.py` — 11/11 green after the store signature change.
- [x] `pytest tests/test_merchant_feed.py` — adjacent merchant-agent surfaces still pass.
- [ ] Manual: run `python mcp-server/scripts/migrate_vector_index_to_per_merchant.py --dry-run` against an environment with a legacy index, then without `--dry-run`, and confirm default-merchant search parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)