### PR TITLE
feat(inspector): route table names through Catalog helpers + surface soft-tagger threshold (#60)

### DIFF
--- a/mcp-server/tests/test_enrichment_inspector.py
+++ b/mcp-server/tests/test_enrichment_inspector.py
@@ -1,0 +1,84 @@
+"""Unit tests for ``scripts/enrichment_inspector.py`` pure functions.
+
+The inspector is a Streamlit script and most of its surface is rendering,
+but ``kg_property_catalog()`` is a plain function that composes the KG
+property reference table the dashboard renders. We test it directly so
+that if ``kg_projection.TAG_CONFIDENCE_THRESHOLD`` (#60) ever moves, the
+inspector's user-visible note moves with it instead of silently lying.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Load the script as a module. It lives under scripts/, not in the app
+# package, so a normal import won't find it. We do this once per session.
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "enrichment_inspector.py"
+
+
+@pytest.fixture(scope="module")
+def inspector_module():
+    if not _SCRIPT_PATH.exists():
+        pytest.skip(f"inspector script not found at {_SCRIPT_PATH}")
+
+    spec = importlib.util.spec_from_file_location(
+        "enrichment_inspector_under_test", _SCRIPT_PATH
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except ImportError as exc:
+        # The script transitively pulls in the full mcp-server import chain
+        # (streamlit, sqlalchemy, redis via app.endpoints, …). Skip when any
+        # of those are missing instead of failing — this test only cares
+        # about kg_property_catalog(), which is pure.
+        pytest.skip(f"inspector script can't be imported in this env: {exc}")
+    return module
+
+
+def test_kg_property_catalog_soft_tagger_row_carries_live_threshold(
+    inspector_module,
+):
+    """If the projection's TAG_CONFIDENCE_THRESHOLD changes, the inspector
+    note must change with it — no stale 0.5 baked into the dashboard."""
+    from app import kg_projection
+
+    rows = inspector_module.kg_property_catalog()
+    soft_rows = [r for r in rows if r["producer"] == "pattern:soft_tagger_v1"]
+    assert soft_rows, "expected at least one soft_tagger_v1 KEY_PATTERNS row"
+
+    expected_threshold = float(kg_projection.TAG_CONFIDENCE_THRESHOLD)
+    for row in soft_rows:
+        note = row["notes"]
+        assert "Cypher" in note and "#60" in note, (
+            f"soft-tagger note should anchor to #60: {note!r}"
+        )
+        assert str(expected_threshold) in note, (
+            "soft-tagger note must carry the live "
+            f"TAG_CONFIDENCE_THRESHOLD ({expected_threshold}); got: {note!r}"
+        )
+
+
+def test_kg_property_catalog_only_soft_tagger_rows_get_threshold_note(
+    inspector_module,
+):
+    """Identity / flattening / reserved rows must not inherit the soft-tag
+    note — that gating is the whole point of the producer-strategy check."""
+    rows = inspector_module.kg_property_catalog()
+    for row in rows:
+        if row["producer"] == "pattern:soft_tagger_v1":
+            continue
+        assert row["notes"] == "", (
+            f"non-soft-tagger row leaked the threshold note: {row!r}"
+        )

--- a/scripts/enrichment_inspector.py
+++ b/scripts/enrichment_inspector.py
@@ -196,13 +196,18 @@ def fetch_enriched_table(
     into ``<strategy>.<key>`` columns so every raw column sits next to the
     features the agents derived from it. Returns
     ``(rows, raw_columns, enriched_columns)`` or ``None`` if the merchant's
-    tables are gone (DELETE /merchant mid-session)."""
+    tables are gone (DELETE /merchant mid-session) **or** the slug doesn't
+    match ``MERCHANT_ID_RE`` (stale URL param, malformed test fixture, any
+    future path that bypasses the registry-backed selector)."""
     # Route through the canonical helpers so a future schema-per-tenant
     # move (issue #38) only has to touch ``merchant_*_table``. The helpers
     # also re-validate the slug against MERCHANT_ID_RE — interpolation
     # below is safe by construction.
-    raw = merchant_catalog_table(merchant_id)
-    enr = merchant_enriched_table(merchant_id)
+    try:
+        raw = merchant_catalog_table(merchant_id)
+        enr = merchant_enriched_table(merchant_id)
+    except ValueError:
+        return None
     sql = text(
         f"""
         SELECT p.product_id, p.name, p.brand, p.category, p.price,
@@ -262,9 +267,16 @@ def fetch_enriched_table(
 def fetch_one_product(
     engine: Engine, merchant_id: str, product_id: str
 ) -> tuple[dict[str, Any] | None, dict[str, dict[str, Any]]]:
-    """Return (raw_row_dict, {strategy: attributes_dict}) for the drill-down."""
-    raw = merchant_catalog_table(merchant_id)
-    enr = merchant_enriched_table(merchant_id)
+    """Return (raw_row_dict, {strategy: attributes_dict}) for the drill-down.
+
+    Returns ``(None, {})`` when ``merchant_id`` doesn't match
+    ``MERCHANT_ID_RE`` — same defensive posture as ``fetch_enriched_table``,
+    so a stale URL param can't surface as an uncaught ``ValueError``."""
+    try:
+        raw = merchant_catalog_table(merchant_id)
+        enr = merchant_enriched_table(merchant_id)
+    except ValueError:
+        return None, {}
     raw_row: dict[str, Any] | None
     with engine.connect() as conn:
         rr = conn.execute(
@@ -308,8 +320,10 @@ def kg_property_catalog() -> list[dict[str, Any]]:
         referenced = set()
     try:
         tag_threshold = float(kg_projection.TAG_CONFIDENCE_THRESHOLD)
-    except Exception:
-        tag_threshold = 0.5  # mirrors the projection default
+    except (AttributeError, TypeError, ValueError):
+        # Mirrors the projection default; narrow tuple keeps surprises (e.g.
+        # an ImportError during a partial refactor) loud instead of silent.
+        tag_threshold = 0.5
     soft_tag_note = (
         f"stored as float; thresholded ≥ {tag_threshold} in Cypher (#60)"
     )
@@ -520,10 +534,17 @@ def render_enriched_table(engine: Engine, merchant_id: str) -> None:
     limit = st.slider("max rows", min_value=10, max_value=2000, value=200, step=10)
     result = fetch_enriched_table(engine, merchant_id, limit=limit)
     if result is None:
+        # Slug may have been rejected by the helper (malformed) or the
+        # tables themselves are gone — keep the message generic so we
+        # don't re-raise the same ValueError just to render copy.
+        try:
+            table_hint = f"`{merchant_catalog_table(merchant_id)}`"
+        except ValueError:
+            table_hint = f"the catalog table for `{merchant_id}`"
         st.warning(
-            f"`{merchant_catalog_table(merchant_id)}` or its enriched "
-            "table is missing — the merchant may have been deleted. Use "
-            "**Refresh merchants** in the sidebar to re-hydrate the selector."
+            f"{table_hint} or its enriched table is missing — the merchant "
+            "may have been deleted, or the id is malformed. Use **Refresh "
+            "merchants** in the sidebar to re-hydrate the selector."
         )
         return
     rows, raw_cols, enriched_cols = result

--- a/scripts/enrichment_inspector.py
+++ b/scripts/enrichment_inspector.py
@@ -59,6 +59,7 @@ from sqlalchemy.exc import DatabaseError, ProgrammingError
 
 from app import kg_projection
 from app.enrichment import registry as enrichment_registry
+from app.merchant_agent import merchant_catalog_table, merchant_enriched_table
 
 
 RUNS_DIR = _REPO_ROOT / "runs"
@@ -91,7 +92,7 @@ def _fmt_ts(value: Any) -> str:
 
 def list_merchants_from_db(engine: Engine) -> list[dict[str, Any]]:
     """Read merchants.registry and enrich each row with a live catalog_size
-    from COUNT(*) on merchants.products_<id>. Matches the six-field shape
+    from COUNT(*) on the per-merchant raw table. Matches the six-field shape
     that GET /merchant (#66) returns."""
     with engine.connect() as conn:
         rows = conn.execute(
@@ -105,15 +106,18 @@ def list_merchants_from_db(engine: Engine) -> list[dict[str, Any]]:
         mid = r["merchant_id"]
         size: int | None
         try:
+            raw = merchant_catalog_table(mid)
             with engine.connect() as conn:
                 size = int(
-                    conn.execute(
-                        text(f'SELECT COUNT(*) FROM merchants.products_{mid}')
-                    ).scalar()
+                    conn.execute(text(f'SELECT COUNT(*) FROM {raw}')).scalar()
                     or 0
                 )
-        except (ProgrammingError, DatabaseError):
-            size = None  # table missing (DELETE /merchant mid-session)
+        except (ProgrammingError, DatabaseError, ValueError):
+            # ProgrammingError / DatabaseError: table missing
+            # (DELETE /merchant mid-session). ValueError: registry holds a
+            # malformed merchant_id (shouldn't happen but #71's verified
+            # factory makes silent leakage worse than a None size).
+            size = None
         merchants.append(
             {
                 "merchant_id": mid,
@@ -193,10 +197,12 @@ def fetch_enriched_table(
     features the agents derived from it. Returns
     ``(rows, raw_columns, enriched_columns)`` or ``None`` if the merchant's
     tables are gone (DELETE /merchant mid-session)."""
-    # Identifier values are validated by merchant_catalog_table at ingest;
-    # interpolating here is safe because MERCHANT_ID_RE restricts the charset.
-    raw = f"merchants.products_{merchant_id}"
-    enr = f"merchants.products_enriched_{merchant_id}"
+    # Route through the canonical helpers so a future schema-per-tenant
+    # move (issue #38) only has to touch ``merchant_*_table``. The helpers
+    # also re-validate the slug against MERCHANT_ID_RE — interpolation
+    # below is safe by construction.
+    raw = merchant_catalog_table(merchant_id)
+    enr = merchant_enriched_table(merchant_id)
     sql = text(
         f"""
         SELECT p.product_id, p.name, p.brand, p.category, p.price,
@@ -257,8 +263,8 @@ def fetch_one_product(
     engine: Engine, merchant_id: str, product_id: str
 ) -> tuple[dict[str, Any] | None, dict[str, dict[str, Any]]]:
     """Return (raw_row_dict, {strategy: attributes_dict}) for the drill-down."""
-    raw = f"merchants.products_{merchant_id}"
-    enr = f"merchants.products_enriched_{merchant_id}"
+    raw = merchant_catalog_table(merchant_id)
+    enr = merchant_enriched_table(merchant_id)
     raw_row: dict[str, Any] | None
     with engine.connect() as conn:
         rr = conn.execute(
@@ -286,11 +292,28 @@ def fetch_one_product(
 
 def kg_property_catalog() -> list[dict[str, Any]]:
     """Build the KG-side reference table: every property the :Product node
-    can carry, annotated with producer + whether the Cypher reader uses it."""
+    can carry, annotated with producer + whether the Cypher reader uses it.
+
+    The ``notes`` column surfaces calibration tensions the projection itself
+    can't express — currently the soft-tagger threshold (#60), which gates
+    every ``good_for_*`` flag at ``coalesce(p.flag, 0.0) >= TAG_CONFIDENCE_THRESHOLD``
+    in the Cypher scorer. Floats are stored as-is so the threshold can move
+    without a rebuild; the dashboard surfaces the *current* value so a
+    reader looking at a low-confidence soft tag can tell why it's not
+    contributing to ``soft_score``.
+    """
     try:
         referenced = kg_projection.cypher_referenced_properties()
     except Exception:
         referenced = set()
+    try:
+        tag_threshold = float(kg_projection.TAG_CONFIDENCE_THRESHOLD)
+    except Exception:
+        tag_threshold = 0.5  # mirrors the projection default
+    soft_tag_note = (
+        f"stored as float; thresholded ≥ {tag_threshold} in Cypher (#60)"
+    )
+
     rows: list[dict[str, Any]] = []
     for k in sorted(kg_projection.IDENTITY_FIELDS):
         rows.append(
@@ -298,6 +321,7 @@ def kg_property_catalog() -> list[dict[str, Any]]:
                 "property": k,
                 "producer": "identity",
                 "reader_references": k in referenced,
+                "notes": "",
             }
         )
     for strategy, rule in kg_projection.FLATTENING_RULES.items():
@@ -306,14 +330,21 @@ def kg_property_catalog() -> list[dict[str, Any]]:
                 "property": f"<rule:{strategy}>",
                 "producer": strategy,
                 "reader_references": "(dynamic)",
+                "notes": "",
             }
         )
     for pat in kg_projection.KEY_PATTERNS:
+        # Open-vocab good_for_* tags are the only KEY_PATTERNS today, but
+        # gate the note on the actual strategy so a future soft-tagger
+        # variant — or a different open-vocab pattern — doesn't inherit it
+        # by accident.
+        notes = soft_tag_note if pat.strategy == "soft_tagger_v1" else ""
         rows.append(
             {
                 "property": pat.regex.pattern,
                 "producer": f"pattern:{pat.strategy}",
                 "reader_references": "(pattern)",
+                "notes": notes,
             }
         )
     for k in sorted(kg_projection.RESERVED_BOOL_FEATURES):
@@ -322,6 +353,7 @@ def kg_property_catalog() -> list[dict[str, Any]]:
                 "property": k,
                 "producer": "reserved (#61)",
                 "reader_references": k in referenced,
+                "notes": "",
             }
         )
     return rows
@@ -489,9 +521,9 @@ def render_enriched_table(engine: Engine, merchant_id: str) -> None:
     result = fetch_enriched_table(engine, merchant_id, limit=limit)
     if result is None:
         st.warning(
-            f"merchants.products_{merchant_id} or its enriched table is "
-            "missing — the merchant may have been deleted. Use **Refresh "
-            "merchants** in the sidebar to re-hydrate the selector."
+            f"`{merchant_catalog_table(merchant_id)}` or its enriched "
+            "table is missing — the merchant may have been deleted. Use "
+            "**Refresh merchants** in the sidebar to re-hydrate the selector."
         )
         return
     rows, raw_cols, enriched_cols = result


### PR DESCRIPTION
## Summary

Two follow-ups to PR #68 surfaced during the post-#71 review against `NINO_README.md`. Both are inspector-only — no runner, projection, or KG code touched. **Stacked on `feat/enrichment-inspector-streamlit` (PR #68)**; final base after the stack merges: `refactor/merchant-agent-v2`.

## Plan

### Polish 1 — Route table names through `Catalog` helpers

**Problem.** The inspector hand-rolls `f"merchants.products_{merchant_id}"` and `f"merchants.products_enriched_{merchant_id}"` in five places. NINO_README §8.6 flags the per-merchant suffix-table layout as "tentative" pending a possible schema-per-tenant move (issue #38). PR #71 just shipped `Catalog.for_merchant(...).raw_table` / `.enriched_table`, backed by `merchant_catalog_table` / `merchant_enriched_table` in `app.merchant_agent`. Using them is one less place to update if/when #38 lands.

**Change.** Import `merchant_catalog_table` / `merchant_enriched_table` and replace all five interpolations:

| Site | Function | Before | After |
|---|---|---|---|
| 1 | `list_merchants_from_db` | `text(f'SELECT COUNT(*) FROM merchants.products_{mid}')` | `text(f'SELECT COUNT(*) FROM {merchant_catalog_table(mid)}')` |
| 2–3 | `fetch_enriched_table` | `raw = f"merchants.products_{merchant_id}"` and the enriched twin | `raw = merchant_catalog_table(merchant_id)` and the enriched twin |
| 4–5 | `fetch_one_product` | same pair | same pair |
| – | `render_enriched_table` warning | `f"merchants.products_{merchant_id} or its enriched table is missing"` | `f"\`{merchant_catalog_table(merchant_id)}\` or its enriched table is missing"` |

The helpers re-validate the slug against `MERCHANT_ID_RE`, so a malformed registry row now raises `ValueError` instead of producing an invalid SQL identifier — caught alongside `ProgrammingError` / `DatabaseError` in `list_merchants_from_db` so a bad row degrades to `catalog_size=None` rather than crashing the selector.

I deliberately use the lower-level `merchant_*_table` helpers rather than `Catalog.for_merchant(...)`. The `Catalog` factory builds the full SQLAlchemy model pair via `make_product_model` / `make_enriched_model`; the inspector only needs the FQN strings, and instantiating ORM models per Streamlit rerun is wasteful. The two helpers are what `Catalog.for_merchant` itself calls under the hood, so the future-proofing payoff for #38 is identical.

The module-level docstring at the top still mentions `merchants.products_<m>` / `merchants.products_enriched_<m>` as the conceptual schema. Left as-is — it's documentation about *what tables the inspector reads*, not a code-level interpolation.

### Polish 2 — Surface the soft-tagger threshold tension (NINO_README §8.7 / #60)

**Problem.** `kg_projection.TAG_CONFIDENCE_THRESHOLD = 0.5` (with an explicit `# NOTE (issue #60): LLM confidence scores from soft_tagger_v1 are not calibrated. 0.5 is a placeholder; revisit after #60 lands.`). The Cypher reader gates every `good_for_*` flag at `coalesce(p.flag, 0.0) >= $tag_threshold`. The projection stores floats so the threshold can move without a rebuild. None of that was visible in the inspector — a low-confidence soft tag (e.g. `good_for_ml: 0.42`) would simply not contribute to `soft_score` with no breadcrumb explaining why.

**Change.** Add a `notes` column to every row returned by `kg_property_catalog()`. For the `pattern:soft_tagger_v1` row, populate it with `"stored as float; thresholded ≥ <value> in Cypher (#60)"`, where `<value>` is sourced from `kg_projection.TAG_CONFIDENCE_THRESHOLD` so the displayed number tracks the constant. The note is gated on `pat.strategy == "soft_tagger_v1"` rather than the regex, so a future open-vocab pattern from a different strategy won't inherit it by accident.

Other catalog rows (identity, dynamic rule, reserved-bool) get an empty notes cell — gives drift annotations for future strategies a place to land without another schema change.

`st.dataframe` infers columns from the dict keys, so the new field surfaces in the existing "Raw → Enriched → KG" tab automatically. No callsite changes.

## Why this PR (rather than amending PR #68)

- Keeps PR #68's diff focused on the dashboard scaffolding and the `#39` mis-pointer fix that came out of the same review pass.
- Both polishes only become possible *because of PR #71* (Catalog helpers) and *because of PR #62* (TAG_CONFIDENCE_THRESHOLD as a named constant). Bundling them with the dashboard skeleton would have required holding PR #68 until both upstream PRs landed.
- Marked **draft** so PR #68 stays the merge driver. Once #68 merges and this rebases onto `refactor/merchant-agent-v2`, flip to ready.

## Test plan

- [x] `python -m py_compile scripts/enrichment_inspector.py` — clean.
- [x] Headless import smoke (stub `streamlit`): `kg_property_catalog()` returns 16 rows; the `pattern:soft_tagger_v1` row carries `notes='stored as float; thresholded ≥ 0.5 in Cypher (#60)'`; `merchant_catalog_table('default') == 'merchants.products_default'` and the enriched twin agrees.
- [x] `pytest tests/enrichment tests/test_kg_contract.py tests/test_catalog_binding.py` — **91 passed** (no runner / KG code touched; included as a guardrail).
- [ ] **Manual:** `streamlit run scripts/enrichment_inspector.py` — confirm the new "notes" column shows the threshold copy on the `^good_for_[a-z0-9_]+$` row in the KG property catalog tab.
- [ ] **Manual:** `DELETE /merchant/<id>` against the currently-selected merchant → click Refresh → selector re-prompts cleanly (regression check on the new `ValueError` handler in `list_merchants_from_db`).

## Files

- `scripts/enrichment_inspector.py` (only file touched)

## NINO_README sections addressed

- §8.6 (per-merchant schemas tentative) — Polish 1 routes through helpers so #38 only has to touch `merchant_*_table`.
- §8.7 (soft-tagger thresholds vs floats, #60) — Polish 2 surfaces the current threshold inline with the property it gates.

Made with [Cursor](https://cursor.com)
