### PR TITLE
chore: split default merchant into raw snapshot + filtered view

### DIFF
--- a/mcp-server/app/ingestion/schema.py
+++ b/mcp-server/app/ingestion/schema.py
@@ -9,10 +9,15 @@ Both are cloned from the default merchant's tables via ``LIKE ... INCLUDING
 ALL``. The FK from enriched → raw is re-added explicitly because LIKE does
 not copy foreign keys.
 
-Prerequisite: migrations 002 and 003 must have run — the clone reads from
-``merchants.products_default`` / ``merchants.products_enriched_default``
+Prerequisite: migrations 002, 003, and 006 must have run — the clone reads
+from ``merchants.raw_products_default`` / ``merchants.products_enriched_default``
 as the template, and ``create_merchant_catalog`` raises a bare Postgres
 "relation does not exist" if those tables aren't there yet.
+
+The raw template is the full unfiltered snapshot, not the quality-filtered
+``products_default`` view (see migration 006): a new merchant uploading its
+own catalog needs the base table schema, not a projection that's specific
+to the default snapshot's quirks.
 
 All identifiers that interpolate the merchant_id are built via
 ``psycopg2.sql.Identifier`` after ``validate_merchant_id`` has matched the
@@ -33,7 +38,9 @@ from app.merchant_agent import validate_merchant_id
 logger = logging.getLogger(__name__)
 
 _SCHEMA = "merchants"
-_TEMPLATE_RAW = "products_default"
+# Clone from the raw snapshot, not the products_default view. CREATE TABLE ... LIKE
+# errors against a view, and new merchants want the base schema regardless.
+_TEMPLATE_RAW = "raw_products_default"
 _TEMPLATE_ENRICHED = "products_enriched_default"
 
 

--- a/mcp-server/migrations/006_split_products_default_into_raw_and_filtered.sql
+++ b/mcp-server/migrations/006_split_products_default_into_raw_and_filtered.sql
@@ -1,0 +1,82 @@
+-- =============================================================================
+-- 006_split_products_default_into_raw_and_filtered.sql
+--
+-- Introduce the raw / cleaned split in the default merchant catalog.
+--
+-- Before:
+--   merchants.products_default           — full snapshot of public.products
+--                                          (51,277 rows; includes NULL-price
+--                                          laptops, Open Library "book" rows,
+--                                          $99,999 sentinel prices, and rows
+--                                          with NULL product_type).
+--
+-- After:
+--   merchants.raw_products_default       — renamed original table. Immutable
+--                                          full copy, kept for reproducibility
+--                                          (storefront sampling, enrichment
+--                                          benchmarks, data-quality audits).
+--   merchants.products_default           — VIEW over raw with quality filters.
+--                                          This is what the application reads.
+--
+-- Filter rationale (2026-04-19 catalog audit):
+--   * product_type IS NOT NULL           drops ~14 rows the scraper never tagged.
+--   * product_type <> 'book'             drops 16 Open Library rows (wrong vertical).
+--   * price IS NOT NULL                  drops ~17,440 mostly-laptop rows with no
+--                                          scraped price — a priceless storefront
+--                                          item is not a storefront item.
+--   * price > 0                          drops 2 router rows priced at 0.
+--   * price < 500000 AND price <> 99999  drops sentinel placeholders (~65 rows
+--                                          across smartphone, tv, smartwatch,
+--                                          tablet, phone, ipad) and the 950125
+--                                          ipad outlier.
+--
+-- Post-filter row count: 33,755 (verified 2026-04-19).
+--
+-- Why a VIEW, not a materialized table:
+--   * Raw is a one-shot snapshot (migration 002 semantics); the cleaned
+--     projection has no independent lifecycle.
+--   * No drift risk — filtered state is always derivable.
+--   * The FK merchants.products_enriched_default.product_id
+--     → merchants.products_default(id) follows the rename automatically,
+--     so enriched rows remain keyed against the RAW UUIDs. That is what we
+--     want: enrichment identity is ground truth, not the filtered projection.
+--     (Consequence: if a product is later removed by the filter, its enriched
+--     rows simply become unreachable through the view. Not a correctness bug.)
+--
+-- Idempotent. Safe to re-run.
+-- =============================================================================
+-- Usage: psql $DATABASE_URL -f mcp-server/migrations/006_split_products_default_into_raw_and_filtered.sql
+-- =============================================================================
+
+BEGIN;
+
+-- Step 1: rename the underlying table. FKs, indexes, and the PK follow
+-- automatically. Guarded with IF EXISTS so a re-run after manual rollback
+-- (where products_default was recreated as a view) is a no-op on this line.
+ALTER TABLE IF EXISTS merchants.products_default
+  RENAME TO raw_products_default;
+
+ALTER INDEX IF EXISTS merchants.idx_merchants_products_default_merchant_id
+  RENAME TO idx_merchants_raw_products_default_merchant_id;
+
+-- Step 2: (re)create the filtered view at the original name. The DROP handles
+-- the re-run case where a stale view already sits at merchants.products_default.
+DROP VIEW IF EXISTS merchants.products_default;
+
+CREATE VIEW merchants.products_default AS
+SELECT *
+FROM merchants.raw_products_default
+WHERE product_type IS NOT NULL
+  AND product_type <> 'book'
+  AND price IS NOT NULL
+  AND price > 0
+  AND price < 500000
+  AND price <> 99999;
+
+COMMENT ON VIEW merchants.products_default IS
+  'Quality-filtered projection of raw_products_default. Application reads go through this view. See migration 006 for filter rationale.';
+
+COMMENT ON TABLE merchants.raw_products_default IS
+  'Full, immutable snapshot of public.products for the default merchant. Preserved for benchmarking and reproducibility; not read by the application directly — reads go through the products_default view.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Rename `merchants.products_default` → `merchants.raw_products_default` (full immutable snapshot, ~51k rows).
- Re-create `merchants.products_default` as a VIEW over raw that drops known-bad rows → ~34k rows. Same name, so every existing reader keeps working.
- Update `ingestion/schema.py` to clone new merchants from `raw_products_default` (the base table), since `CREATE TABLE ... LIKE` errors against a view.

## Why

2026-04-19 audit of `merchants.products_default` found (51,277 raw rows → 33,755 clean):

| Filter | Rows dropped |
|---|---|
| `product_type IS NULL` | ~14 |
| `product_type = 'book'` (Open Library noise) | 16 |
| `price IS NULL` (mostly laptops with no scraped price) | ~17,440 |
| `price = 0` | 2 |
| `price = 99999` or `price > 500000` (sentinels) | ~65 |

Keeping the raw snapshot is important for benchmarking the enrichment layer (PRs #67, #68): storefront-generation work needs the full, unfiltered catalog as a golden source even after the app-facing table is cleaned.

## Design notes

- **VIEW, not materialized table** — raw is a frozen snapshot with no independent lifecycle, so the filtered projection is always derivable. No drift risk.
- **FK follows the rename.** `products_enriched_default.product_id` now points to `raw_products_default(id)`. Enrichment identity stays keyed to raw UUIDs — ground truth, not the current filter. Enriched rows for filtered-out products become unreachable through the view but remain valid references; they cascade-delete if the raw row is removed.
- **`schema.py` template change is load-bearing.** Without it, `create_merchant_catalog` breaks: `CREATE TABLE ... LIKE <view>` errors in Postgres. Cloning from `raw_products_default` is also the right semantics — a newly uploaded merchant gets the base schema, not a projection tailored to the default snapshot's quirks.

## Test plan
- [ ] Apply migration on staging: `psql $DATABASE_URL -f mcp-server/migrations/006_split_products_default_into_raw_and_filtered.sql`
- [ ] Verify row counts: `SELECT COUNT(*) FROM merchants.raw_products_default` (~51k) vs `SELECT COUNT(*) FROM merchants.products_default` (~34k)
- [ ] Verify FK resolved: `\d+ merchants.products_enriched_default` should show the FK pointing at `raw_products_default`
- [ ] Run `tests/test_default_merchant_collapse.py` — should still pass (query goes through the view)
- [ ] Provision a new merchant via `create_merchant_catalog` — should succeed (now clones from raw table, not view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)