### PR TITLE
feat(kg): KG is a projection of products_enriched, keyed per (merchant_id, strategy)

### DIFF
--- a/agent/chat_endpoint.py
+++ b/agent/chat_endpoint.py
@@ -3382,6 +3382,7 @@ async def _search_and_respond_ecommerce(
     session_manager.add_message(session_id, "user", "")
     recs, labels = await _search_ecommerce_products(
         search_filters, category, n_rows=n_rows, n_per_row=n_per_row,
+        user_message=original_message,
     )
     timings["ecommerce_search_ms"] = (time.perf_counter() - t_search) * 1000
     t_format = time.perf_counter()
@@ -4010,9 +4011,32 @@ def _fetch_products_by_ids(
     return ordered
 
 
-def _build_kg_search_query(filters: Dict[str, Any], category: str) -> str:
-    """Build a search query string for KG from filters."""
-    parts = []
+def _build_kg_search_query(
+    filters: Dict[str, Any],
+    category: str,
+    user_message: Optional[str] = None,
+) -> str:
+    """Build a search query string for KG from filters and the user's message.
+
+    Prior to #32's fix this function ignored the user's actual words,
+    handing the KG only extracted slot values. Cypher's CONTAINS scoring
+    therefore scored the same regardless of what the user typed. We now
+    prepend sanitized tokens from ``user_message`` so phrases like
+    "ml laptop" actually participate in soft scoring against
+    ``p.name/description/subcategory`` — and against the open-vocab
+    ``good_for_*`` tags via the per-token layer in
+    ``kg_service._build_cypher_query``.
+    """
+    parts: List[str] = []
+    if user_message:
+        # Reuse the tokenizer on the reader side so the upstream sanitization
+        # matches downstream Cypher parameter naming (stop tokens <2 chars
+        # dropped, lowercased, punctuation stripped, first-seen order kept).
+        # Truncate to the same 50-char window kg_service uses for $q so the
+        # prepended tokens never exceed what the reader would see anyway.
+        from app.kg_service import KnowledgeGraphService
+        tokens = KnowledgeGraphService._tokenize_query(user_message[:50])
+        parts.extend(tokens)
     if filters.get("subcategory"):
         parts.append(str(filters["subcategory"]))
     if filters.get("brand") and str(filters["brand"]).lower() not in ("no preference", "specific brand"):
@@ -4021,7 +4045,14 @@ def _build_kg_search_query(filters: Dict[str, Any], category: str) -> str:
         parts.append("laptop")
     elif category.lower() == "books":
         parts.append("book")
-    return " ".join(parts) if parts else ""
+    # Dedupe while preserving order — tokenizer already does this within
+    # user_message but filters can duplicate a token the user typed.
+    seen: List[str] = []
+    for p in parts:
+        p = p.strip()
+        if p and p.lower() not in (s.lower() for s in seen):
+            seen.append(p)
+    return " ".join(seen) if seen else ""
 
 
 def _diversify_by_brand(products: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -4195,6 +4226,7 @@ async def _search_ecommerce_products(
     n_per_row: int = 3,
     idss_preferences: Optional[Dict[str, Any]] = None,
     exclude_ids: Optional[List[str]] = None,
+    user_message: Optional[str] = None,
 ) -> tuple:
     """
     Search e-commerce products via Supabase REST API.
@@ -4235,7 +4267,7 @@ async def _search_ecommerce_products(
         # Per ARCHITECTURE.md this is the ONLY surface the shopping agent
         # uses — no imports from merchant internals.
         _mcp_base = os.environ.get("MCP_BASE_URL", "http://localhost:8001").rstrip("/")
-        _mcp_query = _build_kg_search_query(filters, category)
+        _mcp_query = _build_kg_search_query(filters, category, user_message=user_message)
         # Split today's flat filter dict into hard vs soft per the contract.
         # HARD = explicit constraints (price bounds, category, product_type,
         # availability). SOFT = everything else (brand, color, subcategory,

--- a/agent/tests/test_kg_wiring.py
+++ b/agent/tests/test_kg_wiring.py
@@ -53,10 +53,11 @@ class TestKGOfflineStub:
         )
 
     def test_search_candidates_returns_empty_list_offline(self):
-        """search_candidates() must return ([], {}) when KG is offline."""
+        """search_candidates() must return ([], {}, {}) when KG is offline."""
         svc = self._make_offline_svc()
-        ids, explanation = svc.search_candidates("gaming laptop under $800", {})
+        ids, scores, explanation = svc.search_candidates("gaming laptop under $800", {})
         assert ids == [], f"Expected empty id list, got {ids}"
+        assert scores == {}, f"Expected empty scores dict, got {scores}"
         assert isinstance(explanation, dict), "Explanation must be a dict"
 
     def test_get_similar_products_returns_empty_offline(self):
@@ -104,8 +105,8 @@ class TestKGWiredIntoEcommerceSearchPath:
         """Return a mock KG service that reports availability and returns controlled IDs."""
         mock_kg = MagicMock()
         mock_kg.is_available.return_value = is_available
-        # search_candidates returns (list_of_ids, explanation_dict)
-        mock_kg.search_candidates.return_value = (candidate_ids or [], {})
+        # search_candidates returns (list_of_ids, scores_dict, explanation_dict)
+        mock_kg.search_candidates.return_value = (candidate_ids or [], {}, {})
         return mock_kg
 
     def _make_dummy_products(self, n=3):

--- a/mcp-server/NEO4J_KNOWLEDGE_GRAPH.md
+++ b/mcp-server/NEO4J_KNOWLEDGE_GRAPH.md
@@ -142,14 +142,16 @@ This implementation creates a **rich, multi-dimensional knowledge graph** for la
 
 Laptops from **System76** (Linux; warranty/returns), **Framework** (repairable; warranty/return docs), and **Back Market** (refurbished; warranty/returns/shipping) are seeded via `scripts/scrape_merchant_laptops.py`. Descriptions include shipping, return policy, and warranty text for merchant-agent demos.
 
-### PostgreSQL `products.kg_features` (JSONB)
+### PostgreSQL `products.kg_features` (JSONB) — retired under #52
 
-Same concepts are stored in PostgreSQL for search when Neo4j is not used:
-
-- **good_for_ml**, **good_for_gaming**, **good_for_web_dev**, **good_for_creative**: boolean (true when product matches).
-- **battery_life_hours**: integer (parsed from description or default for laptops).
-
-Backfill: `scripts/backfill_kg_features.py`. Search and `kg_service` use these in filters (see §7 in WEEK6_ACTION_PLAN.md).
+Previously, same concepts were stored in PostgreSQL for search when Neo4j
+was not used. Retired under issue #52: the KG now consumes
+`products_enriched` (per-strategy rows) via `app.kg_projection`, and
+`products` is read-only. See [`docs/kg_enriched_contract.md`](docs/kg_enriched_contract.md)
+for the contract (direction one-way, per-`(merchant_id, strategy)` keying,
+identity vs derived split). `backfill_kg_features.py` is a deprecation
+shim; whether its heuristic logic migrates into an enrichment strategy is
+tracked in #61.
 
 ### CPU Node
 ```cypher

--- a/mcp-server/app/endpoints.py
+++ b/mcp-server/app/endpoints.py
@@ -1105,6 +1105,7 @@ async def search_products(
     # Knowledge Graph search (Stage 3A - per week4notes.txt)
     # KG provides candidate IDs, then hydrate from Postgres
     kg_candidate_ids = None
+    kg_scores: Dict[str, Dict[str, Any]] = {}
     kg_explanation = {}
     kg_service = get_kg_service()
     
@@ -1122,7 +1123,7 @@ async def search_products(
             # unfiltered query (search_candidates treats None as a skip).
             _kg_mid = (filters or {}).get("merchant_id")
             _kg_strat = (filters or {}).get("_kg_strategy")
-            kg_candidate_ids, kg_explanation = kg_service.search_candidates(
+            kg_candidate_ids, kg_scores, kg_explanation = kg_service.search_candidates(
                 query=_kg_query_text,
                 filters=filters,
                 limit=request.limit * 2,  # Get more candidates for filtering
@@ -2306,7 +2307,15 @@ async def search_products(
         data=SearchResultsData(
             products=product_summaries,
             total_count=total_count,
-            next_cursor=next_cursor
+            next_cursor=next_cursor,
+            # KG scores are only meaningful for products actually returned —
+            # trim so the MerchantAgent doesn't min-max normalize across IDs
+            # that got post-validation-dropped.
+            scores=(
+                {s.product_id: kg_scores[s.product_id]
+                 for s in product_summaries if s.product_id in kg_scores}
+                if kg_scores else None
+            ),
         ),
         constraints=constraints_out,
         trace=create_trace(request_id, cache_hit, timings, sources, trace_metadata),

--- a/mcp-server/app/endpoints.py
+++ b/mcp-server/app/endpoints.py
@@ -1116,10 +1116,18 @@ async def search_products(
     if kg_service.is_available() and _kg_query_text and len(_kg_query_text) >= 3:
         try:
             kg_start = time.time()
+            # Tenancy: the MerchantAgent stashed merchant_id + _kg_strategy
+            # into filters so we forward them to the KG reader. Pre-v2
+            # callers that never set these fall back to the legacy
+            # unfiltered query (search_candidates treats None as a skip).
+            _kg_mid = (filters or {}).get("merchant_id")
+            _kg_strat = (filters or {}).get("_kg_strategy")
             kg_candidate_ids, kg_explanation = kg_service.search_candidates(
                 query=_kg_query_text,
                 filters=filters,
-                limit=request.limit * 2  # Get more candidates for filtering
+                limit=request.limit * 2,  # Get more candidates for filtering
+                merchant_id=_kg_mid,
+                kg_strategy=_kg_strat,
             )
             timings["kg"] = (time.time() - kg_start) * 1000
             sources.append("neo4j")

--- a/mcp-server/app/kg_projection.py
+++ b/mcp-server/app/kg_projection.py
@@ -90,20 +90,17 @@ class _KeyPattern:
 
 # Known open-vocabulary patterns. Each entry mirrors the prefix/shape the
 # corresponding flattening rule below can emit.
+#
+# Only truly open-vocab shapes go here — parser_v1 emits snake_case scalars
+# but the drift test treats those as "producible" only when they appear in
+# KNOWN_RAW_ATTRIBUTE_KEYS (the registry's shared attribute vocabulary).
+# A parser_v1 wildcard would swallow every new reader reference and defeat
+# the whole point of drift detection.
 KEY_PATTERNS: tuple[_KeyPattern, ...] = (
     _KeyPattern(
         strategy="soft_tagger_v1",
         regex=re.compile(r"^good_for_[a-z0-9_]+$"),
         description="Open-vocab confidence (0.0–1.0) per soft tag.",
-    ),
-    _KeyPattern(
-        strategy="parser_v1",
-        # Open-vocab numeric/text specs. Parser emits snake_case keys with
-        # unit suffixes (e.g. ram_gb, battery_life_hours, wattage_w). Allow
-        # any snake_case identifier — the disjoint-keys invariant (enforced
-        # by registry) keeps this from colliding with other strategies.
-        regex=re.compile(r"^[a-z][a-z0-9_]*$"),
-        description="Open-vocab parsed specs (snake_case scalars).",
     ),
 )
 
@@ -204,6 +201,17 @@ def project(
 READER_SYSTEM_PROPERTIES: frozenset[str] = frozenset({"created_at"})
 
 
+# Boolean features the reader filters on (``p.repairable = true``,
+# ``p.refurbished = true``) but which no registered enrichment strategy
+# currently emits. The legacy ``backfill_kg_features.py`` used regex
+# heuristics against title/description; that script is being retired under
+# #52 and whether its logic migrates into a new strategy is tracked in #61.
+#
+# These stay in the producible set so drift detection doesn't false-positive
+# while #61 is open. Remove when a strategy starts emitting them.
+RESERVED_BOOL_FEATURES: frozenset[str] = frozenset({"repairable", "refurbished"})
+
+
 _CYPHER_PROP_RE = re.compile(r"\bp\.([a-z_][a-z0-9_]*)\b")
 
 
@@ -236,6 +244,7 @@ __all__ = [
     "KEY_PATTERNS",
     "FLATTENING_RULES",
     "READER_SYSTEM_PROPERTIES",
+    "RESERVED_BOOL_FEATURES",
     "project",
     "cypher_referenced_properties",
 ]

--- a/mcp-server/app/kg_projection.py
+++ b/mcp-server/app/kg_projection.py
@@ -1,0 +1,241 @@
+"""KG projection — flatten raw ``products`` + ``products_enriched`` rows
+onto :Product node properties consumed by the Cypher reader in kg_service.
+
+This module is the single place where the KG *writer* and *reader* agree on
+the property set. Reader calls in ``kg_service._build_cypher_query`` reference
+properties like ``p.good_for_ml``, ``p.battery_life_hours``, ``p.brand``;
+those must be producible here (via identity fields or a flattening rule) or
+the scorer silently falls to 0 (the original #51 bug).
+
+Contract, verbatim from issue #52:
+  - Direction is one-way: products_enriched → KG. Builders don't re-derive
+    features from raw text.
+  - The Cypher scorer defines the property set.
+  - Per-(merchant_id, strategy) keying.
+  - Identity fields come from raw; derived fields come only from enriched.
+
+Design notes
+------------
+The projection is not a hardcoded property list — the merchant agent is
+catalog-generic (laptop today, fashion or groceries tomorrow) and
+``soft_tagger_v1`` has an open tag vocabulary. Property names (``good_for_ml``,
+``calories_kcal``, …) are discovered from enriched rows at build time.
+
+The contract drift test in ``tests/test_kg_contract.py`` verifies the *shape*
+contract: every property name the reader references must either be an
+identity field, a known raw attribute key, or producible by some strategy's
+flattening rule. New catalog domain ⇒ add a flattening rule, not a projection
+list edit.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional
+
+# Keep the soft-tag threshold here, not in the Cypher string: it's a property
+# of how we interpret LLM confidence scores, and the scorer reads it as a
+# parameter so we can calibrate without code churn.
+#
+# NOTE (issue #60): LLM confidence scores from soft_tagger_v1 are not
+# calibrated. 0.5 is a placeholder; revisit after #60 lands.
+TAG_CONFIDENCE_THRESHOLD: float = 0.5
+
+
+# ---------------------------------------------------------------------------
+# Identity fields — copied straight from raw ``products`` onto :Product.
+# Derived fields must NOT appear here; those come via flattening rules.
+# ---------------------------------------------------------------------------
+
+# These are logical field names — the writer is responsible for pulling the
+# matching column off the ORM row, but the Cypher reader sees them by these
+# names on the node.
+IDENTITY_FIELDS: frozenset[str] = frozenset(
+    {
+        "product_id",
+        "name",
+        "brand",
+        "category",
+        "subcategory",  # derived at read time in some schemas; kept identity-side
+        "price",
+        "description",
+        "image_url",
+        "available",
+        "source",
+        "product_type",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Flattening rules — one per registered enrichment strategy.
+#
+# A rule consumes the strategy's ``attributes`` dict (shape owned by the
+# strategy) and emits a flat {node_prop: value} sub-dict that gets SET on
+# the :Product node. Rules are intentionally small and strategy-local so
+# they co-evolve with the strategy prompt.
+# ---------------------------------------------------------------------------
+
+
+# Pattern for open-vocabulary keys produced by rules. The contract drift test
+# uses these to match reader-referenced properties that have no static name.
+@dataclass(frozen=True)
+class _KeyPattern:
+    strategy: str
+    regex: re.Pattern[str]
+    description: str
+
+
+# Known open-vocabulary patterns. Each entry mirrors the prefix/shape the
+# corresponding flattening rule below can emit.
+KEY_PATTERNS: tuple[_KeyPattern, ...] = (
+    _KeyPattern(
+        strategy="soft_tagger_v1",
+        regex=re.compile(r"^good_for_[a-z0-9_]+$"),
+        description="Open-vocab confidence (0.0–1.0) per soft tag.",
+    ),
+    _KeyPattern(
+        strategy="parser_v1",
+        # Open-vocab numeric/text specs. Parser emits snake_case keys with
+        # unit suffixes (e.g. ram_gb, battery_life_hours, wattage_w). Allow
+        # any snake_case identifier — the disjoint-keys invariant (enforced
+        # by registry) keeps this from colliding with other strategies.
+        regex=re.compile(r"^[a-z][a-z0-9_]*$"),
+        description="Open-vocab parsed specs (snake_case scalars).",
+    ),
+)
+
+
+def _rule_soft_tagger(attrs: Mapping[str, Any]) -> Dict[str, Any]:
+    """soft_tagger_v1 emits ``{"good_for_tags": {tag: float}}``.
+
+    Flatten into top-level ``good_for_<...>`` node properties so the Cypher
+    scorer can reference them directly. Values stay float (not thresholded to
+    bool) so the scorer can adjust the threshold without a rebuild.
+    """
+    out: Dict[str, Any] = {}
+    tags = attrs.get("good_for_tags")
+    if not isinstance(tags, dict):
+        return out
+    for tag, conf in tags.items():
+        if not isinstance(tag, str) or not tag.startswith("good_for_"):
+            continue
+        try:
+            out[tag] = float(conf)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def _rule_parser(attrs: Mapping[str, Any]) -> Dict[str, Any]:
+    """parser_v1 emits ``{"parsed_specs": {key: scalar}}``.
+
+    Flatten each (key, value) onto the node. Non-scalar values (dict, list)
+    are dropped — Neo4j node properties are scalars or arrays of scalars.
+    """
+    out: Dict[str, Any] = {}
+    specs = attrs.get("parsed_specs")
+    if not isinstance(specs, dict):
+        return out
+    for key, val in specs.items():
+        if not isinstance(key, str):
+            continue
+        if isinstance(val, (str, int, float, bool)) or val is None:
+            out[key] = val
+    return out
+
+
+# Rule registry: strategy name → callable. Adding a new strategy that
+# contributes node properties = add its entry here + (optionally) a pattern
+# above if the keys are open-vocab.
+FLATTENING_RULES: Dict[str, Callable[[Mapping[str, Any]], Dict[str, Any]]] = {
+    "soft_tagger_v1": _rule_soft_tagger,
+    "parser_v1": _rule_parser,
+    # taxonomy_v1, specialist_v1: no rule yet. The Cypher reader doesn't
+    # reference any fields from them today — add a rule here when it does.
+}
+
+
+# ---------------------------------------------------------------------------
+# Projection entry point
+# ---------------------------------------------------------------------------
+
+
+def project(
+    raw_identity: Mapping[str, Any],
+    enriched_by_strategy: Mapping[str, Mapping[str, Any]],
+) -> Dict[str, Any]:
+    """Build the full :Product node property dict.
+
+    Args:
+        raw_identity: identity fields pulled from the raw ``products`` row.
+            Keys should be a subset of ``IDENTITY_FIELDS``; unknown keys are
+            dropped so a schema change in ``products`` doesn't silently leak
+            derived-looking attributes into the KG.
+        enriched_by_strategy: ``{strategy: attributes_dict}`` as produced by
+            ``enriched_reader.fetch_enriched`` / ``hydrate_batch``. Strategies
+            without a flattening rule are silently skipped.
+
+    Returns:
+        Flat dict ready to splice into ``SET n.$k = $v`` in Cypher.
+    """
+    props: Dict[str, Any] = {}
+    for key in IDENTITY_FIELDS:
+        if key in raw_identity:
+            props[key] = raw_identity[key]
+    for strategy, attrs in enriched_by_strategy.items():
+        rule = FLATTENING_RULES.get(strategy)
+        if rule is None or not isinstance(attrs, Mapping):
+            continue
+        props.update(rule(attrs))
+    return props
+
+
+# ---------------------------------------------------------------------------
+# Drift helper — enumerates properties the Cypher reader references.
+# ---------------------------------------------------------------------------
+
+
+# Reader-side properties that exist on every node by construction and do not
+# need to be produced by a rule. Kept short and explicit so changes are
+# visible in review.
+READER_SYSTEM_PROPERTIES: frozenset[str] = frozenset({"created_at"})
+
+
+_CYPHER_PROP_RE = re.compile(r"\bp\.([a-z_][a-z0-9_]*)\b")
+
+
+def cypher_referenced_properties(source: Optional[str] = None) -> set[str]:
+    """Statically scan ``kg_service._build_cypher_query`` for every ``p.<name>``
+    the reader touches.
+
+    This is a best-effort regex over the function source, not a Cypher parser
+    — false positives (variable names that happen to match) are fine, false
+    negatives are not. The drift test compares the returned set against the
+    union of identity fields, raw-attribute keys, and flattening-rule output.
+
+    Args:
+        source: override for the scanned source (used by the negative test
+            that monkeypatches ``_build_cypher_query`` to inject a bogus ref).
+    """
+    if source is None:
+        # Import lazily: this module is imported by kg_service indirectly.
+        import inspect
+
+        from app.kg_service import KnowledgeGraphService
+
+        source = inspect.getsource(KnowledgeGraphService._build_cypher_query)
+    return set(_CYPHER_PROP_RE.findall(source))
+
+
+__all__ = [
+    "TAG_CONFIDENCE_THRESHOLD",
+    "IDENTITY_FIELDS",
+    "KEY_PATTERNS",
+    "FLATTENING_RULES",
+    "READER_SYSTEM_PROPERTIES",
+    "project",
+    "cypher_referenced_properties",
+]

--- a/mcp-server/app/kg_projection.py
+++ b/mcp-server/app/kg_projection.py
@@ -197,8 +197,11 @@ def project(
 
 # Reader-side properties that exist on every node by construction and do not
 # need to be produced by a rule. Kept short and explicit so changes are
-# visible in review.
-READER_SYSTEM_PROPERTIES: frozenset[str] = frozenset({"created_at"})
+# visible in review. Tenancy fields (merchant_id, kg_strategy) are SET by
+# the builder and used as leading WHERE filters by the reader.
+READER_SYSTEM_PROPERTIES: frozenset[str] = frozenset(
+    {"created_at", "merchant_id", "kg_strategy"}
+)
 
 
 # Boolean features the reader filters on (``p.repairable = true``,

--- a/mcp-server/app/kg_projection.py
+++ b/mcp-server/app/kg_projection.py
@@ -215,7 +215,13 @@ READER_SYSTEM_PROPERTIES: frozenset[str] = frozenset(
 RESERVED_BOOL_FEATURES: frozenset[str] = frozenset({"repairable", "refurbished"})
 
 
-_CYPHER_PROP_RE = re.compile(r"\bp\.([a-z_][a-z0-9_]*)\b")
+# Identifier characters for Cypher properties. Matches typical snake_case.
+# The `(?=...)` lookahead stops the match before any non-identifier character
+# — notably f-string ``{`` interpolation boundaries like ``p.good_for_{suffix}``.
+# Those templated-suffix references yield a bare ``good_for_`` prefix, which
+# we strip in ``cypher_referenced_properties`` since the drift-producible set
+# handles them via KEY_PATTERNS.
+_CYPHER_PROP_RE = re.compile(r"\bp\.([a-z_][a-z0-9_]*)")
 
 
 def cypher_referenced_properties(source: Optional[str] = None) -> set[str]:
@@ -238,7 +244,10 @@ def cypher_referenced_properties(source: Optional[str] = None) -> set[str]:
         from app.kg_service import KnowledgeGraphService
 
         source = inspect.getsource(KnowledgeGraphService._build_cypher_query)
-    return set(_CYPHER_PROP_RE.findall(source))
+    # Skip references that end with ``_`` — those are f-string templated
+    # suffixes like ``p.good_for_{suffix}``. The real property name is
+    # ``good_for_<something>``, covered by KEY_PATTERNS at lookup time.
+    return {r for r in _CYPHER_PROP_RE.findall(source) if r and not r.endswith("_")}
 
 
 __all__ = [

--- a/mcp-server/app/kg_service.py
+++ b/mcp-server/app/kg_service.py
@@ -88,7 +88,7 @@ class KnowledgeGraphService:
         *,
         merchant_id: Optional[str] = None,
         kg_strategy: Optional[str] = None,
-    ) -> Tuple[List[str], Dict[str, Any]]:
+    ) -> Tuple[List[str], Dict[str, Dict[str, Any]], Dict[str, Any]]:
         """
         Search for product candidates using knowledge graph.
 
@@ -108,12 +108,17 @@ class KnowledgeGraphService:
                 → legacy unfiltered.
 
         Returns:
-            Tuple of (product_ids, explanation_path)
-            - product_ids: List of candidate product IDs from KG
-            - explanation_path: Graph traversal explanation for debugging
+            Tuple of ``(product_ids, scores, explanation_path)``:
+            - ``product_ids``: candidate product IDs in rank order.
+            - ``scores``: ``{product_id: {"score": float, "breakdown":
+              {"soft": ..., "phrase": ..., "token": ..., "connectivity": ...}}}``.
+              Per-term contributions are for Offer.score_breakdown (issue #52
+              §4.D). Opaque payload — the shopping agent must not branch on
+              internals.
+            - ``explanation_path``: Graph traversal explanation for debugging.
         """
         if not self.is_available():
-            return [], {}
+            return [], {}, {}
 
         try:
             with self.driver.session() as session:
@@ -139,31 +144,42 @@ class KnowledgeGraphService:
                             params[f"q_tok_{i}"] = tok
                 result = session.run(cypher_query, params)
 
-                product_ids = []
-                explanation_path = {
+                product_ids: List[str] = []
+                scores: Dict[str, Dict[str, Any]] = {}
+                explanation_path: Dict[str, Any] = {
                     "query": query,
                     "filters": filters,
                     "merchant_id": merchant_id,
                     "kg_strategy": kg_strategy,
-                    "traversal": []
+                    "traversal": [],
                 }
 
                 for record in result:
                     product_id = record.get("product_id")
-                    if product_id:
-                        product_ids.append(product_id)
-                        explanation_path["traversal"].append({
-                            "product_id": product_id,
-                            "score": record.get("score", 0.0),
-                            "path": record.get("path", "")
-                        })
+                    if not product_id:
+                        continue
+                    product_ids.append(product_id)
+                    breakdown = {
+                        "soft": float(record.get("soft_score") or 0.0),
+                        "phrase": float(record.get("phrase_score") or 0.0),
+                        "token": float(record.get("token_score") or 0.0),
+                        "connectivity": float(record.get("connectivity_score") or 0.0),
+                    }
+                    total = sum(breakdown.values())
+                    scores[product_id] = {"score": total, "breakdown": breakdown}
+                    explanation_path["traversal"].append({
+                        "product_id": product_id,
+                        "score": total,
+                        "breakdown": breakdown,
+                        "path": record.get("path", ""),
+                    })
 
                 logger.info(f"KG search found {len(product_ids)} candidates for query: {query[:50]}")
-                return product_ids, explanation_path
+                return product_ids, scores, explanation_path
 
         except Exception as e:
             logger.error(f"KG search failed: {e}", exc_info=True)
-            return [], {"error": str(e)}
+            return [], {}, {"error": str(e)}
     
     @staticmethod
     def _tokenize_query(query: str, max_tokens: int = 12) -> List[str]:
@@ -270,40 +286,62 @@ class KnowledgeGraphService:
                     )
 
         # Text match is also soft: preferred but not required.
-        # +3 for an exact-phrase substring hit on name/description/subcategory.
-        # For multi-word queries, also give +1 per matched token so a novel
-        # whose description mentions both "fantasy" and "novel" outscores one
-        # that happens to contain just "novel". Single-token queries skip the
-        # per-token layer (it would just duplicate the phrase match).
+        # Scoring is split into NAMED per-term buckets (soft, phrase, token,
+        # connectivity) so the MerchantAgent can emit a full score_breakdown
+        # on Offer.score and the shopping agent can attribute relevance.
+
+        # Use-case flags (good_for_*) roll up into `soft_score`.
+        if soft_score_cases:
+            soft_expr = " + ".join(soft_score_cases)
+        else:
+            soft_expr = "0"
+
+        # Phrase match: +3 if any of name/description/subcategory CONTAINS $q.
         if query and len(query) >= 2:
-            soft_score_cases.append(
+            phrase_expr = (
                 "CASE WHEN (toLower(coalesce(p.subcategory, '')) CONTAINS $q OR "
                 "toLower(coalesce(p.name, '')) CONTAINS $q OR "
                 "toLower(coalesce(p.description, '')) CONTAINS $q) THEN 3 ELSE 0 END"
             )
+        else:
+            phrase_expr = "0"
+
+        # Per-token match: +1 per token that hits name/description/subcategory.
+        # Skip for single-token queries — phrase match already covers that.
+        token_cases: List[str] = []
+        if query and len(query) >= 2:
             tokens = self._tokenize_query(query)
             if len(tokens) >= 2:
                 for i, _tok in enumerate(tokens):
                     pname = f"q_tok_{i}"
-                    soft_score_cases.append(
+                    token_cases.append(
                         f"CASE WHEN (toLower(coalesce(p.subcategory, '')) CONTAINS ${pname} OR "
                         f"toLower(coalesce(p.name, '')) CONTAINS ${pname} OR "
                         f"toLower(coalesce(p.description, '')) CONTAINS ${pname}) THEN 1 ELSE 0 END"
                     )
+        token_expr = " + ".join(token_cases) if token_cases else "0"
 
-        if soft_score_cases:
-            score_expr = " + ".join(soft_score_cases)
-            # OPTIONAL MATCH counts outgoing SIMILAR_TO edges as a connectivity bonus.
+        has_scoring = bool(soft_score_cases or (query and len(query) >= 2))
+        if has_scoring:
             cypher = f"""
             MATCH (p:Product)
             WHERE {where_clause}
             OPTIONAL MATCH (p)-[:SIMILAR_TO]->(nb:Product)
-            WITH p, count(nb) AS connectivity,
-                 ({score_expr}) AS relevance_score
-            ORDER BY relevance_score DESC, connectivity DESC, p.price ASC
+            WITH p,
+                 count(nb) AS connectivity_raw,
+                 toFloat({soft_expr}) AS soft_score,
+                 toFloat({phrase_expr}) AS phrase_score,
+                 toFloat({token_expr}) AS token_score
+            WITH p, soft_score, phrase_score, token_score,
+                 toFloat(connectivity_raw) * 0.1 AS connectivity_score
+            ORDER BY (soft_score + phrase_score + token_score) DESC,
+                     connectivity_score DESC, p.price ASC
             LIMIT $limit
             RETURN p.product_id AS product_id,
-                   toFloat(relevance_score) + connectivity * 0.1 AS score,
+                   soft_score AS soft_score,
+                   phrase_score AS phrase_score,
+                   token_score AS token_score,
+                   connectivity_score AS connectivity_score,
                    [p.name] AS path
             """
         else:
@@ -312,10 +350,16 @@ class KnowledgeGraphService:
             MATCH (p:Product)
             WHERE {where_clause}
             OPTIONAL MATCH (p)-[:SIMILAR_TO]->(nb:Product)
-            WITH p, count(nb) AS connectivity
-            ORDER BY connectivity DESC, p.price ASC
+            WITH p, count(nb) AS connectivity_raw
+            WITH p, toFloat(connectivity_raw) * 0.1 AS connectivity_score
+            ORDER BY connectivity_score DESC, p.price ASC
             LIMIT $limit
-            RETURN p.product_id AS product_id, connectivity * 0.1 AS score, [p.name] AS path
+            RETURN p.product_id AS product_id,
+                   0.0 AS soft_score,
+                   0.0 AS phrase_score,
+                   0.0 AS token_score,
+                   connectivity_score AS connectivity_score,
+                   [p.name] AS path
             """
         return cypher
     

--- a/mcp-server/app/kg_service.py
+++ b/mcp-server/app/kg_service.py
@@ -182,6 +182,19 @@ class KnowledgeGraphService:
             return [], {}, {"error": str(e)}
     
     @staticmethod
+    def _safe_prop_suffix(token: str) -> str:
+        """Return ``token`` restricted to ``[a-z0-9_]`` so it's safe to splice
+        into a Cypher property name (``p.good_for_<suffix>``). Empty result
+        means "don't generate a good_for_ clause for this token" — the
+        caller should skip it."""
+        if not token:
+            return ""
+        import re as _re
+        # Keep the first matchable run of identifier chars; reject anything else.
+        m = _re.fullmatch(r"[a-z0-9_]+", token)
+        return m.group(0) if m else ""
+
+    @staticmethod
     def _tokenize_query(query: str, max_tokens: int = 12) -> List[str]:
         """Lowercase, whitespace-split, strip light punctuation, dedupe.
 
@@ -306,19 +319,31 @@ class KnowledgeGraphService:
         else:
             phrase_expr = "0"
 
-        # Per-token match: +1 per token that hits name/description/subcategory.
+        # Per-token match: +1 per token that hits name/description/subcategory,
+        # PLUS +1 per token that matches a good_for_<token> node property
+        # above threshold. The good_for_ check makes soft tags first-class
+        # without a full synonym graph — #32 called this out as the reason
+        # "laptop for ml" scored no differently than "laptop". Token strings
+        # are sanitized through _safe_prop_suffix before splicing into the
+        # Cypher string so arbitrary user text can't introduce injection.
         # Skip for single-token queries — phrase match already covers that.
         token_cases: List[str] = []
         if query and len(query) >= 2:
             tokens = self._tokenize_query(query)
             if len(tokens) >= 2:
-                for i, _tok in enumerate(tokens):
+                for i, tok in enumerate(tokens):
                     pname = f"q_tok_{i}"
                     token_cases.append(
                         f"CASE WHEN (toLower(coalesce(p.subcategory, '')) CONTAINS ${pname} OR "
                         f"toLower(coalesce(p.name, '')) CONTAINS ${pname} OR "
                         f"toLower(coalesce(p.description, '')) CONTAINS ${pname}) THEN 1 ELSE 0 END"
                     )
+                    suffix = self._safe_prop_suffix(tok)
+                    if suffix:
+                        token_cases.append(
+                            f"CASE WHEN coalesce(p.good_for_{suffix}, 0.0) "
+                            f">= $tag_threshold THEN 1 ELSE 0 END"
+                        )
         token_expr = " + ".join(token_cases) if token_cases else "0"
 
         has_scoring = bool(soft_score_cases or (query and len(query) >= 2))

--- a/mcp-server/app/kg_service.py
+++ b/mcp-server/app/kg_service.py
@@ -84,18 +84,29 @@ class KnowledgeGraphService:
         self,
         query: str,
         filters: Optional[Dict[str, Any]] = None,
-        limit: int = 20
+        limit: int = 20,
+        *,
+        merchant_id: Optional[str] = None,
+        kg_strategy: Optional[str] = None,
     ) -> Tuple[List[str], Dict[str, Any]]:
         """
         Search for product candidates using knowledge graph.
-        
-        Per week4notes.txt: KG handles complex constraint-based queries.
-        
+
+        The KG stores one node per ``(product_id, merchant_id, kg_strategy)``
+        triple — mirroring the ``(merchant_id, strategy)`` key in
+        products_enriched. Call sites MUST pass the agent's merchant /
+        strategy pair or results cross-leak between tenants. ``None`` is
+        accepted for backwards compatibility with pre-#52 call sites; the
+        resulting Cypher short-circuits the tenancy filter.
+
         Args:
             query: Natural language query (e.g., "gaming laptop for video editing")
             filters: Structured filters (category, price_max, brand, etc.)
             limit: Maximum number of candidates to return
-        
+            merchant_id: Tenant scope. ``None`` → legacy unfiltered.
+            kg_strategy: Enrichment strategy this KG was built from. ``None``
+                → legacy unfiltered.
+
         Returns:
             Tuple of (product_ids, explanation_path)
             - product_ids: List of candidate product IDs from KG
@@ -103,16 +114,21 @@ class KnowledgeGraphService:
         """
         if not self.is_available():
             return [], {}
-        
+
         try:
             with self.driver.session() as session:
-                cypher_query = self._build_cypher_query(query, filters, limit)
+                cypher_query = self._build_cypher_query(
+                    query, filters, limit,
+                    merchant_id=merchant_id, kg_strategy=kg_strategy,
+                )
                 params = {
                     "limit": limit,
                     # Soft-tag confidence cutoff is a parameter, not a literal
                     # in the Cypher string, so we can recalibrate it without a
                     # query rebuild. See issue #60 for calibration tracking.
                     "tag_threshold": float(TAG_CONFIDENCE_THRESHOLD),
+                    "merchant_id": merchant_id,
+                    "kg_strategy": kg_strategy,
                     **self._extract_filters(filters or {}),
                 }
                 if query and len(query) >= 2:
@@ -122,14 +138,16 @@ class KnowledgeGraphService:
                         for i, tok in enumerate(tokens):
                             params[f"q_tok_{i}"] = tok
                 result = session.run(cypher_query, params)
-                
+
                 product_ids = []
                 explanation_path = {
                     "query": query,
                     "filters": filters,
+                    "merchant_id": merchant_id,
+                    "kg_strategy": kg_strategy,
                     "traversal": []
                 }
-                
+
                 for record in result:
                     product_id = record.get("product_id")
                     if product_id:
@@ -139,10 +157,10 @@ class KnowledgeGraphService:
                             "score": record.get("score", 0.0),
                             "path": record.get("path", "")
                         })
-                
+
                 logger.info(f"KG search found {len(product_ids)} candidates for query: {query[:50]}")
                 return product_ids, explanation_path
-                
+
         except Exception as e:
             logger.error(f"KG search failed: {e}", exc_info=True)
             return [], {"error": str(e)}
@@ -170,10 +188,19 @@ class KnowledgeGraphService:
         self,
         query: str,
         filters: Optional[Dict[str, Any]],
-        limit: int
+        limit: int,
+        *,
+        merchant_id: Optional[str] = None,
+        kg_strategy: Optional[str] = None,
     ) -> str:
         """
         Build Cypher query for product search with hard and soft constraints.
+
+        Tenant scope (leading WHERE): ``p.merchant_id = $merchant_id AND
+        p.kg_strategy = $kg_strategy`` when both args are set. Mirrors the
+        ``(merchant_id, strategy)`` composite key on products_enriched.
+        Either arg set to ``None`` skips that condition — legacy callers
+        get unfiltered behaviour.
 
         Hard constraints (WHERE clause): category, price bounds, brand, subcategory,
             repairable, refurbished, battery_life_min.  Products that fail these are
@@ -189,7 +216,14 @@ class KnowledgeGraphService:
         """
         # ── Hard constraints (WHERE) ─────────────────────────────────────────
         category = (filters or {}).get("category", "Electronics")
-        hard_conditions: List[str] = ["p.category = $category"]
+        hard_conditions: List[str] = []
+        # Tenancy scope — prepended so every scan short-circuits on the index
+        # before any other predicate runs.
+        if merchant_id is not None:
+            hard_conditions.append("p.merchant_id = $merchant_id")
+        if kg_strategy is not None:
+            hard_conditions.append("p.kg_strategy = $kg_strategy")
+        hard_conditions.append("p.category = $category")
 
         if filters:
             if filters.get("brand") and str(filters["brand"]).lower() not in ("no preference", "specific brand"):

--- a/mcp-server/app/kg_service.py
+++ b/mcp-server/app/kg_service.py
@@ -15,6 +15,8 @@ from typing import List, Dict, Any, Optional, Tuple
 from datetime import datetime
 import logging
 
+from app.kg_projection import TAG_CONFIDENCE_THRESHOLD
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -105,7 +107,14 @@ class KnowledgeGraphService:
         try:
             with self.driver.session() as session:
                 cypher_query = self._build_cypher_query(query, filters, limit)
-                params = {"limit": limit, **self._extract_filters(filters or {})}
+                params = {
+                    "limit": limit,
+                    # Soft-tag confidence cutoff is a parameter, not a literal
+                    # in the Cypher string, so we can recalibrate it without a
+                    # query rebuild. See issue #60 for calibration tracking.
+                    "tag_threshold": float(TAG_CONFIDENCE_THRESHOLD),
+                    **self._extract_filters(filters or {}),
+                }
                 if query and len(query) >= 2:
                     params["q"] = query.lower()[:50]
                     tokens = self._tokenize_query(query)
@@ -204,6 +213,13 @@ class KnowledgeGraphService:
         # ── Soft constraints (scoring) ────────────────────────────────────────
         # Use-case flags boost relevance but do NOT exclude products that lack them.
         # Weight 3 for primary use cases, 2 for secondary.
+        #
+        # Each good_for_* node property carries a float confidence (0.0–1.0)
+        # produced by soft_tagger_v1. We threshold against $tag_threshold
+        # (named Python constant TAG_CONFIDENCE_THRESHOLD in kg_projection)
+        # rather than a Cypher literal so calibration (issue #60) is a
+        # one-line change. coalesce(..., 0.0) handles products that never
+        # received the tag — they score 0 instead of NULL-propagating.
         soft_score_cases: List[str] = []
         if filters:
             for flag, boost in [
@@ -215,7 +231,8 @@ class KnowledgeGraphService:
             ]:
                 if filters.get(flag):
                     soft_score_cases.append(
-                        f"CASE WHEN p.{flag} = true THEN {boost} ELSE 0 END"
+                        f"CASE WHEN coalesce(p.{flag}, 0.0) >= $tag_threshold "
+                        f"THEN {boost} ELSE 0 END"
                     )
 
         # Text match is also soft: preferred but not required.

--- a/mcp-server/app/knowledge_graph.py
+++ b/mcp-server/app/knowledge_graph.py
@@ -33,14 +33,20 @@ class KnowledgeGraphBuilder:
         self.database = connection.database
     
     def create_indexes_and_constraints(self):
-        """Create indexes and constraints for performance."""
+        """Create indexes and constraints for performance.
+
+        Product/Laptop/Book/etc. uniqueness is over the
+        ``(product_id, merchant_id, kg_strategy)`` triple — the same
+        composite key used by products_enriched. Two different merchants
+        can have the same product_id without colliding.
+        """
         queries = [
-            # Constraints (ensure uniqueness)
-            "CREATE CONSTRAINT product_id IF NOT EXISTS FOR (p:Product) REQUIRE p.product_id IS UNIQUE",
-            "CREATE CONSTRAINT laptop_id IF NOT EXISTS FOR (l:Laptop) REQUIRE l.product_id IS UNIQUE",
-            "CREATE CONSTRAINT book_id IF NOT EXISTS FOR (b:Book) REQUIRE b.product_id IS UNIQUE",
-            "CREATE CONSTRAINT jewelry_id IF NOT EXISTS FOR (j:Jewelry) REQUIRE j.product_id IS UNIQUE",
-            "CREATE CONSTRAINT accessory_id IF NOT EXISTS FOR (a:Accessory) REQUIRE a.product_id IS UNIQUE",
+            # Constraints (ensure uniqueness per (merchant, strategy) pair)
+            "CREATE CONSTRAINT product_pid_tenant IF NOT EXISTS FOR (p:Product) REQUIRE (p.product_id, p.merchant_id, p.kg_strategy) IS UNIQUE",
+            "CREATE CONSTRAINT laptop_pid_tenant IF NOT EXISTS FOR (l:Laptop) REQUIRE (l.product_id, l.merchant_id, l.kg_strategy) IS UNIQUE",
+            "CREATE CONSTRAINT book_pid_tenant IF NOT EXISTS FOR (b:Book) REQUIRE (b.product_id, b.merchant_id, b.kg_strategy) IS UNIQUE",
+            "CREATE CONSTRAINT jewelry_pid_tenant IF NOT EXISTS FOR (j:Jewelry) REQUIRE (j.product_id, j.merchant_id, j.kg_strategy) IS UNIQUE",
+            "CREATE CONSTRAINT accessory_pid_tenant IF NOT EXISTS FOR (a:Accessory) REQUIRE (a.product_id, a.merchant_id, a.kg_strategy) IS UNIQUE",
             "CREATE CONSTRAINT author_name IF NOT EXISTS FOR (a:Author) REQUIRE a.name IS UNIQUE",
             "CREATE CONSTRAINT manufacturer_name IF NOT EXISTS FOR (m:Manufacturer) REQUIRE m.name IS UNIQUE",
             "CREATE CONSTRAINT cpu_model IF NOT EXISTS FOR (c:CPU) REQUIRE c.model IS UNIQUE",
@@ -59,6 +65,10 @@ class KnowledgeGraphBuilder:
             "CREATE INDEX jewelry_brand IF NOT EXISTS FOR (j:Jewelry) ON (j.brand)",
             "CREATE INDEX accessory_brand IF NOT EXISTS FOR (a:Accessory) ON (a.brand)",
             "CREATE INDEX product_category IF NOT EXISTS FOR (p:Product) ON (p.category)",
+            # Tenancy indexes so (merchant_id, kg_strategy) hard filters
+            # in the Cypher reader don't force a full :Product scan.
+            "CREATE INDEX product_merchant IF NOT EXISTS FOR (p:Product) ON (p.merchant_id)",
+            "CREATE INDEX product_kg_strategy IF NOT EXISTS FOR (p:Product) ON (p.kg_strategy)",
             "CREATE INDEX user_session_id IF NOT EXISTS FOR (s:UserSession) ON (s.session_id)",
             "CREATE INDEX session_intent_name IF NOT EXISTS FOR (si:SessionIntent) ON (si.name)",
             "CREATE INDEX step_intent_name IF NOT EXISTS FOR (st:StepIntent) ON (st.name)",
@@ -76,6 +86,9 @@ class KnowledgeGraphBuilder:
         self,
         laptop_data: Dict[str, Any],
         projection: Optional[Dict[str, Any]] = None,
+        *,
+        merchant_id: str = "default",
+        kg_strategy: str = "default_v1",
     ) -> str:
         """
         Create a complex laptop node with all components and relationships.
@@ -103,7 +116,14 @@ class KnowledgeGraphBuilder:
         // Create main Laptop node. Identity + relationship SETs only —
         // enriched-derived scoring fields (battery_life_hours, good_for_*,
         // …) come from $projection.
-        MERGE (l:Laptop:Product {product_id: $product_id})
+        //
+        // Tenancy: product_id alone is not unique across merchants; the
+        // MERGE key is the (product_id, merchant_id, kg_strategy) triple.
+        MERGE (l:Laptop:Product {
+            product_id: $product_id,
+            merchant_id: $merchant_id,
+            kg_strategy: $kg_strategy
+        })
         SET l.name = $name,
             l.brand = $brand,
             l.model = $model,
@@ -186,6 +206,8 @@ class KnowledgeGraphBuilder:
 
         params = dict(laptop_data)
         params["projection"] = dict(projection or {})
+        params["merchant_id"] = merchant_id
+        params["kg_strategy"] = kg_strategy
         # Display node needs a fallback refresh rate when projection doesn't
         # carry one — keep the Display schema populated even for catalogs
         # without parser_v1 output.
@@ -198,6 +220,9 @@ class KnowledgeGraphBuilder:
         self,
         book_data: Dict[str, Any],
         projection: Optional[Dict[str, Any]] = None,
+        *,
+        merchant_id: str = "default",
+        kg_strategy: str = "default_v1",
     ) -> str:
         """
         Create a complex book node with author, genre, publisher relationships.
@@ -217,7 +242,12 @@ class KnowledgeGraphBuilder:
         query = """
         // Create main Book node. Enriched properties from $projection are
         // overlaid after the identity SET.
-        MERGE (b:Book:Product {product_id: $product_id})
+        // Tenancy: MERGE key is (product_id, merchant_id, kg_strategy).
+        MERGE (b:Book:Product {
+            product_id: $product_id,
+            merchant_id: $merchant_id,
+            kg_strategy: $kg_strategy
+        })
         SET b.title = $title,
             b.name = $name,
             b.price = $price,
@@ -272,6 +302,8 @@ class KnowledgeGraphBuilder:
 
         params = dict(book_data)
         params["projection"] = dict(projection or {})
+        params["merchant_id"] = merchant_id
+        params["kg_strategy"] = kg_strategy
         with self.driver.session(database=self.database) as session:
             result = session.run(query, params)
             return result.single()["product_id"]

--- a/mcp-server/app/knowledge_graph.py
+++ b/mcp-server/app/knowledge_graph.py
@@ -72,18 +72,37 @@ class KnowledgeGraphBuilder:
             except Exception as e:
                 print(f"[WARN] {query}: {e}")
     
-    def create_laptop_node(self, laptop_data: Dict[str, Any]) -> str:
+    def create_laptop_node(
+        self,
+        laptop_data: Dict[str, Any],
+        projection: Optional[Dict[str, Any]] = None,
+    ) -> str:
         """
         Create a complex laptop node with all components and relationships.
-        
+
+        Node-level Product properties the Cypher reader scores against
+        (``battery_life_hours``, ``good_for_*``, etc.) come from the
+        ``projection`` arg — the output of ``kg_projection.project()`` over
+        the raw identity fields + per-strategy enriched rows. The main MERGE
+        only sets identity/relationship fields here; projection is applied as
+        a second-pass ``SET l += $projection`` so tomorrow's new reader
+        reference needs only a flattening-rule edit, not a builder edit.
+
         Args:
-            laptop_data: Dictionary containing laptop information
-            
+            laptop_data: Dictionary containing laptop information (identity +
+                relationship fields: brand, CPU/GPU/RAM/Storage/Display).
+            projection: Flat dict of node properties from kg_projection.project().
+                Empty / None ⇒ node receives no enriched-derived properties
+                (safe degrade: the Cypher scorer will score 0 on them via
+                coalesce, not error).
+
         Returns:
             Product ID of created laptop
         """
         query = """
-        // Create main Laptop node
+        // Create main Laptop node. Identity + relationship SETs only —
+        // enriched-derived scoring fields (battery_life_hours, good_for_*,
+        // …) come from $projection.
         MERGE (l:Laptop:Product {product_id: $product_id})
         SET l.name = $name,
             l.brand = $brand,
@@ -96,18 +115,19 @@ class KnowledgeGraphBuilder:
             l.available = $available,
             l.weight_kg = $weight_kg,
             l.portability_score = $portability_score,
-            l.battery_life_hours = $battery_life_hours,
-            l.screen_size_inches = $screen_size_inches,
-            l.refresh_rate_hz = $refresh_rate_hz,
             l.created_at = datetime()
-        
+        // Overlay enriched-derived properties last so they win over any
+        // stale value from a prior build. $projection is always bound (empty
+        // dict when no enrichment available) so the += is valid either way.
+        SET l += $projection
+
         // Create or connect Manufacturer
         MERGE (m:Manufacturer {name: $brand})
         SET m.country = $manufacturer_country,
             m.founded_year = $manufacturer_founded,
             m.website = $manufacturer_website
         MERGE (l)-[:MANUFACTURED_BY]->(m)
-        
+
         // Create CPU node
         MERGE (cpu:CPU {model: $cpu_model})
         SET cpu.manufacturer = $cpu_manufacturer,
@@ -119,7 +139,7 @@ class KnowledgeGraphBuilder:
             cpu.generation = $cpu_generation,
             cpu.tier = $cpu_tier
         MERGE (l)-[:HAS_CPU]->(cpu)
-        
+
         // Create GPU node (if exists)
         FOREACH (ignore IN CASE WHEN $gpu_model IS NOT NULL THEN [1] ELSE [] END |
             MERGE (gpu:GPU {model: $gpu_model})
@@ -131,14 +151,14 @@ class KnowledgeGraphBuilder:
                 gpu.ray_tracing = $gpu_ray_tracing
             MERGE (l)-[:HAS_GPU]->(gpu)
         )
-        
+
         // Create RAM node
         MERGE (ram:RAM {capacity_gb: $ram_capacity, type: $ram_type})
         SET ram.speed_mhz = $ram_speed,
             ram.channels = $ram_channels,
             ram.expandable = $ram_expandable
         MERGE (l)-[:HAS_RAM]->(ram)
-        
+
         // Create Storage node
         MERGE (storage:Storage {capacity_gb: $storage_capacity, type: $storage_type})
         SET storage.interface = $storage_interface,
@@ -146,35 +166,57 @@ class KnowledgeGraphBuilder:
             storage.write_speed_mbps = $storage_write_speed,
             storage.expandable = $storage_expandable
         MERGE (l)-[:HAS_STORAGE]->(storage)
-        
-        // Create Display node
-        MERGE (display:Display {size_inches: $screen_size_inches, resolution: $display_resolution})
+
+        // Create Display node. display_size_inches falls back to the
+        // projection-supplied screen_size_inches when set; Display uniqueness
+        // is (size_inches, resolution) so a missing projection means a single
+        // "unknown-size" Display node per resolution.
+        WITH l
+        WITH l, coalesce(l.screen_size_inches, 0.0) AS _disp_size
+        MERGE (display:Display {size_inches: _disp_size, resolution: $display_resolution})
         SET display.panel_type = $display_panel_type,
-            display.refresh_rate_hz = $refresh_rate_hz,
+            display.refresh_rate_hz = coalesce(l.refresh_rate_hz, $display_refresh_rate_fallback),
             display.brightness_nits = $display_brightness,
             display.color_gamut = $display_color_gamut,
             display.touch_screen = $display_touch
         MERGE (l)-[:HAS_DISPLAY]->(display)
-        
+
         RETURN l.product_id AS product_id
         """
-        
+
+        params = dict(laptop_data)
+        params["projection"] = dict(projection or {})
+        # Display node needs a fallback refresh rate when projection doesn't
+        # carry one — keep the Display schema populated even for catalogs
+        # without parser_v1 output.
+        params.setdefault("display_refresh_rate_fallback", 60)
         with self.driver.session(database=self.database) as session:
-            result = session.run(query, laptop_data)
+            result = session.run(query, params)
             return result.single()["product_id"]
     
-    def create_book_node(self, book_data: Dict[str, Any]) -> str:
+    def create_book_node(
+        self,
+        book_data: Dict[str, Any],
+        projection: Optional[Dict[str, Any]] = None,
+    ) -> str:
         """
         Create a complex book node with author, genre, publisher relationships.
-        
+
+        Enriched-derived node properties come from ``projection`` (output of
+        ``kg_projection.project()``), overlaid as ``SET b += $projection``
+        after the main MERGE. See ``create_laptop_node`` for the rationale.
+
         Args:
-            book_data: Dictionary containing book information
-            
+            book_data: Dictionary containing book information (identity +
+                relationship fields: author, publisher, genre, themes, series).
+            projection: Flat dict of node properties from kg_projection.project().
+
         Returns:
             Product ID of created book
         """
         query = """
-        // Create main Book node
+        // Create main Book node. Enriched properties from $projection are
+        // overlaid after the identity SET.
         MERGE (b:Book:Product {product_id: $product_id})
         SET b.title = $title,
             b.name = $name,
@@ -190,6 +232,7 @@ class KnowledgeGraphBuilder:
             b.format = $format,
             b.available = $available,
             b.created_at = datetime()
+        SET b += $projection
         
         // Create or connect Author
         MERGE (a:Author {name: $author})
@@ -223,12 +266,14 @@ class KnowledgeGraphBuilder:
             SET s.total_books = $series_total_books
             MERGE (b)-[:PART_OF_SERIES {position: $series_position}]->(s)
         )
-        
+
         RETURN b.product_id AS product_id
         """
-        
+
+        params = dict(book_data)
+        params["projection"] = dict(projection or {})
         with self.driver.session(database=self.database) as session:
-            result = session.run(query, book_data)
+            result = session.run(query, params)
             return result.single()["product_id"]
     
     def create_jewelry_node(self, jewelry_data: Dict[str, Any]) -> str:

--- a/mcp-server/app/merchant_agent.py
+++ b/mcp-server/app/merchant_agent.py
@@ -259,16 +259,63 @@ class MerchantAgent:
         raw = resp.data.products if resp.data and resp.data.products else []
         products = [p for p in raw if p.product_id not in exclude_set][: query.top_k]
         n = max(len(products), 1)
+
+        # Pull per-product KG scores out of the response envelope. When
+        # KG didn't run (SQL-only hit, KG offline) or none of the returned
+        # products have a score, we fall back to the pre-#52 positional
+        # ranking and log once at INFO so the degraded path stays visible.
+        kg_scores: Dict[str, Dict[str, Any]] = (
+            (resp.data.scores or {}) if resp.data else {}
+        )
+        scored_totals = [
+            kg_scores[p.product_id]["score"]
+            for p in products
+            if p.product_id in kg_scores
+        ]
+        if scored_totals:
+            # Min-max normalize onto [0, 1] per request. Single-score batches
+            # collapse to 1.0 rather than divide-by-zero.
+            lo, hi = min(scored_totals), max(scored_totals)
+            span = hi - lo if hi > lo else 0.0
+        else:
+            lo = hi = span = 0.0
+            logger.info(
+                "merchant_search_no_kg_scores merchant=%s n=%d — falling back "
+                "to positional score (KG offline or SQL-only hit)",
+                self.merchant_id, len(products),
+            )
+
         offers: List[Offer] = []
         for i, p in enumerate(products):
-            offers.append(Offer(
-                merchant_id=self.merchant_id,
-                product_id=p.product_id,
-                score=round(1.0 - (i / n), 4),
-                score_breakdown={},
-                product=p,
-                rationale=p.reason or "",
-            ))
+            score_row = kg_scores.get(p.product_id)
+            if score_row is not None:
+                raw_total = float(score_row["score"])
+                if span > 0:
+                    normalized = (raw_total - lo) / span
+                else:
+                    normalized = 1.0
+                breakdown_terms = {
+                    k: float(v) for k, v in (score_row.get("breakdown") or {}).items()
+                }
+                breakdown_terms["raw"] = raw_total
+                offers.append(Offer(
+                    merchant_id=self.merchant_id,
+                    product_id=p.product_id,
+                    score=round(normalized, 4),
+                    score_breakdown=breakdown_terms,
+                    product=p,
+                    rationale=p.reason or "",
+                ))
+            else:
+                # Pre-#52 fallback: positional placeholder with empty breakdown.
+                offers.append(Offer(
+                    merchant_id=self.merchant_id,
+                    product_id=p.product_id,
+                    score=round(1.0 - (i / n), 4),
+                    score_breakdown={},
+                    product=p,
+                    rationale=p.reason or "",
+                ))
         return offers
 
     # ------------------------------------------------------------------

--- a/mcp-server/app/merchant_agent.py
+++ b/mcp-server/app/merchant_agent.py
@@ -65,15 +65,25 @@ _TEXT_HARVEST_SLOTS = ("subcategory", "brand", "genre", "style", "material", "co
 
 class MerchantAgent:
     """Per-merchant search agent. Scopes catalog by merchant_id and delegates
-    to the shared retrieval stack (KG → vector → SQL)."""
+    to the shared retrieval stack (KG → vector → SQL).
+
+    ``kg_strategy`` identifies the enrichment mix this agent's KG was built
+    from — one ``MerchantAgent`` ↔ one ``(merchant_id, kg_strategy)`` pair,
+    mirroring how products_enriched rows are keyed. The default of
+    ``"default_v1"`` is a pin for the pre-multi-strategy era; merchants that
+    run two strategies in parallel will need two MerchantAgent instances and
+    two KG instances (contract rule 3 of #52).
+    """
 
     def __init__(
         self,
         merchant_id: str,
         domain: str,
+        kg_strategy: str = "default_v1",
     ) -> None:
         self.merchant_id = validate_merchant_id(merchant_id)
         self.domain = domain
+        self.kg_strategy = kg_strategy
         self._catalog_table = merchant_catalog_table(self.merchant_id)
         self._enriched_table = merchant_enriched_table(self.merchant_id)
         # Per-merchant ORM models. Cached on the instance so downstream
@@ -216,6 +226,9 @@ class MerchantAgent:
 
         # --- Catalog scope --------------------------------------------
         merged_filters["merchant_id"] = self.merchant_id
+        # Thread kg_strategy through filters so endpoints.search_products can
+        # pick it up at the KG call site without a new positional arg.
+        merged_filters["_kg_strategy"] = self.kg_strategy
 
         # --- Extract exclude_ids from user_context --------------------
         _ctx = query.user_context if isinstance(query.user_context, dict) else {}

--- a/mcp-server/app/schemas.py
+++ b/mcp-server/app/schemas.py
@@ -324,6 +324,15 @@ class SearchResultsData(BaseModel):
     products: List[ProductSummary]
     total_count: int
     next_cursor: Optional[str] = None
+    # KG per-product retrieval scores and per-term breakdown. Opaque to the
+    # shopping agent — consumed by MerchantAgent.search to populate
+    # Offer.score / Offer.score_breakdown (issue #52 §4.D, replacing the
+    # positional placeholder that #34 flagged). Default None preserves the
+    # pre-#52 shape for clients that never look at scoring internals.
+    scores: Optional[Dict[str, Dict[str, Any]]] = Field(
+        None,
+        description="Per-product KG score + breakdown; internal.",
+    )
 
 
 # 

--- a/mcp-server/docs/kg_enriched_contract.md
+++ b/mcp-server/docs/kg_enriched_contract.md
@@ -1,0 +1,76 @@
+# KG ↔ products_enriched contract
+
+This doc is the shared source of truth for how the knowledge graph relates
+to enriched catalog data. Issue #52 rewrote the rules below after #51
+surfaced a silent-zero-score bug (reader asked for a property the writer
+never set; scorer fell to 0 without erroring).
+
+## The five rules
+
+1. **Direction is one-way: `products_enriched → KG`.** KG builders read
+   enriched rows; they do not re-derive features from raw title/description
+   text. Enrichment is its own pipeline under `app.enrichment` with LLM
+   agents writing per-strategy rows to `products_enriched`.
+
+2. **The Cypher scorer defines the property set.** Every `p.<name>` the
+   reader (`kg_service._build_cypher_query`) touches must be producible
+   by either: an identity field from raw `products`, a known raw attribute
+   key (`registry.KNOWN_RAW_ATTRIBUTE_KEYS`), or a flattening rule in
+   `app.kg_projection.FLATTENING_RULES` / `KEY_PATTERNS`. The offline
+   `tests/test_kg_contract.py::test_cypher_referenced_properties_are_producible`
+   asserts this; a new reader reference that isn't producible breaks that
+   test and therefore CI.
+
+3. **Per-`(merchant_id, strategy)` keying.** One KG "instance" per pair,
+   mirroring how `MerchantAgent` and `products_enriched` are keyed. In
+   Neo4j this is property-based: every `:Product` node carries
+   `merchant_id` and `kg_strategy`, uniqueness is `(product_id,
+   merchant_id, kg_strategy)`, and `search_candidates` hard-filters on
+   both. Two merchants with the same `product_id` don't collide. Two
+   strategies on the same merchant give two separate node populations.
+
+4. **Rebuild order.** `raw ingest → enrichment → KG sync → vector index`.
+   Anything upstream needs to land before anything downstream; there's no
+   partial-rebuild fast path in this contract. CI and the scheduled
+   scrape (`scripts/run_scheduled_scrape.sh`) run them in that order.
+
+5. **Identity vs derived split.** Identity fields (`product_id`, `name`,
+   `brand`, `category`, `subcategory`, `price`, `description`, `image_url`)
+   come from raw `products`; derived fields come only from
+   `products_enriched`. At read time they're joined; at write time each
+   table owns its fields — no merge semantics, no COALESCE fallback. The
+   `enriched_reader.combine_raw_and_enriched` helper asserts the disjoint-keys
+   invariant so a violating writer fails loudly.
+
+## What lives where
+
+| Artifact | Location | Notes |
+| --- | --- | --- |
+| Projection rules | `mcp-server/app/kg_projection.py` | Identity fields + per-strategy flattening rules + `project()` + `cypher_referenced_properties()` |
+| Contract drift test | `mcp-server/tests/test_kg_contract.py` | Offline; asserts reader refs are producible. Negative test covers injected drift. |
+| Cypher reader | `mcp-server/app/kg_service.py` | `_build_cypher_query` + `search_candidates`. Threshold and tenancy bind via parameters. |
+| Cypher writer | `mcp-server/app/knowledge_graph.py` | `create_laptop_node` / `create_book_node` consume `projection` + `(merchant_id, kg_strategy)` kwargs. |
+| Orchestrator | `mcp-server/scripts/build_knowledge_graph.py` | `--merchant-id` + `--strategy` flags. Batches enriched via `hydrate_batch`. |
+| Score plumbing | `mcp-server/app/merchant_agent.py` | Min-max normalizes KG scores onto `Offer.score`; per-term breakdown on `Offer.score_breakdown`. |
+
+## Adding a new enrichment strategy that contributes KG properties
+
+1. Register the agent in `app.enrichment`. Declare `OUTPUT_KEYS`.
+2. Add a flattening-rule function to `FLATTENING_RULES` in
+   `app/kg_projection.py` that turns the strategy's `attributes` dict into
+   flat `{node_prop: value}` pairs. Keep it strategy-local; don't reach
+   into other strategies' outputs.
+3. If the property names are open-vocab (like `good_for_*`), extend
+   `KEY_PATTERNS` so the drift test covers them.
+4. Update `_PROJECTION_STRATEGIES` in `scripts/build_knowledge_graph.py`
+   if the orchestrator should feed this strategy's rows into `project()`.
+
+## Related tracked issues
+
+- **#52** — this contract.
+- **#60** — LLM confidence scores in `soft_tagger_v1` are uncalibrated.
+  Threshold lives in `TAG_CONFIDENCE_THRESHOLD`; revisit when calibration
+  data lands.
+- **#61** — decide whether `backfill_kg_features.py`'s regex heuristic
+  logic migrates into a new enrichment strategy.
+- **#38** — long-term per-schema-per-merchant storage direction (tentative).

--- a/mcp-server/scripts/backfill_kg_features.py
+++ b/mcp-server/scripts/backfill_kg_features.py
@@ -1,205 +1,47 @@
 #!/usr/bin/env python3
 """
-Backfill kg_features (PostgreSQL) for richer KG (§7).
+DEPRECATED — retired under issue #52.
 
-Sets Reddit-style features from existing product data (per week6tips: 30+ features).
-Features inferred:
-- good_for_ml, good_for_gaming, good_for_web_dev, good_for_creative
-- good_for_linux, good_for_programming, repairable, refurbished
-- battery_life_hours, ram_gb, storage_gb, screen_size_inches, year
-- keyboard_quality (tiered: excellent/good based on context)
+This script used to regex-scan ``products.name`` / ``products.description``
+for use-case hints (good_for_gaming, good_for_ml, battery_life_hours, …)
+and write them back into ``products.attributes.kg_features``. Two problems
+the #52 contract rewrite surfaces:
 
-Run from mcp-server: python scripts/backfill_kg_features.py
+1. It writes to ``products``, which is now the immutable golden catalog —
+   no INSERT/UPDATE allowed without explicit user approval.
+2. The direction is backward. The KG contract is
+   ``products_enriched → KG``; enrichment lives in ``app.enrichment`` and
+   writes per-strategy rows to ``products_enriched`` keyed by
+   ``(merchant_id, strategy)``.
+
+Whether any of the original regex/source-heuristic logic should migrate
+into the pipeline (e.g. as a cheap rule-based ``heuristic_v1`` strategy
+that runs before LLM enrichment) is tracked in issue #61.
+
+Shim intentionally prints + exits 1 so any remaining caller surfaces this
+retirement in its logs instead of silently no-op-ing.
 """
-import os
-import re
+
 import sys
 
-# Add parent so app is importable
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from app.database import SessionLocal
-from app.models import Product
-
-
-def parse_battery_hours(description: str | None, name: str | None) -> int | None:
-    """Try to extract battery life in hours from text. Returns None if not found."""
-    text = f" {(description or '')} {(name or '')} ".lower()
-    # e.g. "10 hour battery", "up to 12 hours", "8hr"
-    m = re.search(r"(?:up to |about |approx\.? )?(\d+)\s*(?:hour|hr)s?", text)
-    if m:
-        return int(m.group(1))
-    m = re.search(r"battery[^\d]*(\d+)\s*(?:hour|hr)", text)
-    if m:
-        return int(m.group(1))
-    return None
+_MESSAGE = (
+    "backfill_kg_features.py has been retired under issue #52.\n"
+    "\n"
+    "Enrichment now runs via app.enrichment (taxonomy_v1 → parser_v1 →\n"
+    "specialist_v1 → soft_tagger_v1) and writes to products_enriched\n"
+    "under per-strategy rows. The KG builder consumes those rows via\n"
+    "app.kg_projection; the direction is one-way (enriched → KG).\n"
+    "\n"
+    "If you need the old script's output, see issue #61 for the decision\n"
+    "on whether the regex/source-heuristic logic migrates into the pipeline.\n"
+)
 
 
-def parse_ram_gb(text: str) -> int | None:
-    """Extract RAM in GB from text. e.g. '16GB RAM', '32 GB', '64gb'."""
-    m = re.search(r"(\d+)\s*(?:gb|gigabytes?)\s*(?:ram|ddr|memory)?", text, re.I)
-    if m:
-        gb = int(m.group(1))
-        if 4 <= gb <= 256:
-            return gb
-    return None
-
-
-def parse_storage_gb(text: str) -> int | None:
-    """Extract storage in GB from text. e.g. '512GB SSD', '1TB', '256 GB'."""
-    m = re.search(r"(\d+)\s*(?:tb|terabytes?)", text, re.I)
-    if m:
-        return int(m.group(1)) * 1024
-    m = re.search(r"(\d+)\s*(?:gb|gigabytes?)\s*(?:ssd|nvme|storage)?", text, re.I)
-    if m:
-        gb = int(m.group(1))
-        if 64 <= gb <= 8192:
-            return gb
-    return None
-
-
-def parse_screen_inches(text: str) -> float | None:
-    """Extract screen size in inches. e.g. '15.6"', '16 inch', '14 inch'."""
-    m = re.search(r"(\d+(?:\.\d+)?)\s*(?: inch|in\.?|[\"'])", text, re.I)
-    if m:
-        n = float(m.group(1))
-        if 10 <= n <= 24:
-            return n
-    m = re.search(r"(\d+(?:\.\d+)?)\s*inch", text, re.I)
-    if m:
-        return float(m.group(1))
-    return None
-
-
-def parse_year(text: str) -> int | None:
-    """Extract product/model year. e.g. '2024 model', 'Laptop (2023)', 'MacBook Pro 2024'."""
-    # Pattern: standalone year like "(2024)", "2023 laptop", "laptop 2024"
-    m = re.search(r"\b(20[12]\d)\b", text)
-    if m:
-        year = int(m.group(1))
-        if 2015 <= year <= 2026:
-            return year
-    return None
-
-
-def build_kg_features(product: Product) -> dict | None:
-    """Build kg_features dict for a product from existing fields (30+ features per week6tips)."""
-    features: dict = {}
-    name = (product.name or "").lower()
-    desc = (product.description or "").lower()
-    sub = (product.subcategory or "").lower()
-    tags = product.tags or []
-    tag_str = " ".join(t.lower() for t in tags if isinstance(t, str))
-    combined = f" {name} {desc} {tag_str} {sub} "
-    source = (product.source or "").lower()
-    scraped_url = (product.scraped_from_url or "").lower()
-
-    # good_for_gaming
-    if "gaming" in sub or "gaming" in combined or "gaming_laptop" == (product.product_type or ""):
-        features["good_for_gaming"] = True
-    # good_for_ml: NVIDIA/AMD GPU, 32GB+ RAM, ML/AI keywords, CUDA, data science
-    if any(x in combined for x in [
-        "nvidia", "rtx", "gtx", "32gb", "64gb", "128gb",
-        "machine learning", "deep learning", "ml ", " ai ",
-        "cuda", "tensor", "data science", "jupyter", "pytorch", "tensorflow",
-        "instinct", "intel arc", "a100", "h100", "v100",
-    ]):
-        features["good_for_ml"] = True
-    # good_for_web_dev: actual web dev tools/frameworks (tightened from broad "work")
-    if any(x in combined for x in [
-        "web dev", "web development", "frontend", "fullstack", "full-stack",
-        "react", "node", "angular", "vue", "figma", "webflow", "xano",
-    ]) or "work" in sub or "school" in sub:
-        features["good_for_web_dev"] = True
-    # good_for_programming: general coding/IDE/language mentions
-    if any(x in combined for x in [
-        "programming", "developer", "coding", "software development",
-        "ide", "compiler", "debug", "python", "java ", "c++", "rust",
-        "vscode", "pycharm", "intellij", "vim", "emacs",
-    ]):
-        features["good_for_programming"] = True
-    # good_for_creative: video, photo, creative, 3D
-    if "creative" in sub or any(x in combined for x in [
-        "video", "photo", "editing", "3d modeling", "blender",
-        "photoshop", "premiere", "davinci", "autocad",
-    ]):
-        features["good_for_creative"] = True
-
-    # good_for_linux: System76, Framework, Pop!_OS, Linux
-    if "system76" in source or "framework" in source or "linux" in combined or "pop!_os" in combined or "pop os" in combined:
-        features["good_for_linux"] = True
-
-    # repairable: Framework, Fairphone
-    if "framework" in source or "fairphone" in source or "repairable" in combined or "modular" in combined:
-        features["repairable"] = True
-
-    # refurbished: Back Market, refurbished in text
-    if "back market" in source or "backmarket" in source or "refurbished" in combined:
-        features["refurbished"] = True
-
-    # keyboard_quality: tiered based on context
-    if any(x in combined for x in ["thinkpad", "mechanical keyboard", "travel keyboard", "excellent keyboard"]):
-        features["keyboard_quality"] = "excellent"
-    elif "keyboard" in combined or "typing" in combined or "backlit" in combined:
-        features["keyboard_quality"] = "good"
-
-    # battery_life_hours
-    hours = parse_battery_hours(product.description, product.name)
-    if hours is not None:
-        features["battery_life_hours"] = hours
-    elif product.category == "Electronics" and (product.product_type or "").lower() in ("laptop", "gaming_laptop", ""):
-        features["battery_life_hours"] = 8
-
-    # ram_gb, storage_gb, screen_size_inches (parse from text)
-    ram = parse_ram_gb(combined)
-    if ram is not None:
-        features["ram_gb"] = ram
-    storage = parse_storage_gb(combined)
-    if storage is not None:
-        features["storage_gb"] = storage
-    screen = parse_screen_inches(combined)
-    if screen is not None:
-        features["screen_size_inches"] = screen
-
-    # year (model/release year)
-    year = parse_year(combined)
-    if year is not None:
-        features["year"] = year
-
-    # Phones: battery_life_hours fallback
-    if product.category == "Electronics" and (product.product_type or "").lower() in ("phone", "smartphone"):
-        if "battery_life_hours" not in features:
-            features["battery_life_hours"] = 12  # typical phone
-
-    if not features:
-        return None
-    return features
-
-
-def main():
-    db = SessionLocal()
-    try:
-        products = db.query(Product).all()
-    except Exception as e:
-        if "kg_features" in str(e) or "UndefinedColumn" in str(e):
-            print("The products.kg_features column is missing. Run the migration first:")
-            print("  PostgreSQL: psql <your_db> -f scripts/add_kg_features_column.sql")
-            print("  Or ensure tables are created from the current models (e.g. create_all).")
-        else:
-            raise
-        return
-    try:
-        updated = 0
-        for p in products:
-            kg = build_kg_features(p)
-            if kg:
-                p.kg_features = kg
-                updated += 1
-        db.commit()
-        print(f"Backfilled kg_features for {updated} / {len(products)} products.")
-    finally:
-        db.close()
+def main() -> int:
+    sys.stderr.write(_MESSAGE)
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/mcp-server/scripts/build_knowledge_graph.py
+++ b/mcp-server/scripts/build_knowledge_graph.py
@@ -320,6 +320,17 @@ def main():
     import argparse
     parser = argparse.ArgumentParser(description="Build Neo4j knowledge graph from PostgreSQL")
     parser.add_argument("--clear", action="store_true", help="Clear Neo4j before building (use after populate_real_only_db)")
+    parser.add_argument(
+        "--merchant-id",
+        default="default",
+        help="Merchant scope to build nodes under (mirrors products_enriched.merchant_id). Default: 'default'.",
+    )
+    parser.add_argument(
+        "--strategy",
+        default="default_v1",
+        dest="kg_strategy",
+        help="KG strategy label that identifies which enrichment mix the KG was built from. Default: 'default_v1'.",
+    )
     args = parser.parse_args()
 
     print("="*80)
@@ -394,7 +405,12 @@ def main():
 
             # Create node (projection carries enriched-derived node properties)
             projection = laptop_projections.get(laptop.product_id, {})
-            product_id = builder.create_laptop_node(laptop_data, projection=projection)
+            product_id = builder.create_laptop_node(
+                laptop_data,
+                projection=projection,
+                merchant_id=args.merchant_id,
+                kg_strategy=args.kg_strategy,
+            )
             laptop_ids.append(product_id)
             
             # Add software compatibility
@@ -426,7 +442,12 @@ def main():
 
             # Create node (projection carries enriched-derived node properties)
             projection = book_projections.get(book.product_id, {})
-            product_id = builder.create_book_node(book_data, projection=projection)
+            product_id = builder.create_book_node(
+                book_data,
+                projection=projection,
+                merchant_id=args.merchant_id,
+                kg_strategy=args.kg_strategy,
+            )
             book_ids.append(product_id)
             
             if i % 10 == 0:

--- a/mcp-server/scripts/build_knowledge_graph.py
+++ b/mcp-server/scripts/build_knowledge_graph.py
@@ -26,6 +26,8 @@ except Exception:
     pass
 
 from app.database import SessionLocal
+from app.enriched_reader import hydrate_batch
+from app.kg_projection import project as kg_project
 from app.models import Product, Price, Inventory
 from app.neo4j_config import Neo4jConnection
 from app.knowledge_graph import KnowledgeGraphBuilder
@@ -33,6 +35,10 @@ import json
 import random
 from datetime import datetime, timedelta
 import uuid
+
+# Enrichment strategies the KG builder flattens onto :Product nodes.
+# Order is irrelevant — the flattening-rule registry keys on strategy name.
+_PROJECTION_STRATEGIES: tuple[str, ...] = ("soft_tagger_v1", "parser_v1")
 
 
 # Sample data for enrichment
@@ -80,7 +86,15 @@ SOFTWARE_CATALOG = [
 
 
 def extract_laptop_specs(product: Product) -> dict:
-    """Extract detailed laptop specifications from metadata."""
+    """Extract detailed laptop specifications from metadata.
+
+    Node-scoring fields (``battery_life_hours``, ``screen_size_inches``,
+    ``refresh_rate_hz``) are intentionally NOT populated here — they come
+    from the projection dict built via ``kg_projection.project`` over
+    ``products_enriched``. Legacy random generators for those fields were
+    the root cause of #51: values that had nothing to do with the actual
+    product, which the scorer then trusted.
+    """
     specs = {
         "product_id": product.product_id,
         "name": product.name,
@@ -91,12 +105,11 @@ def extract_laptop_specs(product: Product) -> dict:
         "image_url": product.image_url or "",
         "subcategory": product.subcategory or "General",
         "available": True,
+        # Non-projection orthogonal fields retain random placeholders until a
+        # strategy starts emitting them.
         "weight_kg": round(random.uniform(1.2, 3.5), 2),
         "portability_score": random.randint(60, 95),
-        "battery_life_hours": random.randint(4, 15),
-        "screen_size_inches": random.choice([13.3, 14.0, 15.6, 16.0, 17.3]),
-        "refresh_rate_hz": random.choice([60, 120, 144, 165, 240]),
-        
+
         # Manufacturer
         "manufacturer_country": LAPTOP_MANUFACTURERS.get(product.brand, {}).get("country", "Unknown"),
         "manufacturer_founded": LAPTOP_MANUFACTURERS.get(product.brand, {}).get("founded"),
@@ -269,6 +282,39 @@ def extract_book_metadata(product: Product) -> dict:
     return metadata
 
 
+def _build_enriched_projection_map(
+    db, products: list, strategies: tuple[str, ...] = _PROJECTION_STRATEGIES
+) -> dict:
+    """Return ``{product_id: projection_dict}`` for ``products``.
+
+    Batch-fetches enriched rows per strategy via ``hydrate_batch`` and feeds
+    them through ``kg_projection.project()`` so the builder can apply a
+    single ``SET n += $projection`` per node. Products with no enriched rows
+    get an empty projection — the builder treats that as "no enriched-derived
+    properties on this node", which degrades to zero-score scoring rather
+    than erroring (issue #52, contract rule 2).
+    """
+    if not products:
+        return {}
+    product_ids = [p.product_id for p in products]
+    enriched_by_strategy: dict[str, dict] = {
+        strategy: hydrate_batch(db, product_ids, strategy) for strategy in strategies
+    }
+    out: dict = {}
+    for p in products:
+        pid = p.product_id
+        per_strategy_attrs = {
+            strategy: enriched_by_strategy[strategy].get(pid, {})
+            for strategy in strategies
+        }
+        # Identity side intentionally left minimal — the laptop/book MERGE
+        # still sets name/brand/price/etc. from the original data dict. The
+        # projection path is reserved for enriched-derived keys so it never
+        # clobbers identity-side writes.
+        out[pid] = kg_project(raw_identity={}, enriched_by_strategy=per_strategy_attrs)
+    return out
+
+
 def main():
     """Build the complete knowledge graph."""
     import argparse
@@ -321,6 +367,18 @@ def main():
     builder.create_genre_hierarchy(GENRE_HIERARCHY)
     print(f" Created {len(GENRE_HIERARCHY)} genres")
     
+    # Fetch enriched rows and build per-product projection dicts once per
+    # batch — builder applies them with a single SET per node.
+    print("\n4b. Fetching enriched rows and building projections...")
+    laptop_projections = _build_enriched_projection_map(pg_db, laptops[:50])
+    book_projections = _build_enriched_projection_map(pg_db, books[:50])
+    n_laptop_with_proj = sum(1 for v in laptop_projections.values() if v)
+    n_book_with_proj = sum(1 for v in book_projections.values() if v)
+    print(
+        f"   {n_laptop_with_proj}/{len(laptop_projections)} laptops and "
+        f"{n_book_with_proj}/{len(book_projections)} books have enriched projections"
+    )
+
     # Process laptops
     print("\n5. Processing laptops...")
     laptop_ids = []
@@ -329,13 +387,14 @@ def main():
             # Get price
             price_obj = pg_db.query(Price).filter(Price.product_id == laptop.product_id).first()
             price = price_obj.price_cents / 100 if price_obj else 999.99
-            
+
             # Extract specs
             laptop_data = extract_laptop_specs(laptop)
             laptop_data["price"] = price
-            
-            # Create node
-            product_id = builder.create_laptop_node(laptop_data)
+
+            # Create node (projection carries enriched-derived node properties)
+            projection = laptop_projections.get(laptop.product_id, {})
+            product_id = builder.create_laptop_node(laptop_data, projection=projection)
             laptop_ids.append(product_id)
             
             # Add software compatibility
@@ -364,9 +423,10 @@ def main():
             # Extract metadata
             book_data = extract_book_metadata(book)
             book_data["price"] = price
-            
-            # Create node
-            product_id = builder.create_book_node(book_data)
+
+            # Create node (projection carries enriched-derived node properties)
+            projection = book_projections.get(book.product_id, {})
+            product_id = builder.create_book_node(book_data, projection=projection)
             book_ids.append(product_id)
             
             if i % 10 == 0:

--- a/mcp-server/scripts/run_scheduled_scrape.sh
+++ b/mcp-server/scripts/run_scheduled_scrape.sh
@@ -26,8 +26,11 @@ fi
 # 1. Populate real-only DB (--full = books + Selenium for blocked sites)
 python scripts/populate_real_only_db.py --full
 
-# 2. Backfill kg_features
-python scripts/backfill_kg_features.py
+# 2. (Removed) backfill_kg_features.py was retired under issue #52 — the KG
+#    now consumes products_enriched instead of deriving features from raw
+#    text. Whether the legacy heuristic logic migrates into the enrichment
+#    pipeline is tracked in issue #61. Until that lands, enriched rows for
+#    this refresh must come from a separate run_enrichment invocation.
 
 # 3. Rebuild Neo4j knowledge graph (optional; comment out if not using Neo4j)
 if command -v python &>/dev/null; then

--- a/mcp-server/tests/test_kg_contract.py
+++ b/mcp-server/tests/test_kg_contract.py
@@ -1,0 +1,143 @@
+"""Contract drift test for the KG projection.
+
+The Cypher reader in ``app.kg_service._build_cypher_query`` references
+:Product node properties (``p.brand``, ``p.good_for_ml``, etc.). Every one
+of those must be producible by either:
+
+  1. An identity field from the raw ``products`` row (``IDENTITY_FIELDS``),
+  2. A known raw-attribute key (``registry.KNOWN_RAW_ATTRIBUTE_KEYS``),
+  3. A flattening rule for a registered strategy (exact match via
+     ``FLATTENING_RULES`` output, or pattern match via ``KEY_PATTERNS``), or
+  4. A system-owned property (``READER_SYSTEM_PROPERTIES``).
+
+If a reader reference is unsatisfied, the scorer silently falls to 0 — this
+is the class of bug that #51 was. The test is offline (no Neo4j required).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from app.enrichment.registry import KNOWN_RAW_ATTRIBUTE_KEYS
+from app.kg_projection import (
+    FLATTENING_RULES,
+    IDENTITY_FIELDS,
+    KEY_PATTERNS,
+    READER_SYSTEM_PROPERTIES,
+    RESERVED_BOOL_FEATURES,
+    cypher_referenced_properties,
+)
+
+
+def _static_produceable_keys() -> set[str]:
+    """Keys we can enumerate up front: identity fields, known raw attributes,
+    system-owned reader properties, reserved boolean features awaiting #61,
+    plus any fixed keys emitted by a rule (we probe each rule with a shaped
+    dummy input)."""
+    keys: set[str] = (
+        set(IDENTITY_FIELDS)
+        | set(KNOWN_RAW_ATTRIBUTE_KEYS)
+        | set(READER_SYSTEM_PROPERTIES)
+        | set(RESERVED_BOOL_FEATURES)
+    )
+    # Probe each rule with a shaped dummy so any *static* keys the rule
+    # always emits get included. Open-vocab rules return nothing here — they
+    # must be matched via KEY_PATTERNS.
+    for _strategy, rule in FLATTENING_RULES.items():
+        try:
+            keys.update(rule({}))
+        except Exception:  # noqa: BLE001 — empty-input rule is best-effort
+            pass
+    return keys
+
+
+def _matches_pattern(prop: str) -> bool:
+    return any(pat.regex.match(prop) for pat in KEY_PATTERNS)
+
+
+def test_cypher_referenced_properties_are_producible():
+    """Every ``p.<name>`` the Cypher reader touches must be producible via
+    identity fields, known raw attrs, a flattening rule, or a pattern."""
+    referenced = cypher_referenced_properties()
+    assert referenced, (
+        "cypher_referenced_properties() returned empty — the static scan "
+        "should find at least p.category / p.brand / p.price in the reader."
+    )
+    static_ok = _static_produceable_keys()
+    unsatisfied = {
+        prop
+        for prop in referenced
+        if prop not in static_ok and not _matches_pattern(prop)
+    }
+    assert not unsatisfied, (
+        "Cypher reader references properties with no producer. Either add "
+        "a flattening rule / identity field, or extend KEY_PATTERNS if the "
+        "keys are open-vocab. Unsatisfied: " + repr(sorted(unsatisfied))
+    )
+
+
+def test_drift_detected_when_reader_references_unknown_property():
+    """Negative test: inject a fake ``p.nonexistent_prop`` reference and
+    confirm the drift check flags it."""
+    bogus_source = """
+    def _build_cypher_query(self, *args, **kwargs):
+        return "MATCH (p:Product) WHERE p.nonexistent_prop = 1 RETURN p"
+    """
+    refs = cypher_referenced_properties(source=bogus_source)
+    assert "nonexistent_prop" in refs
+    static_ok = _static_produceable_keys()
+    unsatisfied = {
+        prop
+        for prop in refs
+        if prop not in static_ok and not _matches_pattern(prop)
+    }
+    assert "nonexistent_prop" in unsatisfied, (
+        "Drift helper should flag p.nonexistent_prop as unsatisfied; "
+        f"instead got unsatisfied={sorted(unsatisfied)}"
+    )
+
+
+def test_flattening_rules_emit_declared_shape():
+    """soft_tagger_v1 rule turns good_for_tags dict into top-level props."""
+    rule = FLATTENING_RULES["soft_tagger_v1"]
+    out = rule({"good_for_tags": {"good_for_ml": 0.9, "good_for_gaming": 0.3}})
+    assert out == {"good_for_ml": 0.9, "good_for_gaming": 0.3}
+    # Non-tag keys are dropped
+    out_filtered = rule({"good_for_tags": {"not_a_good_for": 1.0, "good_for_ml": 0.5}})
+    assert out_filtered == {"good_for_ml": 0.5}
+    # Bad shape → empty
+    assert rule({"good_for_tags": "not a dict"}) == {}
+    assert rule({}) == {}
+
+
+def test_parser_rule_flattens_scalar_specs():
+    """parser_v1 rule flattens parsed_specs scalars onto the node."""
+    rule = FLATTENING_RULES["parser_v1"]
+    out = rule(
+        {
+            "parsed_specs": {
+                "ram_gb": 16,
+                "battery_life_hours": 10,
+                "dropped_nested": {"not": "scalar"},
+                "dropped_list": [1, 2, 3],
+                "kept_string": "foo",
+            }
+        }
+    )
+    assert out == {"ram_gb": 16, "battery_life_hours": 10, "kept_string": "foo"}
+    assert rule({}) == {}
+
+
+def test_good_for_pattern_covers_open_vocabulary():
+    """KEY_PATTERNS should match any snake_case ``good_for_*`` key."""
+    good = ["good_for_ml", "good_for_gaming", "good_for_baby_food", "good_for_linux"]
+    for key in good:
+        assert _matches_pattern(key), f"expected pattern match for {key!r}"
+    # Non-good_for_ keys do not match a pattern — drift detection relies on
+    # KNOWN_RAW_ATTRIBUTE_KEYS for parser-produced specs.
+    assert not _matches_pattern("ram_gb")
+    assert not _matches_pattern("nonexistent_prop")
+    # Uppercase fails (Cypher props are lowercase snake_case by convention)
+    assert not _matches_pattern("GOOD_FOR_ML")

--- a/mcp-server/tests/test_kg_live_regression.py
+++ b/mcp-server/tests/test_kg_live_regression.py
@@ -1,0 +1,182 @@
+"""Live-Neo4j tests for the #52 KG contract.
+
+Two scenarios:
+  - KG ranking regression for #51: products with higher good_for_ml
+    confidence rank above those without.
+  - Per-pair KG isolation: queries scoped to one (merchant_id, strategy)
+    pair don't leak nodes from another pair.
+
+Both require a running Neo4j and seed data they own. Skip-gated on the
+same NEO4J_ENV_READY flag used by test_kg_service.py — no harness, no
+fancy fixture — we clean up our own seeded rows in a ``finally`` block.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from app.kg_service import KnowledgeGraphService, NEO4J_AVAILABLE
+
+
+NEO4J_ENV_READY = all(
+    os.getenv(key) for key in ("NEO4J_URI", "NEO4J_USER", "NEO4J_PASSWORD")
+)
+
+
+@pytest.fixture
+def kg_service():
+    svc = KnowledgeGraphService(
+        uri=os.getenv("NEO4J_URI", "bolt://localhost:7687"),
+        user=os.getenv("NEO4J_USER", "neo4j"),
+        password=os.getenv("NEO4J_PASSWORD"),
+    )
+    yield svc
+    svc.close()
+
+
+def _seed_product(
+    svc: KnowledgeGraphService,
+    *,
+    product_id: str,
+    merchant_id: str,
+    kg_strategy: str,
+    category: str = "Electronics",
+    good_for: dict[str, float] | None = None,
+    extra_props: dict | None = None,
+) -> None:
+    """Create one :Product node with the given tenant scope and tag floats."""
+    props = {
+        "product_id": product_id,
+        "merchant_id": merchant_id,
+        "kg_strategy": kg_strategy,
+        "category": category,
+        "name": f"Seeded {product_id}",
+        "description": "test seed",
+        "price": 1000.0,
+        "brand": "TestBrand",
+    }
+    if good_for:
+        props.update(good_for)
+    if extra_props:
+        props.update(extra_props)
+    with svc.driver.session() as session:
+        session.run(
+            "CREATE (p:Product) SET p = $props",
+            props=props,
+        )
+
+
+def _cleanup_seeded(svc: KnowledgeGraphService, product_ids: list[str]) -> None:
+    if not product_ids:
+        return
+    with svc.driver.session() as session:
+        session.run(
+            "MATCH (p:Product) WHERE p.product_id IN $ids DETACH DELETE p",
+            ids=product_ids,
+        )
+
+
+@pytest.mark.skipif(not NEO4J_AVAILABLE, reason="neo4j driver not installed")
+@pytest.mark.skipif(not NEO4J_ENV_READY, reason="Neo4j env vars not configured")
+def test_good_for_ml_float_ranks_high_confidence_product_first(kg_service):
+    """#51 regression: product with good_for_ml=0.9 must rank above one
+    with good_for_ml=0.1 when the user filters for ML. Pre-#52 the
+    scorer compared floats to literal ``true`` and both scored zero."""
+    if not kg_service.is_available():
+        pytest.skip("Neo4j not reachable")
+
+    mid = "test_pair_ml"
+    strat = f"strat_{uuid.uuid4().hex[:8]}"
+    hi_pid = f"hi_{uuid.uuid4().hex[:8]}"
+    lo_pid = f"lo_{uuid.uuid4().hex[:8]}"
+    seeded = [hi_pid, lo_pid]
+
+    try:
+        _seed_product(
+            kg_service,
+            product_id=hi_pid, merchant_id=mid, kg_strategy=strat,
+            good_for={"good_for_ml": 0.9},
+        )
+        _seed_product(
+            kg_service,
+            product_id=lo_pid, merchant_id=mid, kg_strategy=strat,
+            good_for={"good_for_ml": 0.1},
+        )
+
+        ids, scores, _ = kg_service.search_candidates(
+            query="ml laptop",
+            filters={"category": "Electronics", "good_for_ml": True},
+            limit=10,
+            merchant_id=mid,
+            kg_strategy=strat,
+        )
+
+        assert hi_pid in ids, f"high-confidence product missing from results: {ids}"
+        assert lo_pid not in ids[: ids.index(hi_pid)], (
+            f"low-confidence product outranked high-confidence; order={ids}"
+        )
+        if lo_pid in ids:
+            assert scores[hi_pid]["score"] > scores[lo_pid]["score"], (
+                f"hi score {scores[hi_pid]['score']} not > lo {scores[lo_pid]['score']}"
+            )
+    finally:
+        _cleanup_seeded(kg_service, seeded)
+
+
+@pytest.mark.skipif(not NEO4J_AVAILABLE, reason="neo4j driver not installed")
+@pytest.mark.skipif(not NEO4J_ENV_READY, reason="Neo4j env vars not configured")
+def test_per_pair_tenancy_isolates_results(kg_service):
+    """A query scoped to (m1, strat_a) must not see nodes created under
+    (m2, strat_b) — the contract rule 3 from #52."""
+    if not kg_service.is_available():
+        pytest.skip("Neo4j not reachable")
+
+    mid_a = "m1_test"
+    mid_b = "m2_test"
+    strat_a = f"strat_a_{uuid.uuid4().hex[:6]}"
+    strat_b = f"strat_b_{uuid.uuid4().hex[:6]}"
+    pid_a = f"a_{uuid.uuid4().hex[:8]}"
+    pid_b = f"b_{uuid.uuid4().hex[:8]}"
+    seeded = [pid_a, pid_b]
+
+    try:
+        _seed_product(
+            kg_service,
+            product_id=pid_a, merchant_id=mid_a, kg_strategy=strat_a,
+            good_for={"good_for_ml": 0.8},
+        )
+        _seed_product(
+            kg_service,
+            product_id=pid_b, merchant_id=mid_b, kg_strategy=strat_b,
+            good_for={"good_for_ml": 0.8},
+        )
+
+        ids_a, _scores_a, _ = kg_service.search_candidates(
+            query="laptop",
+            filters={"category": "Electronics"},
+            limit=50,
+            merchant_id=mid_a,
+            kg_strategy=strat_a,
+        )
+        assert pid_a in ids_a, f"own-tenant product missing: {ids_a}"
+        assert pid_b not in ids_a, (
+            f"tenant leak: pid_b ({mid_b},{strat_b}) in {mid_a}'s results {ids_a}"
+        )
+
+        # Mirror: scoping to (m2, strat_b) sees only m2's product.
+        ids_b, _scores_b, _ = kg_service.search_candidates(
+            query="laptop",
+            filters={"category": "Electronics"},
+            limit=50,
+            merchant_id=mid_b,
+            kg_strategy=strat_b,
+        )
+        assert pid_b in ids_b
+        assert pid_a not in ids_b, (
+            f"tenant leak: pid_a ({mid_a},{strat_a}) in {mid_b}'s results {ids_b}"
+        )
+    finally:
+        _cleanup_seeded(kg_service, seeded)

--- a/mcp-server/tests/test_kg_service.py
+++ b/mcp-server/tests/test_kg_service.py
@@ -80,7 +80,8 @@ def test_build_cypher_query_soft_constraints_become_case_when():
         limit=10,
     )
     # Soft: use-case flag is a CASE WHEN, not a hard WHERE condition
-    assert "CASE WHEN p.good_for_gaming" in cypher
+    assert "CASE WHEN coalesce(p.good_for_gaming" in cypher
+    assert "$tag_threshold" in cypher
     # Hard WHERE should NOT contain the use-case flag as a bare condition
     where_part = cypher.split("WHERE")[1].split("WITH")[0] if "WITH" in cypher else cypher
     assert "p.good_for_gaming = true" not in where_part

--- a/mcp-server/tests/test_kg_service.py
+++ b/mcp-server/tests/test_kg_service.py
@@ -42,8 +42,9 @@ def test_kg_unavailable_returns_empty_lists():
     assert svc.get_better_than("any-id") == []
     assert svc.get_diverse_alternatives(["any-id"]) == []
     assert svc.get_compatible_components("any-id") == []
-    ids, explanation = svc.search_candidates("gaming laptop", {})
+    ids, scores, explanation = svc.search_candidates("gaming laptop", {})
     assert ids == []
+    assert scores == {}
     assert isinstance(explanation, dict)
     svc.close()
 
@@ -223,13 +224,14 @@ def test_kg_connection_available():
 @pytest.mark.skipif(not NEO4J_AVAILABLE, reason="neo4j driver not installed")
 @pytest.mark.skipif(not NEO4J_ENV_READY, reason="Neo4j env vars not configured")
 def test_kg_search_candidates_returns_list():
-    """Basic KG search should return list output and explanation dict."""
+    """Basic KG search should return list output, scores dict, and explanation."""
     service = _make_service()
     try:
-        product_ids, explanation = service.search_candidates(
+        product_ids, scores, explanation = service.search_candidates(
             "gaming laptop", {"category": "Electronics"}, limit=5
         )
         assert isinstance(product_ids, list)
+        assert isinstance(scores, dict)
         assert isinstance(explanation, dict)
     finally:
         service.close()
@@ -272,7 +274,7 @@ def test_kg_soft_constraint_search_returns_results():
         # Searching with good_for_gaming as a soft constraint.
         # Even if no product has good_for_gaming=true, we should still get results
         # because it's now a CASE WHEN score, not a hard WHERE filter.
-        ids, _ = service.search_candidates(
+        ids, _scores, _explanation = service.search_candidates(
             query="laptop",
             filters={"category": "Electronics", "good_for_gaming": True},
             limit=5,

--- a/mcp-server/tests/test_offer_score_breakdown.py
+++ b/mcp-server/tests/test_offer_score_breakdown.py
@@ -1,0 +1,136 @@
+"""Unit test: MerchantAgent.search populates Offer.score_breakdown from
+the KG scores returned in SearchResultsData.
+
+Offline — no Neo4j, no Postgres. We stub search_products so we can assert
+the MerchantAgent's plumbing in isolation (issue #52 §4.D, closing #34).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from app.contract import StructuredQuery
+from app.merchant_agent import MerchantAgent
+from app.schemas import (
+    ProductSummary,
+    ResponseStatus,
+    RequestTrace,
+    SearchProductsResponse,
+    SearchResultsData,
+    VersionInfo,
+)
+
+
+def _make_summary(pid: str, price_cents: int = 10000) -> ProductSummary:
+    return ProductSummary(
+        product_id=pid,
+        name=f"Product {pid}",
+        price_cents=price_cents,
+        currency="USD",
+        available_qty=1,
+    )
+
+
+def _fake_response(products: List[ProductSummary], scores: Dict[str, Any]) -> SearchProductsResponse:
+    from datetime import datetime, timezone
+    return SearchProductsResponse(
+        status=ResponseStatus.OK,
+        data=SearchResultsData(
+            products=products,
+            total_count=len(products),
+            next_cursor=None,
+            scores=scores or None,
+        ),
+        constraints=[],
+        trace=RequestTrace(
+            request_id="unit-test",
+            cache_hit=False,
+            timings_ms={"total": 1.0},
+            sources=["unit-test"],
+        ),
+        version=VersionInfo(
+            catalog_version="test",
+            updated_at=datetime.now(timezone.utc),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_offer_score_breakdown_populated_when_kg_scores_present():
+    """When the response carries per-product KG scores, every Offer must
+    expose the per-term breakdown plus the raw total, and Offer.score
+    should be the min-max normalized value."""
+    products = [_make_summary("p1"), _make_summary("p2"), _make_summary("p3")]
+    scores = {
+        "p1": {
+            "score": 4.2,
+            "breakdown": {"soft": 3.0, "phrase": 1.0, "token": 0.0, "connectivity": 0.2},
+        },
+        "p2": {
+            "score": 2.0,
+            "breakdown": {"soft": 1.0, "phrase": 1.0, "token": 0.0, "connectivity": 0.0},
+        },
+        "p3": {
+            "score": 0.5,
+            "breakdown": {"soft": 0.5, "phrase": 0.0, "token": 0.0, "connectivity": 0.0},
+        },
+    }
+
+    agent = MerchantAgent(merchant_id="default", domain="electronics")
+    query = StructuredQuery(
+        domain="electronics", hard_filters={}, soft_preferences={}, user_context={}, top_k=3,
+    )
+
+    async def fake_search(req, db):  # noqa: ARG001 (shapes match)
+        return _fake_response(products, scores)
+
+    with patch("app.merchant_agent.search_products", side_effect=fake_search):
+        offers = await agent.search(query, db=object())  # db unused in stub
+
+    assert len(offers) == 3
+    for offer in offers:
+        breakdown = offer.score_breakdown
+        assert "raw" in breakdown, (
+            f"score_breakdown must carry the pre-normalized raw total; got {breakdown}"
+        )
+        for term in ("soft", "phrase", "token", "connectivity"):
+            assert term in breakdown, (
+                f"missing per-term key {term!r} in score_breakdown {breakdown}"
+            )
+
+    # Min-max normalization: raw range is [0.5, 4.2], so the highest-scoring
+    # product maps to 1.0 and the lowest to 0.0.
+    by_id = {o.product_id: o for o in offers}
+    assert by_id["p1"].score == pytest.approx(1.0)
+    assert by_id["p3"].score == pytest.approx(0.0)
+    assert 0.0 < by_id["p2"].score < 1.0
+
+
+@pytest.mark.asyncio
+async def test_offer_score_degrades_gracefully_when_kg_scores_missing():
+    """Pre-#52 behaviour: when the response carries no scores (KG offline,
+    SQL-only hit), Offer.score falls back to the positional placeholder
+    and score_breakdown is empty."""
+    products = [_make_summary("a"), _make_summary("b")]
+    agent = MerchantAgent(merchant_id="default", domain="electronics")
+    query = StructuredQuery(
+        domain="electronics", hard_filters={}, soft_preferences={}, user_context={}, top_k=2,
+    )
+
+    async def fake_search(req, db):  # noqa: ARG001
+        return _fake_response(products, scores={})
+
+    with patch("app.merchant_agent.search_products", side_effect=fake_search):
+        offers = await agent.search(query, db=object())
+
+    assert [o.product_id for o in offers] == ["a", "b"]
+    assert all(o.score_breakdown == {} for o in offers)
+    # Positional: first is 1.0, last drops by 1/n.
+    assert offers[0].score == pytest.approx(1.0)
+    assert offers[1].score < offers[0].score


### PR DESCRIPTION
## Summary

Implements the contract from #52: the knowledge graph is a flattened projection of `products_enriched` rows joined to raw identity fields, keyed per `(merchant_id, kg_strategy)`. Reader and writer agree on the property set via a single `app.kg_projection` module; a contract-drift test makes that agreement enforceable.

Closes #52. Closes #51 (silent zero-score on use-case flags). Closes #34 (positional `Offer.score` placeholder). Closes #32 (KG ignored user message).

## Checklist mapping

Each #52 checklist item → commit:

| #52 item | Commit |
| --- | --- |
| 1. Write the contract down | `8065702` docs(kg): kg_enriched_contract.md |
| 2. Share one property projection between reader and writer | `4a2c353` add kg_projection module |
| 3. Project `good_for_*` onto Product nodes (was #51) | `a097c0f` threshold floats + `b8a7a03` builder consumes projection |
| 4. KG text matcher runs against enriched tags, not raw CONTAINS (was #32) | `6add701` user message in KG soft scoring |
| 5. `Offer.score` exposes real per-product retrieval score (was #34) | `966762f` plumb KG score + breakdown |
| 6. Migrate `backfill_kg_features.py` output off raw `products` | `5bebd95` deprecation shim |

Plus tenancy (`6cf6a0c`) — required for projection rule 3 — and the §6 test coverage (`f7fc7a6`, `7f411f9`).

## Contract doc pointer

[`mcp-server/docs/kg_enriched_contract.md`](mcp-server/docs/kg_enriched_contract.md). `NEO4J_KNOWLEDGE_GRAPH.md` §`products.kg_features` now points at the new doc.

## Test plan

- [x] `mcp-server/tests/test_kg_contract.py` — drift test enumerates every `p.<name>` reference; negative test confirms a bogus reference is flagged.
- [x] `mcp-server/tests/test_offer_score_breakdown.py` — unit test asserts `Offer.score_breakdown` carries per-term keys + `raw`, and `Offer.score` is min-max normalized. Degraded-path fallback (no KG scores) preserves the pre-#52 positional placeholder + empty breakdown + INFO log.
- [x] `mcp-server/tests/test_kg_live_regression.py` — live-Neo4j (skip-gated on `NEO4J_ENV_READY`):
  - `good_for_ml=0.9` ranks above `good_for_ml=0.1` under the same `(merchant_id, kg_strategy)` pair (#51 regression).
  - `(m1, strat_a)` query never surfaces nodes seeded under `(m2, strat_b)`.
- [x] Existing `tests/test_kg_service.py` updated to the new 3-tuple `search_candidates` return shape and the `coalesce(...) >= $tag_threshold` Cypher.

No parity harness on this branch — none was present (the harness lives on a different branch).

## Open items

- `repairable` / `refurbished` Cypher hard filters still have no enrichment-strategy producer; held in `RESERVED_BOOL_FEATURES` while #61 decides whether the legacy heuristic logic migrates into a strategy.
- `display_size_inches` previously sourced from random; the Display node now reads `coalesce(l.screen_size_inches, 0.0)` from projection, so catalogs without `parser_v1` collapse to a single "unknown-size" Display per resolution. Acceptable for now — a follow-up could split Display by `(size, resolution)` only when both are present.
- Default merchant uses `kg_strategy="default_v1"`. When merchants run two strategies in parallel the operator is responsible for instantiating two `MerchantAgent`s and pointing the orchestrator at each pair separately.

## Links

Closes #52
Refs #51, #32, #34, #60, #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)