### PR TITLE
feat(merchant): persist merchant registry across workers (#53)

### DIFF
--- a/mcp-server/app/main.py
+++ b/mcp-server/app/main.py
@@ -152,12 +152,35 @@ async def lifespan(app: FastAPI):
         logger.warning("Could not create shared_chats table: %s", _e)
 
     # --- Merchant registry -------------------------------------------
+    # In-process ``merchants`` dict is a cache; the source of truth is
+    # ``merchants.registry`` (issue #53). Seeding the default entry here —
+    # both in the dict and in the registry table — avoids a bootstrap
+    # special case elsewhere: after this block, any worker can hydrate the
+    # default merchant by the same path as any other merchant.
     from app.merchant_agent import MerchantAgent
 
     merchants["default"] = MerchantAgent(
         merchant_id="default",
         domain="electronics",
     )
+    try:
+        with engine.connect() as _conn:
+            _conn.execute(_sa_text(
+                """
+                INSERT INTO merchants.registry
+                    (merchant_id, domain, strategy, kg_strategy)
+                VALUES
+                    ('default', 'electronics', 'normalizer_v1', 'default_v1')
+                ON CONFLICT (merchant_id) DO NOTHING
+                """
+            ))
+            _conn.commit()
+    except Exception as _e:
+        # Missing table means migration 005 has not been applied on this DB.
+        # Do not crash startup — the dict still serves the default merchant;
+        # lazy hydration for other merchants will fail loudly on first use,
+        # which is the correct failure mode to surface the deploy gap.
+        logger.warning("Could not UPSERT default merchant into registry: %s", _e)
     logger.info("Merchant registry initialised: %s", list(merchants.keys()))
 
     skip_preload = os.getenv("MCP_SKIP_PRELOAD", "0") == "1"
@@ -1275,13 +1298,53 @@ from typing import List as _List
 from app.contract import StructuredQuery, Offer
 
 
+def _get_or_hydrate_merchant(merchant_id: str, db: Session):
+    """Return the MerchantAgent for ``merchant_id``, hydrating from DB on miss.
+
+    The ``merchants`` dict is the per-process cache; ``merchants.registry``
+    is the cross-process source of truth (issue #53). On a cache miss we
+    reconstruct the agent with the plain constructor — the per-merchant
+    FAISS index is already on disk and KG rows already live in Neo4j keyed
+    by ``(merchant_id, kg_strategy)``, so there's nothing to rebuild.
+
+    Raises 404 if the merchant is absent from both the cache and the
+    registry — that's the real "unknown merchant" signal.
+    """
+    from app.merchant_agent import MerchantAgent
+
+    agent = merchants.get(merchant_id)
+    if agent is not None:
+        return agent
+    row = db.execute(
+        _sa_text(
+            "SELECT merchant_id, domain, strategy, kg_strategy "
+            "FROM merchants.registry WHERE merchant_id = :mid"
+        ),
+        {"mid": merchant_id},
+    ).mappings().first()
+    if row is None:
+        raise HTTPException(
+            status_code=404, detail=f"Merchant '{merchant_id}' not found"
+        )
+    agent = MerchantAgent(
+        merchant_id=row["merchant_id"],
+        domain=row["domain"],
+        strategy=row["strategy"],
+        kg_strategy=row["kg_strategy"],
+    )
+    merchants[merchant_id] = agent
+    logger.info("merchant_hydrated id=%s domain=%s", merchant_id, row["domain"])
+    return agent
+
+
 @app.post("/merchant/search", response_model=_List[Offer])
 async def merchant_search(
     query: StructuredQuery,
     db: Session = Depends(get_db),
 ) -> _List[Offer]:
     """Default merchant search — backward-compatible entry point."""
-    return await merchants["default"].search(query, db)
+    agent = _get_or_hydrate_merchant("default", db)
+    return await agent.search(query, db)
 
 
 @app.post("/merchant/{merchant_id}/search", response_model=_List[Offer])
@@ -1291,18 +1354,14 @@ async def merchant_search_by_id(
     db: Session = Depends(get_db),
 ) -> _List[Offer]:
     """Per-merchant search endpoint."""
-    agent = merchants.get(merchant_id)
-    if not agent:
-        raise HTTPException(status_code=404, detail=f"Merchant '{merchant_id}' not found")
+    agent = _get_or_hydrate_merchant(merchant_id, db)
     return await agent.search(query, db)
 
 
 @app.get("/merchant/{merchant_id}/health")
 def merchant_health(merchant_id: str, db: Session = Depends(get_db)):
     """Per-merchant health check."""
-    agent = merchants.get(merchant_id)
-    if not agent:
-        raise HTTPException(status_code=404, detail=f"Merchant '{merchant_id}' not found")
+    agent = _get_or_hydrate_merchant(merchant_id, db)
     return agent.health(db)
 
 

--- a/mcp-server/app/merchant_agent.py
+++ b/mcp-server/app/merchant_agent.py
@@ -45,6 +45,52 @@ def merchant_enriched_table(merchant_id: str) -> str:
     """Fully-qualified enriched catalog table for this merchant."""
     return f"merchants.products_enriched_{validate_merchant_id(merchant_id)}"
 
+
+def upsert_registry_row(
+    *,
+    merchant_id: str,
+    domain: str,
+    strategy: str,
+    kg_strategy: str,
+) -> None:
+    """Persist this merchant into merchants.registry (issue #53).
+
+    UPSERT semantics: re-running ``from_csv`` with the same ``merchant_id``
+    refreshes ``domain`` / ``strategy`` / ``kg_strategy`` and bumps
+    ``updated_at``; it does not error. This is the only idempotency
+    guarantee in the registry PR — CSV row-level dedupe is unrelated.
+    """
+    from sqlalchemy import text
+
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        db.execute(
+            text(
+                """
+                INSERT INTO merchants.registry
+                    (merchant_id, domain, strategy, kg_strategy)
+                VALUES
+                    (:mid, :domain, :strategy, :kg_strategy)
+                ON CONFLICT (merchant_id) DO UPDATE SET
+                    domain      = EXCLUDED.domain,
+                    strategy    = EXCLUDED.strategy,
+                    kg_strategy = EXCLUDED.kg_strategy,
+                    updated_at  = NOW()
+                """
+            ),
+            {
+                "mid": validate_merchant_id(merchant_id),
+                "domain": domain,
+                "strategy": strategy,
+                "kg_strategy": kg_strategy,
+            },
+        )
+        db.commit()
+    finally:
+        db.close()
+
 # Translate agent slot vocabulary → KG scoring-flag vocabulary.
 # Two naming conventions arrive depending on the upstream path:
 #   - "use_case"  (singular, string)  — from agent chat interview
@@ -126,6 +172,7 @@ class MerchantAgent:
         domain: str,
         product_type: str,
         strategy: str = "normalizer_v1",
+        kg_strategy: str = "default_v1",
         source: Optional[str] = None,
         col_map: Optional[Dict[str, str]] = None,
         normalize_limit: int = 1000,
@@ -164,7 +211,12 @@ class MerchantAgent:
         finally:
             raw_conn.close()
 
-        agent = cls(merchant_id=merchant_id, domain=domain, strategy=strategy)
+        agent = cls(
+            merchant_id=merchant_id,
+            domain=domain,
+            strategy=strategy,
+            kg_strategy=kg_strategy,
+        )
 
         db = SessionLocal()
         try:
@@ -211,8 +263,16 @@ class MerchantAgent:
                     merchant_id, exc,
                 )
 
-        # In-memory registry only — on restart, the operator re-runs bootstrap
-        # to re-register. Tables persist in Postgres so data is not lost.
+        # Durable registration. merchants.registry is the source of truth;
+        # the in-process dict is a cache that other workers / post-restart
+        # processes populate via lazy hydration. See issue #53.
+        upsert_registry_row(
+            merchant_id=merchant_id,
+            domain=domain,
+            strategy=strategy,
+            kg_strategy=kg_strategy,
+        )
+
         from app import main as app_main
         app_main.merchants[merchant_id] = agent
         logger.info("merchant_registered id=%s domain=%s", merchant_id, domain)

--- a/mcp-server/migrations/005_create_merchants_registry.sql
+++ b/mcp-server/migrations/005_create_merchants_registry.sql
@@ -1,0 +1,53 @@
+-- =============================================================================
+-- merchants.registry — durable source of truth for merchant registrations.
+--
+-- Issue #53. Before this migration, merchant registrations lived only in
+-- app.main.merchants, an in-process Python dict populated by
+-- MerchantAgent.from_csv. That dict has two well-known failure modes:
+--
+--   * Restarting the backend loses every non-default registration. The
+--     catalog tables in merchants.* persist but the "this merchant exists
+--     with these strategies" pointer is gone, so /merchant/<id>/* returns
+--     404 until someone re-runs bootstrap.
+--   * Under multi-worker deploys (uvicorn/gunicorn --workers >1) a
+--     from_csv call on worker A writes to A's dict only. A subsequent
+--     request landing on worker B 404s.
+--
+-- After this migration the dict becomes a cache and merchants.registry is
+-- the source of truth. /merchant/{id}/* lazy-hydrates on cache miss.
+--
+-- Strategy columns
+-- ----------------
+-- Both `strategy` and `kg_strategy` are stored. Since #62,
+-- MerchantAgent.__init__ takes both as distinct fields — they key
+-- different subsystems:
+--   * strategy     — enrichment rows (products_enriched.strategy) and
+--                    per-merchant FAISS index path.
+--   * kg_strategy  — Neo4j KG tenancy (one KG per (merchant, kg_strategy)).
+-- Omitting either here would silently snap rehydrated agents back to
+-- the default on the missing axis.
+--
+-- NOTE: the api_token column planned in #57 is intentionally NOT added
+-- here. It will ship in its own later migration alongside the admin
+-- auth surface so this PR stays scoped to "persist what already exists".
+-- =============================================================================
+-- Usage: psql $DATABASE_URL -f mcp-server/migrations/005_create_merchants_registry.sql
+-- =============================================================================
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS merchants;
+
+CREATE TABLE IF NOT EXISTS merchants.registry (
+    merchant_id  TEXT        PRIMARY KEY,
+    domain       TEXT        NOT NULL,
+    strategy     TEXT        NOT NULL DEFAULT 'normalizer_v1',
+    kg_strategy  TEXT        NOT NULL DEFAULT 'default_v1',
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE merchants.registry IS
+  'Durable merchant registrations. App dict is a cache; this table is the source of truth. See issue #53.';
+
+COMMIT;

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -58,6 +58,7 @@ _POSTGRES_REQUIRED_FILES = {
     "test_endpoint_integration.py",
     "test_endpoints.py",
     "test_inventory_agent_response.py",
+    "test_merchant_registry.py",
     "test_mcp_pipeline.py",
     "test_reddit_queries.py",
     "test_week6_enriched.py",

--- a/mcp-server/tests/test_merchant_registry.py
+++ b/mcp-server/tests/test_merchant_registry.py
@@ -1,0 +1,367 @@
+"""
+Issue #53 — persistent merchant registry.
+
+Locks in the post-migration contract for ``merchants.registry``:
+
+  1. Hydration from the registry works with the constructor alone — no
+     enrichment, no vector rebuild. Clearing ``app.main.merchants`` and
+     calling ``/merchant/{id}/*`` must still serve the merchant.
+
+  2. Cross-worker parity: a row written in one Postgres session is visible
+     to a fresh, cache-cold lookup in another session (same-process
+     simulation, since the durability contract lives in Postgres not in
+     Python).
+
+  3. The default merchant is bootstrapped idempotently (cold / warm / twice).
+
+  4. ``upsert_registry_row`` — the helper ``MerchantAgent.from_csv`` calls
+     next to the in-memory dict write — is itself idempotent: a second
+     call with the same ``merchant_id`` updates strategy fields and bumps
+     ``updated_at`` instead of erroring.
+
+All tests are Postgres-integration tests and are auto-skipped via
+``conftest.py`` when ``DATABASE_URL`` is not reachable.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+# Load .env before importing app so DATABASE_URL is available.
+_env_path = Path(__file__).parent.parent.parent / ".env"
+if _env_path.exists():
+    load_dotenv(_env_path)
+else:
+    load_dotenv()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from app import main as app_main
+from app.database import DATABASE_URL
+from app.merchant_agent import MerchantAgent, upsert_registry_row
+
+
+_TEST_DATABASE_URL = os.getenv("DATABASE_URL") or DATABASE_URL
+_engine = create_engine(_TEST_DATABASE_URL, pool_pre_ping=True)
+_Session = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_migration_005() -> None:
+    """Skip the whole module if migration 005 has not been applied yet."""
+    with _engine.connect() as conn:
+        exists = conn.execute(
+            text(
+                "SELECT to_regclass('merchants.registry') IS NOT NULL"
+            )
+        ).scalar()
+    if not exists:
+        pytest.skip(
+            "merchants.registry not present — apply migration 005 before "
+            "running these tests."
+        )
+
+
+@pytest.fixture
+def db_session():
+    s = _Session()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+@pytest.fixture
+def synthetic_merchant_ids():
+    """Return a list of test-only merchant_ids and scrub them before + after.
+
+    The slug grammar (MERCHANT_ID_RE) forbids hyphens, so we use underscores.
+    """
+    ids = ["test_reg_hydrate", "test_reg_worker", "test_reg_idemp"]
+
+    def _scrub():
+        with _engine.begin() as conn:
+            conn.execute(
+                text("DELETE FROM merchants.registry WHERE merchant_id = ANY(:ids)"),
+                {"ids": ids},
+            )
+
+    _scrub()
+    yield ids
+    _scrub()
+
+
+@pytest.fixture
+def clean_dict_cache():
+    """Snapshot ``app.main.merchants`` before and restore after the test."""
+    snapshot = dict(app_main.merchants)
+    try:
+        yield
+    finally:
+        app_main.merchants.clear()
+        app_main.merchants.update(snapshot)
+
+
+# ---------------------------------------------------------------------------
+# 1. Restart simulation — lazy hydrate, no rebuild
+# ---------------------------------------------------------------------------
+
+
+def test_hydrate_from_registry_after_dict_clear(
+    db_session, synthetic_merchant_ids, clean_dict_cache, monkeypatch
+):
+    """Cache miss + registry hit must construct the agent and cache it.
+
+    Locks the "restart simulation" contract: ``app.main.merchants`` empty
+    (simulates a fresh worker process), ``merchants.registry`` populated
+    (simulates the persistent source of truth), lookup must return the
+    agent without triggering enrichment or vector rebuild.
+    """
+    mid = synthetic_merchant_ids[0]
+
+    # Seed the registry directly — no from_csv, so we prove the hydrate path
+    # does not depend on any per-test catalog bootstrap.
+    with _engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO merchants.registry
+                    (merchant_id, domain, strategy, kg_strategy)
+                VALUES (:mid, 'books', 'normalizer_v1', 'default_v1')
+                """
+            ),
+            {"mid": mid},
+        )
+
+    # Clear the in-process cache so the helper must hydrate from DB.
+    app_main.merchants.clear()
+
+    # Trip-wire: if anything in this code path attempts to re-enrich or
+    # rebuild the vector index, fail the test. Plain hydration must only
+    # call the MerchantAgent constructor.
+    def _fail_vector(self):  # pragma: no cover - trip wire
+        pytest.fail("refresh_vector_index called during hydrate")
+
+    def _fail_enrich(*a, **kw):  # pragma: no cover - trip wire
+        pytest.fail("CatalogNormalizer.batch_normalize called during hydrate")
+
+    monkeypatch.setattr(MerchantAgent, "refresh_vector_index", _fail_vector)
+    from app.catalog_ingestion import CatalogNormalizer
+    monkeypatch.setattr(CatalogNormalizer, "batch_normalize", _fail_enrich)
+
+    agent = app_main._get_or_hydrate_merchant(mid, db_session)
+
+    assert isinstance(agent, MerchantAgent)
+    assert agent.merchant_id == mid
+    assert agent.domain == "books"
+    assert agent.strategy == "normalizer_v1"
+    assert agent.kg_strategy == "default_v1"
+    # And the dict now caches it, so a second call is a pure cache hit.
+    assert app_main.merchants[mid] is agent
+
+
+def test_hydrate_unknown_merchant_returns_404(db_session, clean_dict_cache):
+    """A cache miss that also misses the registry must raise HTTPException 404."""
+    from fastapi import HTTPException
+
+    app_main.merchants.clear()
+
+    with pytest.raises(HTTPException) as excinfo:
+        app_main._get_or_hydrate_merchant("ghost_merchant_for_issue_53", db_session)
+    assert excinfo.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# 2. Multi-worker simulation
+# ---------------------------------------------------------------------------
+
+
+def test_cross_session_visibility(
+    db_session, synthetic_merchant_ids, clean_dict_cache
+):
+    """Row written in session A is visible to cache-cold hydrate in session B.
+
+    A uvicorn --workers=N deployment has N independent Python processes;
+    each has its own ``app.main.merchants`` dict but shares Postgres. This
+    test simulates that by writing via one SQLAlchemy session, clearing
+    the dict, and reading through ``_get_or_hydrate_merchant`` with a
+    second session — the exact path worker B would take for a merchant
+    first registered on worker A.
+    """
+    mid = synthetic_merchant_ids[1]
+
+    # "Worker A" — register via the same helper from_csv uses.
+    upsert_registry_row(
+        merchant_id=mid,
+        domain="apparel",
+        strategy="normalizer_v2",
+        kg_strategy="alt_kg_v1",
+    )
+
+    # Start worker B with an empty cache and a brand-new session.
+    app_main.merchants.clear()
+    session_b = _Session()
+    try:
+        agent = app_main._get_or_hydrate_merchant(mid, session_b)
+    finally:
+        session_b.close()
+
+    assert agent.merchant_id == mid
+    assert agent.domain == "apparel"
+    # Both strategy axes survive the round-trip — this is the specific
+    # regression #53 has to block.
+    assert agent.strategy == "normalizer_v2"
+    assert agent.kg_strategy == "alt_kg_v1"
+
+
+# ---------------------------------------------------------------------------
+# 3. Default merchant bootstrap — cold + warm + idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_default_registry_row_is_idempotent(db_session):
+    """Running the bootstrap UPSERT twice yields exactly one row.
+
+    Mirrors the lifespan block in ``app.main`` that issues
+    ``INSERT ... ON CONFLICT DO NOTHING`` for the default merchant on every
+    startup. A second startup must not duplicate the row nor error.
+    """
+    bootstrap = text(
+        """
+        INSERT INTO merchants.registry
+            (merchant_id, domain, strategy, kg_strategy)
+        VALUES ('default', 'electronics', 'normalizer_v1', 'default_v1')
+        ON CONFLICT (merchant_id) DO NOTHING
+        """
+    )
+    with _engine.begin() as conn:
+        conn.execute(bootstrap)
+        conn.execute(bootstrap)
+
+    count = db_session.execute(
+        text("SELECT COUNT(*) FROM merchants.registry WHERE merchant_id = 'default'")
+    ).scalar()
+    assert count == 1
+
+
+def test_default_merchant_hydrates_cold(db_session, clean_dict_cache):
+    """With the dict empty, the default merchant must hydrate from the registry.
+
+    Covers the worker-B-sees-default scenario: the lifespan block already
+    ran on worker A and seeded both the dict and the registry; worker B's
+    dict starts empty and the first /merchant/default/* request must still
+    work. Prerequisite: the lifespan on this test DB has seeded the row
+    at least once (either by running the app, or by the previous test in
+    this module).
+    """
+    # Ensure the default row exists regardless of test-ordering — we don't
+    # want this test to depend on test_default_registry_row_is_idempotent
+    # running first.
+    with _engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO merchants.registry
+                    (merchant_id, domain, strategy, kg_strategy)
+                VALUES ('default', 'electronics', 'normalizer_v1', 'default_v1')
+                ON CONFLICT (merchant_id) DO NOTHING
+                """
+            )
+        )
+
+    app_main.merchants.clear()
+    agent = app_main._get_or_hydrate_merchant("default", db_session)
+    assert agent.merchant_id == "default"
+    assert agent.domain == "electronics"
+    assert agent.strategy == "normalizer_v1"
+    assert agent.kg_strategy == "default_v1"
+
+
+# ---------------------------------------------------------------------------
+# 4. upsert_registry_row idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_registry_row_is_idempotent(
+    db_session, synthetic_merchant_ids
+):
+    """Two calls with the same merchant_id — one row, updated strategy fields,
+    updated_at advanced.
+
+    ``MerchantAgent.from_csv`` calls this helper on every invocation; the
+    registry UPSERT is the only idempotency guarantee in this PR. This
+    test asserts the UPSERT behaviour directly rather than running the
+    full CSV pipeline — CSV row-level dedupe is explicitly out of scope
+    for #53.
+    """
+    mid = synthetic_merchant_ids[2]
+
+    upsert_registry_row(
+        merchant_id=mid,
+        domain="pets",
+        strategy="normalizer_v1",
+        kg_strategy="default_v1",
+    )
+    first = db_session.execute(
+        text(
+            "SELECT domain, strategy, kg_strategy, created_at, updated_at "
+            "FROM merchants.registry WHERE merchant_id = :mid"
+        ),
+        {"mid": mid},
+    ).mappings().first()
+    assert first is not None
+    assert first["domain"] == "pets"
+    assert first["strategy"] == "normalizer_v1"
+
+    # Postgres ``now()`` has microsecond resolution but the two UPSERTs can
+    # still land in the same microsecond on a fast machine; force a gap.
+    time.sleep(0.01)
+
+    # Second call with different strategy values.
+    upsert_registry_row(
+        merchant_id=mid,
+        domain="pets_supplies",
+        strategy="normalizer_v2",
+        kg_strategy="alt_kg_v1",
+    )
+
+    # Fresh read — SessionLocal's earlier statement sits in a separate txn.
+    db_session.commit()
+    second = db_session.execute(
+        text(
+            "SELECT domain, strategy, kg_strategy, created_at, updated_at "
+            "FROM merchants.registry WHERE merchant_id = :mid"
+        ),
+        {"mid": mid},
+    ).mappings().first()
+
+    # Still exactly one row.
+    count = db_session.execute(
+        text("SELECT COUNT(*) FROM merchants.registry WHERE merchant_id = :mid"),
+        {"mid": mid},
+    ).scalar()
+    assert count == 1
+
+    # Values refreshed to the most recent call.
+    assert second["domain"] == "pets_supplies"
+    assert second["strategy"] == "normalizer_v2"
+    assert second["kg_strategy"] == "alt_kg_v1"
+
+    # created_at preserved, updated_at advanced.
+    assert second["created_at"] == first["created_at"]
+    assert second["updated_at"] > first["updated_at"]


### PR DESCRIPTION
## Summary

- Adds `merchants.registry` (migration 005) as the durable source of truth for merchant registrations — `app.main.merchants` becomes a per-process cache.
- `_get_or_hydrate_merchant` lazy-loads from the registry on cache miss; constructor-only hydration because per-merchant FAISS lives on disk and KG rows live in Neo4j keyed by `(merchant_id, kg_strategy)`.
- `MerchantAgent.from_csv` now UPSERTs the registry row next to the existing in-dict write; the lifespan handler UPSERTs the `default` row via `ON CONFLICT DO NOTHING`.

Fixes interactive-decision-support-system/idss-backend#53 — restart no longer wipes non-default merchants, and `--workers > 1` serves consistent results regardless of which worker handled the registration.

## Design notes

- **Both strategy axes persisted.** Since interactive-decision-support-system/idss-backend#62, `strategy` (enrichment + FAISS) and `kg_strategy` (Neo4j KG tenancy) key different subsystems. Storing only one would silently snap rehydrated agents back to the default on the missing axis.
- **Lazy hydrate, not warm-load.** The dict is a cache; registry is the source of truth — every worker hydrates uniformly on first hit. Warm-load can be layered on later if a listing endpoint needs it.
- **`api_token` (#57) explicitly deferred** — noted inline in the migration; will ship with its own migration alongside the admin auth surface.

## Test plan

- [x] `pytest tests/test_merchant_registry.py -v` — 6 new tests covering: restart-simulation hydrate (trip-wires on `refresh_vector_index` / `CatalogNormalizer.batch_normalize`), cross-session visibility with preserved `(strategy, kg_strategy)`, default-row idempotency, cold hydrate of default, unknown-merchant 404, and `upsert_registry_row` idempotency (single row, advanced `updated_at`, refreshed fields).
- [x] `pytest tests/test_default_merchant_collapse.py -v` — regression, still green.
- [x] `pytest tests/test_merchant.py -v` — regression, still green.
- [x] Reviewer: apply migration 005 to target DB before deploy — `psql $DATABASE_URL -f mcp-server/migrations/005_create_merchants_registry.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)