### PR TITLE
feat(merchant): HTTP admin surface — POST/GET/DELETE /merchant (#54)

### DIFF
--- a/mcp-server/app/ingestion/schema.py
+++ b/mcp-server/app/ingestion/schema.py
@@ -102,9 +102,14 @@ def create_merchant_catalog(merchant_id: str, conn: Any) -> None:
     logger.info("created_merchant_catalog merchant_id=%s", merchant_id)
 
 
-def drop_merchant_catalog(merchant_id: str, conn: Any) -> None:
-    """Drop both per-merchant tables. Gated on ``ALLOW_MERCHANT_DROP=1``."""
-    if os.environ.get("ALLOW_MERCHANT_DROP", "") != "1":
+def drop_merchant_catalog(merchant_id: str, conn: Any, *, _force: bool = False) -> None:
+    """Drop both per-merchant tables. Gated on ``ALLOW_MERCHANT_DROP=1``.
+
+    ``_force=True`` bypasses the env gate — reserved for in-request cleanup
+    of a half-provisioned merchant whose tables were just created in the
+    same turn. Not for external callers.
+    """
+    if not _force and os.environ.get("ALLOW_MERCHANT_DROP", "") != "1":
         raise PermissionError(
             "drop_merchant_catalog disabled. Set ALLOW_MERCHANT_DROP=1 to enable."
         )

--- a/mcp-server/app/main.py
+++ b/mcp-server/app/main.py
@@ -18,6 +18,7 @@ import logging
 import traceback
 import os
 import sys
+import tempfile
 import time as _time
 import json as _json
 import uuid as _uuid
@@ -1403,7 +1404,7 @@ def _catalog_row_count(db: Session, merchant_id: str) -> int:
 
 
 @app.post("/merchant", status_code=status.HTTP_201_CREATED)
-async def create_merchant(
+def create_merchant(
     file: UploadFile = File(...),
     merchant_id: str = Form(...),
     domain: str = Form(...),
@@ -1416,7 +1417,9 @@ async def create_merchant(
     """Provision a new merchant from a CSV upload (synchronous).
 
     Delegates to ``MerchantAgent.from_csv`` — DDL clone → CSV load →
-    enrichment → vector index → registry UPSERT.
+    enrichment → vector index → registry UPSERT. Sync ``def`` because
+    ``from_csv`` is blocking: running as ``async def`` would stall the
+    event loop for the full ingest.
 
     Duplicate ``merchant_id`` → 409. The CSV load path is append-only; a
     silent re-POST would duplicate rows in ``merchants.products_<id>``.
@@ -1427,11 +1430,24 @@ async def create_merchant(
     is wired in.
     """
     from app.merchant_agent import MerchantAgent, validate_merchant_id
+    from app.ingestion.schema import drop_merchant_catalog
 
     try:
         validate_merchant_id(merchant_id)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+
+    # Serialize concurrent provisions of the same merchant_id. Without the
+    # lock, two in-flight POSTs can both pass the existence check and each
+    # run create_merchant_catalog (CREATE IF NOT EXISTS is a no-op on the
+    # second) plus load_csv_into_merchant — doubling the rows in
+    # merchants.products_<id>. xact_lock is released when ``db`` closes
+    # (Depends(get_db) rolls back on request end), which happens after
+    # from_csv completes.
+    db.execute(
+        _sa_text("SELECT pg_advisory_xact_lock(hashtext(:mid))"),
+        {"mid": merchant_id},
+    )
 
     existing = db.execute(
         _sa_text("SELECT 1 FROM merchants.registry WHERE merchant_id = :mid"),
@@ -1458,23 +1474,54 @@ async def create_merchant(
             raise HTTPException(
                 status_code=400, detail="col_map must be a JSON object"
             )
+        if not all(
+            isinstance(k, str) and isinstance(v, str)
+            for k, v in parsed_col_map.items()
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="col_map must be a JSON object of string → string",
+            )
 
-    import tempfile
-
-    contents = await file.read()
+    contents = file.file.read()
     tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv")
     try:
         with os.fdopen(tmp_fd, "wb") as fh:
             fh.write(contents)
-        agent = MerchantAgent.from_csv(
-            tmp_path,
-            merchant_id=merchant_id,
-            domain=domain,
-            product_type=product_type,
-            strategy=strategy,
-            kg_strategy=kg_strategy,
-            col_map=parsed_col_map,
-        )
+        try:
+            agent = MerchantAgent.from_csv(
+                tmp_path,
+                merchant_id=merchant_id,
+                domain=domain,
+                product_type=product_type,
+                strategy=strategy,
+                kg_strategy=kg_strategy,
+                col_map=parsed_col_map,
+            )
+        except Exception as exc:
+            # from_csv may have already run create_merchant_catalog before
+            # failing. CREATE TABLE IF NOT EXISTS means a naive retry would
+            # append to whatever rows the aborted load left behind. Drop
+            # the half-built tables so the next POST starts clean. _force
+            # bypasses ALLOW_MERCHANT_DROP for this in-request cleanup.
+            try:
+                cleanup_conn = engine.raw_connection()
+                try:
+                    drop_merchant_catalog(merchant_id, cleanup_conn, _force=True)
+                finally:
+                    cleanup_conn.close()
+            except Exception as cleanup_exc:
+                logger.warning(
+                    "create_merchant_cleanup_failed id=%s err=%s",
+                    merchant_id, cleanup_exc,
+                )
+            # Also evict any half-registered in-memory entry from_csv may
+            # have written before it raised.
+            merchants.pop(merchant_id, None)
+            raise HTTPException(
+                status_code=500,
+                detail=f"merchant provisioning failed: {exc}",
+            )
     finally:
         try:
             os.unlink(tmp_path)
@@ -1516,11 +1563,16 @@ def list_merchants(db: Session = Depends(get_db)):
 
 @app.delete("/merchant/{merchant_id}")
 def delete_merchant(merchant_id: str, db: Session = Depends(get_db)):
-    """Deregister a merchant: drop tables, delete registry row, evict cache.
+    """Deregister a merchant: delete registry row, drop tables, evict cache.
 
     Refuses ``default`` (it is the clone template for every new merchant).
     Gated on ``ALLOW_MERCHANT_DROP=1`` — surfaced as 403 when the env var
-    is not set.
+    is not set. Unknown ``merchant_id`` → 404.
+
+    Registry row is removed first, then tables: a mid-flight failure after
+    the commit leaves no route pointing at the orphan tables, so the
+    merchant is functionally gone from the API surface even if the DDL
+    phase errors out.
     """
     from app.merchant_agent import validate_merchant_id
     from app.ingestion.schema import drop_merchant_catalog
@@ -1536,20 +1588,36 @@ def delete_merchant(merchant_id: str, db: Session = Depends(get_db)):
             detail="refusing to delete the default merchant",
         )
 
-    raw_conn = engine.raw_connection()
-    try:
-        try:
-            drop_merchant_catalog(merchant_id, raw_conn)
-        except PermissionError as exc:
-            raise HTTPException(status_code=403, detail=str(exc))
-    finally:
-        raw_conn.close()
+    existing = db.execute(
+        _sa_text("SELECT 1 FROM merchants.registry WHERE merchant_id = :mid"),
+        {"mid": merchant_id},
+    ).first()
+    if existing is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"merchant '{merchant_id}' not found",
+        )
+
+    # Pre-check the env gate before mutating the registry. Without this,
+    # the registry DELETE below would commit and then drop_merchant_catalog
+    # would raise 403 — leaving registry gone but tables intact.
+    if os.environ.get("ALLOW_MERCHANT_DROP", "") != "1":
+        raise HTTPException(
+            status_code=403,
+            detail="drop_merchant_catalog disabled. Set ALLOW_MERCHANT_DROP=1 to enable.",
+        )
 
     db.execute(
         _sa_text("DELETE FROM merchants.registry WHERE merchant_id = :mid"),
         {"mid": merchant_id},
     )
     db.commit()
+
+    raw_conn = engine.raw_connection()
+    try:
+        drop_merchant_catalog(merchant_id, raw_conn)
+    finally:
+        raw_conn.close()
 
     merchants.pop(merchant_id, None)
     logger.info("merchant_deleted id=%s", merchant_id)

--- a/mcp-server/app/main.py
+++ b/mcp-server/app/main.py
@@ -5,7 +5,7 @@ Exposes typed tool-call endpoints for agent interactions.
 All endpoints follow the standard response envelope pattern.
 """
 
-from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi import FastAPI, Depends, HTTPException, Request, UploadFile, File, Form, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
@@ -1363,6 +1363,197 @@ def merchant_health(merchant_id: str, db: Session = Depends(get_db)):
     """Per-merchant health check."""
     agent = _get_or_hydrate_merchant(merchant_id, db)
     return agent.health(db)
+
+
+# ---------------------------------------------------------------------------
+# Merchant admin surface — issue #54
+# ---------------------------------------------------------------------------
+# CRUD over merchants.registry. Three sync routes (POST / GET / DELETE).
+# Auth, async ingest, UI, and KG build on ingest are out of scope here —
+# tracked in #57, #39, #61 respectively.
+
+def _catalog_row_count(db: Session, merchant_id: str) -> int:
+    """COUNT(*) for ``merchants.products_<merchant_id>``.
+
+    Live count over the per-merchant raw table — the registry does not
+    cache catalog size. Returns 0 if the table is missing (a registry row
+    with no table is a deploy-skew bug, not a runtime error).
+    """
+    from app.merchant_agent import validate_merchant_id
+
+    # Defence in depth: every registry row was inserted via validate_merchant_id,
+    # but re-validate before splicing into a SQL identifier position.
+    validate_merchant_id(merchant_id)
+    try:
+        return int(db.execute(
+            _sa_text(f"SELECT COUNT(*) FROM merchants.products_{merchant_id}")
+        ).scalar() or 0)
+    except Exception as exc:
+        logger.warning(
+            "catalog_count_failed merchant=%s err=%s — registry row without table?",
+            merchant_id, exc,
+        )
+        # Roll back the failed transaction so the surrounding session is
+        # still usable for the next merchant in the GET loop.
+        try:
+            db.rollback()
+        except Exception:
+            pass
+        return 0
+
+
+@app.post("/merchant", status_code=status.HTTP_201_CREATED)
+async def create_merchant(
+    file: UploadFile = File(...),
+    merchant_id: str = Form(...),
+    domain: str = Form(...),
+    product_type: str = Form(...),
+    strategy: str = Form("normalizer_v1"),
+    kg_strategy: str = Form("default_v1"),
+    col_map: Optional[str] = Form(None),
+    db: Session = Depends(get_db),
+):
+    """Provision a new merchant from a CSV upload (synchronous).
+
+    Delegates to ``MerchantAgent.from_csv`` — DDL clone → CSV load →
+    enrichment → vector index → registry UPSERT.
+
+    Duplicate ``merchant_id`` → 409. The CSV load path is append-only; a
+    silent re-POST would duplicate rows in ``merchants.products_<id>``.
+    Operators must DELETE the merchant first and re-POST with a fresh CSV.
+
+    KG build is out of scope for this PR (tracked in #61). Search will
+    fall back to positional scoring on ``Offer.score`` until the KG path
+    is wired in.
+    """
+    from app.merchant_agent import MerchantAgent, validate_merchant_id
+
+    try:
+        validate_merchant_id(merchant_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    existing = db.execute(
+        _sa_text("SELECT 1 FROM merchants.registry WHERE merchant_id = :mid"),
+        {"mid": merchant_id},
+    ).first()
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Merchant '{merchant_id}' already exists. "
+                "DELETE /merchant/{id} first, then re-POST."
+            ),
+        )
+
+    parsed_col_map: Optional[Dict[str, str]] = None
+    if col_map:
+        try:
+            parsed_col_map = _json.loads(col_map)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail=f"col_map is not valid JSON: {exc}"
+            )
+        if not isinstance(parsed_col_map, dict):
+            raise HTTPException(
+                status_code=400, detail="col_map must be a JSON object"
+            )
+
+    import tempfile
+
+    contents = await file.read()
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv")
+    try:
+        with os.fdopen(tmp_fd, "wb") as fh:
+            fh.write(contents)
+        agent = MerchantAgent.from_csv(
+            tmp_path,
+            merchant_id=merchant_id,
+            domain=domain,
+            product_type=product_type,
+            strategy=strategy,
+            kg_strategy=kg_strategy,
+            col_map=parsed_col_map,
+        )
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+    return {
+        "merchant_id": agent.merchant_id,
+        "onboarding_state": "ready",
+        "catalog_size": _catalog_row_count(db, agent.merchant_id),
+    }
+
+
+@app.get("/merchant")
+def list_merchants(db: Session = Depends(get_db)):
+    """List registered merchants from ``merchants.registry``.
+
+    ``catalog_size`` is computed live via COUNT(*) on the per-merchant
+    table — the registry does not persist it.
+    """
+    rows = db.execute(
+        _sa_text(
+            "SELECT merchant_id, domain, strategy, kg_strategy, created_at "
+            "FROM merchants.registry ORDER BY created_at"
+        )
+    ).mappings().all()
+    return [
+        {
+            "merchant_id": row["merchant_id"],
+            "domain": row["domain"],
+            "strategy": row["strategy"],
+            "kg_strategy": row["kg_strategy"],
+            "catalog_size": _catalog_row_count(db, row["merchant_id"]),
+            "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+        }
+        for row in rows
+    ]
+
+
+@app.delete("/merchant/{merchant_id}")
+def delete_merchant(merchant_id: str, db: Session = Depends(get_db)):
+    """Deregister a merchant: drop tables, delete registry row, evict cache.
+
+    Refuses ``default`` (it is the clone template for every new merchant).
+    Gated on ``ALLOW_MERCHANT_DROP=1`` — surfaced as 403 when the env var
+    is not set.
+    """
+    from app.merchant_agent import validate_merchant_id
+    from app.ingestion.schema import drop_merchant_catalog
+
+    try:
+        validate_merchant_id(merchant_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    if merchant_id == "default":
+        raise HTTPException(
+            status_code=400,
+            detail="refusing to delete the default merchant",
+        )
+
+    raw_conn = engine.raw_connection()
+    try:
+        try:
+            drop_merchant_catalog(merchant_id, raw_conn)
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+    finally:
+        raw_conn.close()
+
+    db.execute(
+        _sa_text("DELETE FROM merchants.registry WHERE merchant_id = :mid"),
+        {"mid": merchant_id},
+    )
+    db.commit()
+
+    merchants.pop(merchant_id, None)
+    logger.info("merchant_deleted id=%s", merchant_id)
+    return {"merchant_id": merchant_id, "deleted": True}
 
 
 @app.post("/api/get-product", response_model=GetProductResponse, response_model_exclude_none=True)

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -58,6 +58,7 @@ _POSTGRES_REQUIRED_FILES = {
     "test_endpoint_integration.py",
     "test_endpoints.py",
     "test_inventory_agent_response.py",
+    "test_merchant_admin_http.py",
     "test_merchant_registry.py",
     "test_mcp_pipeline.py",
     "test_reddit_queries.py",

--- a/mcp-server/tests/test_merchant_admin_http.py
+++ b/mcp-server/tests/test_merchant_admin_http.py
@@ -1,0 +1,432 @@
+"""
+Issue #54 — HTTP admin surface for merchants.
+
+Locks in the public contract for the three new routes:
+
+  * ``POST /merchant``    — multipart CSV upload, sync provisioning.
+  * ``GET  /merchant``    — list rows from ``merchants.registry``.
+  * ``DELETE /merchant/{id}`` — drop tables + registry row + dict cache.
+
+These tests are Postgres-integration tests (auto-skipped via
+``conftest.py`` when DATABASE_URL is unreachable) and require migration
+005 (``merchants.registry``) plus 002/003 (``products_default`` template
+tables) to be present.
+
+Enrichment and the per-merchant FAISS index are stubbed for the duration
+of every test that POSTs a merchant — both call out to OpenAI / sentence
+transformers, neither is in scope for the admin-routes contract, and the
+search assertion only needs SQL-level dispatch to confirm rows are
+sourced from the new merchant table.
+
+KG is also out of scope for #54 (tracked in #61). Search via the new
+merchant will fall back to ``MerchantAgent``'s positional ``score``
+ranking — these tests deliberately avoid asserting on
+``score_breakdown``.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+_env_path = Path(__file__).parent.parent.parent / ".env"
+if _env_path.exists():
+    load_dotenv(_env_path)
+else:
+    load_dotenv()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from app import main as app_main
+from app.database import DATABASE_URL
+from app.main import app
+
+
+_TEST_DATABASE_URL = os.getenv("DATABASE_URL") or DATABASE_URL
+_engine = create_engine(_TEST_DATABASE_URL, pool_pre_ping=True)
+_Session = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_migration_005() -> None:
+    """Skip the module if merchants.registry isn't present."""
+    with _engine.connect() as conn:
+        exists = conn.execute(
+            text("SELECT to_regclass('merchants.registry') IS NOT NULL")
+        ).scalar()
+    if not exists:
+        pytest.skip(
+            "merchants.registry not present — apply migration 005 before "
+            "running these tests."
+        )
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _scrub_merchant(merchant_id: str) -> None:
+    """Force-drop a test merchant's tables and registry row.
+
+    Idempotent — used both as setup (in case a prior crashed run left
+    state) and teardown.
+    """
+    os.environ["ALLOW_MERCHANT_DROP"] = "1"
+    from app.ingestion.schema import drop_merchant_catalog
+
+    raw_conn = _engine.raw_connection()
+    try:
+        try:
+            drop_merchant_catalog(merchant_id, raw_conn)
+        except Exception:
+            # Tables may not exist yet on the first call; ignore.
+            pass
+    finally:
+        raw_conn.close()
+    with _engine.begin() as conn:
+        conn.execute(
+            text("DELETE FROM merchants.registry WHERE merchant_id = :mid"),
+            {"mid": merchant_id},
+        )
+    app_main.merchants.pop(merchant_id, None)
+
+
+@pytest.fixture
+def temp_merchant_ids():
+    """A pool of deterministic test ids; scrub before + after every test."""
+    ids = [
+        "test_admin_one",
+        "test_admin_two",
+        "test_admin_three",
+    ]
+    for mid in ids:
+        _scrub_merchant(mid)
+    yield ids
+    for mid in ids:
+        _scrub_merchant(mid)
+
+
+@pytest.fixture
+def stub_enrichment_and_vector(monkeypatch):
+    """Skip OpenAI + sentence-transformer work for admin-route tests.
+
+    Enrichment correctness is covered by the catalog_ingestion tests; the
+    per-merchant FAISS index is covered by test_per_merchant_vector_index.
+    Neither belongs in the admin-routes contract — and exercising them
+    here would make the test suite depend on OPENAI_API_KEY and a
+    several-second model load on every run.
+    """
+    from app.catalog_ingestion import CatalogNormalizer
+    from app.merchant_agent import MerchantAgent
+
+    monkeypatch.setattr(
+        CatalogNormalizer,
+        "batch_normalize",
+        lambda self, *a, **kw: {"normalized": 0, "skipped": 0, "failed": 0},
+    )
+    monkeypatch.setattr(MerchantAgent, "refresh_vector_index", lambda self: 0)
+
+
+def _csv_bytes(rows: list[dict]) -> bytes:
+    """Build an in-memory CSV from a list of dicts."""
+    if not rows:
+        return b"title,price,product_type\n"
+    headers = list(rows[0].keys())
+    buf = io.StringIO()
+    buf.write(",".join(headers) + "\n")
+    for r in rows:
+        buf.write(",".join(str(r[h]) for h in headers) + "\n")
+    return buf.getvalue().encode("utf-8")
+
+
+def _post_merchant(client: TestClient, *, merchant_id: str, **overrides):
+    """POST /merchant helper. ``overrides`` patches form fields and CSV rows."""
+    rows = overrides.pop("rows", None) or [
+        {"title": "Test Book One", "price": "9.99", "product_type": "book"},
+        {"title": "Test Book Two", "price": "12.50", "product_type": "book"},
+    ]
+    data = {
+        "merchant_id": merchant_id,
+        "domain": overrides.pop("domain", "books"),
+        "product_type": overrides.pop("product_type", "book"),
+    }
+    for k in ("strategy", "kg_strategy", "col_map"):
+        if k in overrides:
+            data[k] = overrides.pop(k)
+    files = {"file": ("catalog.csv", _csv_bytes(rows), "text/csv")}
+    return client.post("/merchant", data=data, files=files)
+
+
+# ---------------------------------------------------------------------------
+# POST /merchant
+# ---------------------------------------------------------------------------
+
+
+def test_post_creates_merchant_and_search_returns_uploaded_rows(
+    client, temp_merchant_ids, stub_enrichment_and_vector
+):
+    """End-to-end: POST a CSV, then /merchant/{id}/search returns its rows.
+
+    Asserts that ``Offer.product.product_id`` is one of the IDs that
+    landed in ``merchants.products_<id>`` from this POST — proves the
+    new merchant agent is dispatched (not the default catalog).
+    Score semantics are out of scope here.
+    """
+    mid = temp_merchant_ids[0]
+
+    resp = _post_merchant(client, merchant_id=mid)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["merchant_id"] == mid
+    assert body["onboarding_state"] == "ready"
+    assert body["catalog_size"] == 2
+
+    # Snapshot the IDs that actually landed in the per-merchant table —
+    # cannot pre-compute them because csv_loader assigns UUIDs at insert.
+    db = _Session()
+    try:
+        # The Postgres column is 'id'; the Python ORM attribute is 'product_id'.
+        rows = db.execute(
+            text(f"SELECT id FROM merchants.products_{mid}")
+        ).all()
+    finally:
+        db.close()
+    posted_ids = {str(r[0]) for r in rows}
+    assert len(posted_ids) == 2
+
+    search_resp = client.post(
+        f"/merchant/{mid}/search",
+        json={"domain": "books", "top_k": 5},
+    )
+    assert search_resp.status_code == 200, search_resp.text
+    offers = search_resp.json()
+    assert offers, "search returned no offers — merchant agent not dispatched"
+    returned_ids = {o["product"]["product_id"] for o in offers}
+    assert returned_ids & posted_ids, (
+        f"none of the returned offers are from this merchant's catalog. "
+        f"returned={returned_ids} posted={posted_ids}"
+    )
+
+
+def test_post_invalid_merchant_id_returns_400(
+    client, stub_enrichment_and_vector
+):
+    """Slug grammar is enforced at the boundary, before the upload is read."""
+    resp = _post_merchant(client, merchant_id="BadID-with-hyphen")
+    assert resp.status_code == 400, resp.text
+    assert "merchant_id" in resp.json()["detail"]
+
+
+def test_post_duplicate_merchant_id_returns_409_and_leaves_existing_intact(
+    client, temp_merchant_ids, stub_enrichment_and_vector
+):
+    """Re-POST is rejected without touching the existing rows.
+
+    The CSV load path is append-only; a silent re-POST would duplicate
+    every row in ``merchants.products_<id>``. The 409 is the only thing
+    standing between an operator's typo and a doubled catalog.
+    """
+    mid = temp_merchant_ids[1]
+
+    # First POST seeds the merchant.
+    first = _post_merchant(client, merchant_id=mid)
+    assert first.status_code == 201
+
+    db = _Session()
+    try:
+        before_count = db.execute(
+            text(f"SELECT COUNT(*) FROM merchants.products_{mid}")
+        ).scalar()
+        before_registry = db.execute(
+            text(
+                "SELECT domain, strategy, kg_strategy "
+                "FROM merchants.registry WHERE merchant_id = :mid"
+            ),
+            {"mid": mid},
+        ).mappings().first()
+    finally:
+        db.close()
+
+    # Second POST with the same id, deliberately different payload — the
+    # 409 must fire before any write, so even the registry row stays put.
+    dup = _post_merchant(
+        client,
+        merchant_id=mid,
+        domain="apparel",
+        rows=[{"title": "Should Not Land", "price": "1.00", "product_type": "book"}],
+    )
+    assert dup.status_code == 409, dup.text
+    assert mid in dup.json()["detail"]
+
+    db = _Session()
+    try:
+        after_count = db.execute(
+            text(f"SELECT COUNT(*) FROM merchants.products_{mid}")
+        ).scalar()
+        after_registry = db.execute(
+            text(
+                "SELECT domain, strategy, kg_strategy "
+                "FROM merchants.registry WHERE merchant_id = :mid"
+            ),
+            {"mid": mid},
+        ).mappings().first()
+    finally:
+        db.close()
+    assert after_count == before_count, (
+        f"duplicate POST mutated catalog: {before_count} -> {after_count}"
+    )
+    assert dict(after_registry) == dict(before_registry), (
+        "duplicate POST mutated registry row"
+    )
+
+
+def test_post_persists_explicit_kg_strategy(
+    client, temp_merchant_ids, stub_enrichment_and_vector
+):
+    """The kg_strategy form field is threaded into the registry UPSERT."""
+    mid = temp_merchant_ids[2]
+
+    resp = _post_merchant(
+        client, merchant_id=mid, kg_strategy="alt_kg_v1"
+    )
+    assert resp.status_code == 201, resp.text
+
+    with _engine.connect() as conn:
+        row = conn.execute(
+            text(
+                "SELECT kg_strategy FROM merchants.registry "
+                "WHERE merchant_id = :mid"
+            ),
+            {"mid": mid},
+        ).mappings().first()
+    assert row is not None
+    assert row["kg_strategy"] == "alt_kg_v1"
+
+
+# ---------------------------------------------------------------------------
+# GET /merchant
+# ---------------------------------------------------------------------------
+
+
+def test_get_lists_default_and_new_merchant_with_all_fields(
+    client, temp_merchant_ids, stub_enrichment_and_vector
+):
+    """GET returns one entry per registry row with the full six-field shape.
+
+    ``catalog_size`` must reflect the live COUNT(*) from the per-merchant
+    table — the registry doesn't cache it, so the value drifts the moment
+    rows are inserted or deleted.
+    """
+    mid = temp_merchant_ids[0]
+
+    create = _post_merchant(client, merchant_id=mid)
+    assert create.status_code == 201
+
+    resp = client.get("/merchant")
+    assert resp.status_code == 200, resp.text
+    entries = resp.json()
+    by_id = {e["merchant_id"]: e for e in entries}
+
+    assert "default" in by_id, "default merchant must always be listed"
+
+    new = by_id.get(mid)
+    assert new is not None, f"newly POSTed merchant {mid} not in GET output"
+    assert set(new.keys()) == {
+        "merchant_id", "domain", "strategy",
+        "kg_strategy", "catalog_size", "created_at",
+    }
+    assert new["domain"] == "books"
+    assert new["catalog_size"] == 2  # matches the two CSV rows
+
+
+# ---------------------------------------------------------------------------
+# DELETE /merchant/{merchant_id}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_without_env_var_returns_403(
+    client, temp_merchant_ids, stub_enrichment_and_vector, monkeypatch
+):
+    """Without ``ALLOW_MERCHANT_DROP=1`` the helper raises and we surface 403."""
+    mid = temp_merchant_ids[0]
+
+    create = _post_merchant(client, merchant_id=mid)
+    assert create.status_code == 201
+
+    # Deliberately pop the env var the underlying helper guards on.
+    monkeypatch.delenv("ALLOW_MERCHANT_DROP", raising=False)
+
+    resp = client.delete(f"/merchant/{mid}")
+    assert resp.status_code == 403, resp.text
+
+    # Registry row still present — DELETE was a no-op.
+    with _engine.connect() as conn:
+        still_there = conn.execute(
+            text(
+                "SELECT 1 FROM merchants.registry WHERE merchant_id = :mid"
+            ),
+            {"mid": mid},
+        ).first()
+    assert still_there is not None
+
+
+def test_delete_with_env_var_removes_registry_row_dict_and_get_listing(
+    client, temp_merchant_ids, stub_enrichment_and_vector, monkeypatch
+):
+    """The happy path — DELETE drops tables, registry row, and the cache entry."""
+    mid = temp_merchant_ids[1]
+
+    create = _post_merchant(client, merchant_id=mid)
+    assert create.status_code == 201
+    assert mid in app_main.merchants  # from_csv populated the dict
+
+    monkeypatch.setenv("ALLOW_MERCHANT_DROP", "1")
+
+    resp = client.delete(f"/merchant/{mid}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"merchant_id": mid, "deleted": True}
+
+    # Registry row gone.
+    with _engine.connect() as conn:
+        gone = conn.execute(
+            text(
+                "SELECT 1 FROM merchants.registry WHERE merchant_id = :mid"
+            ),
+            {"mid": mid},
+        ).first()
+    assert gone is None
+
+    # Dict entry gone.
+    assert mid not in app_main.merchants
+
+    # GET no longer lists it.
+    listing = client.get("/merchant").json()
+    assert mid not in {e["merchant_id"] for e in listing}
+
+
+def test_delete_default_returns_400_even_with_env_var(
+    client, monkeypatch
+):
+    """The default merchant is the clone template — refuse even when armed."""
+    monkeypatch.setenv("ALLOW_MERCHANT_DROP", "1")
+
+    resp = client.delete("/merchant/default")
+    assert resp.status_code == 400, resp.text
+    assert "default" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Wraps `MerchantAgent.from_csv` behind three sync HTTP routes so other features (upload UI, internal tools, integrations) can provision merchants without reaching into the Python API. Closes interactive-decision-support-system/idss-backend#54.

- **`POST /merchant`** — multipart CSV upload. Validates `merchant_id` against `MERCHANT_ID_RE`, rejects duplicates with **409** (the CSV load path is append-only; a silent re-POST would double-insert into `merchants.products_<id>`), threads `kg_strategy` into both the agent and the registry UPSERT, returns 201 with the live `catalog_size`.
- **`GET /merchant`** — lists registry rows as `{merchant_id, domain, strategy, kg_strategy, catalog_size, created_at}`. `catalog_size` is computed live via COUNT(*) on the per-merchant table — the registry doesn't cache it.
- **`DELETE /merchant/{id}`** — drops tables, deletes the registry row, evicts the in-memory cache. Gated on `ALLOW_MERCHANT_DROP=1` (surfaced as **403** when unset). Refuses `default` even when armed, since it's the clone template every new merchant copies from.

Provisioning is currently sync. Pre-PR, callers used `MerchantAgent.from_csv` directly from a Python shell — there is no `scripts/bootstrap_merchant.py` in the repo despite older issue text referencing one.

## Out of scope

- Auth / token gating — tracked in interactive-decision-support-system/merchant-agent#2.
- Async ingest with progress polling — tracked in interactive-decision-support-system/idss-backend#39.
- KG build on ingest — tracked in interactive-decision-support-system/idss-backend#61. Search via a freshly-provisioned merchant will hit the positional `score` fallback at [`merchant_agent.py:362`](mcp-server/app/merchant_agent.py#L362) until then; the tests here intentionally don't assert on `score_breakdown`.
- Onboarding UI — cross-repo, tracked in interactive-decision-support-system/idss-backend#39.

## curl example

\`\`\`bash
# create
curl -F file=@catalog.csv \
     -F merchant_id=acme \
     -F domain=electronics \
     -F product_type=laptop \
     -F kg_strategy=default_v1 \
     http://localhost:8000/merchant

# list
curl http://localhost:8000/merchant

# delete (env-gated)
ALLOW_MERCHANT_DROP=1 \
curl -X DELETE http://localhost:8000/merchant/acme
\`\`\`

## Test plan

- [x] POST with a small CSV boots a new merchant; follow-up `/merchant/{id}/search` returns offers whose `product_id` is in the POSTed CSV.
- [x] POST with invalid `merchant_id` → 400 (boundary check fires before the upload is read).
- [x] POST with duplicate `merchant_id` → 409; the existing merchant's registry row and catalog row count are unchanged.
- [x] POST with explicit `kg_strategy` persists that value into `merchants.registry`.
- [x] GET returns the new merchant with all six fields; `default` is always present; `catalog_size` reflects the live row count.
- [x] DELETE without `ALLOW_MERCHANT_DROP=1` → 403; the registry row is preserved.
- [x] DELETE with `ALLOW_MERCHANT_DROP=1` → 200, registry row deleted, dict entry evicted, GET no longer lists it.
- [x] DELETE on `default` → 400 even when `ALLOW_MERCHANT_DROP=1` is set.

8 new admin-route tests pass against Supabase Postgres. Existing merchant tests (registry persistence, default collapse, merchant stub) still pass — 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)