### PR TITLE
Mock-laptop seed + per-merchant enrichment runs + inspector trace tab

### DIFF
--- a/mcp-server/app/enrichment/orchestration/runner.py
+++ b/mcp-server/app/enrichment/orchestration/runner.py
@@ -182,8 +182,14 @@ def _run_inner(
     dry_run: bool,
     audit: bool,
 ) -> RunResult:
+    catalog = Catalog.for_merchant(merchant_id)
+
     # 1) load products
-    products = load_products(db, merchant_id=merchant_id, limit=limit)
+    products = load_products(
+        db,
+        product_model=catalog.product_model,
+        limit=limit,
+    )
     per_product_dump: dict[str, list[dict[str, Any]]] = defaultdict(list)
     if not products:
         summary.notes.append("no_products_loaded")
@@ -262,7 +268,12 @@ def _run_inner(
             validator_mod.make_audit_output(product_id=pid, verdicts=verdicts)
             for pid, verdicts in verdicts_by_pid.items()
         )
-    db_writer.upsert_many(db, all_outputs, dry_run=dry_run)
+    db_writer.upsert_many(
+        db,
+        all_outputs,
+        enriched_model=catalog.enriched_model,
+        dry_run=dry_run,
+    )
 
     # 7) catalog schema + propose extensions
     schema = _build_catalog_schema(merchant_id, successful_outputs_by_pid, products)

--- a/mcp-server/app/enrichment/tools/db_writer.py
+++ b/mcp-server/app/enrichment/tools/db_writer.py
@@ -1,25 +1,36 @@
-"""UPSERT a StrategyOutput into merchants.products_enriched_default.
+"""UPSERT a StrategyOutput into merchants.products_enriched_<merchant>.
 
 Mirrors CatalogNormalizer.batch_normalize's write path so behavior is
 identical: pg_insert + on_conflict_do_update keyed by (product_id, strategy).
+
+The target table is bound by ``enriched_model`` — typically
+``Catalog.for_merchant(mid).enriched_model``. Hardcoding ProductEnriched
+(the default merchant's table) caused FK violations on raw_products_default
+for any non-default merchant after migration 006 retired the default-merchant
+privilege.
 """
 
 from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Iterable
+from typing import Any, Iterable
 
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from app.enrichment.types import StrategyOutput
-from app.models import ProductEnriched
 
 logger = logging.getLogger(__name__)
 
 
-def upsert_one(db: Session, output: StrategyOutput, *, dry_run: bool = False) -> None:
+def upsert_one(
+    db: Session,
+    output: StrategyOutput,
+    *,
+    enriched_model: Any,
+    dry_run: bool = False,
+) -> None:
     if dry_run:
         logger.info(
             "enrichment_dry_run_write",
@@ -32,7 +43,7 @@ def upsert_one(db: Session, output: StrategyOutput, *, dry_run: bool = False) ->
         return
 
     now = datetime.now(timezone.utc)
-    stmt = pg_insert(ProductEnriched).values(
+    stmt = pg_insert(enriched_model).values(
         product_id=output.product_id,
         strategy=output.strategy,
         attributes=output.attributes,
@@ -53,12 +64,13 @@ def upsert_many(
     db: Session,
     outputs: Iterable[StrategyOutput],
     *,
+    enriched_model: Any,
     dry_run: bool = False,
 ) -> int:
     """UPSERT a batch and commit once at the end. Returns count written."""
     count = 0
     for output in outputs:
-        upsert_one(db, output, dry_run=dry_run)
+        upsert_one(db, output, enriched_model=enriched_model, dry_run=dry_run)
         count += 1
     if count and not dry_run:
         db.commit()

--- a/mcp-server/tests/enrichment/test_runner.py
+++ b/mcp-server/tests/enrichment/test_runner.py
@@ -130,11 +130,15 @@ def patched_runtime(monkeypatch):
     monkeypatch.setattr(llm_module.LLMClient, "complete", lambda self, **kw: scripted.complete(**kw))
 
     written: list = []
-    monkeypatch.setattr(db_writer, "upsert_one", lambda db, out, dry_run=False: written.append(out))
+    monkeypatch.setattr(
+        db_writer,
+        "upsert_one",
+        lambda db, out, *, enriched_model, dry_run=False: written.append(out),
+    )
     monkeypatch.setattr(
         db_writer,
         "upsert_many",
-        lambda db, outs, dry_run=False: written.extend(outs) or len(written),
+        lambda db, outs, *, enriched_model, dry_run=False: written.extend(outs) or len(written),
     )
     return {"products": products, "scripted": scripted, "written": written}
 

--- a/scripts/enrichment_inspector.py
+++ b/scripts/enrichment_inspector.py
@@ -63,6 +63,7 @@ from app.merchant_agent import merchant_catalog_table, merchant_enriched_table
 
 
 RUNS_DIR = _REPO_ROOT / "runs"
+TRACES_DIR = _REPO_ROOT / "logs" / "enrichment_traces"
 LANGFUSE_HOST = os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com")
 MERCHANT_ADMIN_HOST = os.getenv("MERCHANT_ADMIN_HOST", "").rstrip("/") or None
 
@@ -695,6 +696,203 @@ def render_per_product(
     st.json(_jsonable(projected))
 
 
+def _load_trace_jsonl(run_id: str) -> list[dict[str, Any]] | None:
+    """Read ``logs/enrichment_traces/<run_id>.jsonl``.
+
+    Returns the parsed span list, or ``None`` if the file doesn't exist
+    (JSONL tracing is opt-in via ``ENRICHMENT_TRACE_JSONL=1``). Malformed
+    lines are skipped with a caption-level note so a single corrupt span
+    doesn't blank the whole tab.
+    """
+    path = TRACES_DIR / f"{run_id}.jsonl"
+    if not path.exists():
+        return None
+    spans: list[dict[str, Any]] = []
+    skipped = 0
+    with open(path, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                spans.append(json.loads(line))
+            except json.JSONDecodeError:
+                skipped += 1
+    if skipped:
+        st.caption(f"_skipped {skipped} malformed trace line(s) in {path.name}_")
+    return spans
+
+
+def _span_product_id(span: dict[str, Any]) -> str | None:
+    """Extract product_id from a span's input or tags, if present."""
+    inp = span.get("input") or {}
+    if isinstance(inp, dict) and inp.get("product_id"):
+        return str(inp["product_id"])
+    for tag in span.get("tags") or []:
+        if isinstance(tag, str) and tag.startswith("product:"):
+            return tag.split(":", 1)[1]
+    return None
+
+
+def _span_duration_ms(span: dict[str, Any]) -> float | None:
+    """Compute span duration. ``tracing.py`` writes ``started_at`` / ``ended_at``
+    as unix-epoch floats, but tolerate ISO strings too in case the writer
+    format changes."""
+    started = span.get("started_at")
+    ended = span.get("ended_at")
+    if started is None or ended is None:
+        return None
+    if isinstance(started, (int, float)) and isinstance(ended, (int, float)):
+        return round((ended - started) * 1000, 1)
+    try:
+        s = datetime.fromisoformat(str(started).replace("Z", "+00:00"))
+        e = datetime.fromisoformat(str(ended).replace("Z", "+00:00"))
+        return round((e - s).total_seconds() * 1000, 1)
+    except ValueError:
+        return None
+
+
+def render_reasoning_trace(run: dict[str, Any]) -> None:
+    """Render JSONL agent traces for the current run.
+
+    The runner writes spans to ``logs/enrichment_traces/<run_id>.jsonl`` when
+    ``ENRICHMENT_TRACE_JSONL=1``. Spans carry the agent/strategy name, LLM
+    calls (``llm:<model>``), inputs, outputs, and tags. This tab groups them
+    by product and strategy so you can walk the decision path the agents
+    took on each row.
+    """
+    summary = run.get("summary", {})
+    run_id = summary.get("run_id")
+    st.markdown("### Reasoning traces (per-agent spans)")
+    if not run_id:
+        st.info(
+            "No `run_id` in this artifact — traces are keyed by run_id. "
+            "Re-run with `--eval-output` from a recent revision."
+        )
+        return
+    spans = _load_trace_jsonl(run_id)
+    if spans is None:
+        st.info(
+            f"No JSONL trace file at `logs/enrichment_traces/{run_id}.jsonl`. "
+            "Re-run with `ENRICHMENT_TRACE_JSONL=1` to enable JSONL tracing:\n\n"
+            "`ENRICHMENT_TRACE_JSONL=1 python scripts/run_enrichment.py "
+            "--merchant <id> --mode fixed --limit 5 --eval-output runs/x.json`"
+        )
+        return
+    if not spans:
+        st.warning("Trace file is empty.")
+        return
+
+    strategy_spans: list[dict[str, Any]] = []
+    llm_by_strategy: dict[str, list[dict[str, Any]]] = {}
+    other_spans: list[dict[str, Any]] = []
+    known_strategies = set(
+        enrichment_registry.list_strategies()
+        if hasattr(enrichment_registry, "list_strategies")
+        else []
+    )
+    # Fall back to the set of names that look like strategies when the
+    # registry doesn't expose a listing helper.
+    if not known_strategies:
+        known_strategies = {
+            s.get("name", "") for s in spans if not (s.get("name") or "").startswith("llm:")
+        }
+
+    current_strategy: str | None = None
+    for span in spans:
+        name = span.get("name") or ""
+        if name.startswith("llm:"):
+            key = current_strategy or "(unassigned)"
+            llm_by_strategy.setdefault(key, []).append(span)
+        elif name in known_strategies:
+            current_strategy = name
+            strategy_spans.append(span)
+        else:
+            other_spans.append(span)
+
+    total_llm = sum(len(v) for v in llm_by_strategy.values())
+    cols = st.columns(4)
+    cols[0].metric("Spans", len(spans))
+    cols[1].metric("Strategy spans", len(strategy_spans))
+    cols[2].metric("LLM calls", total_llm)
+    cols[3].metric("Other spans", len(other_spans))
+
+    pids = sorted({pid for pid in (_span_product_id(s) for s in strategy_spans) if pid})
+    pid_filter = st.selectbox(
+        "Filter by product_id",
+        ["(all)"] + pids,
+        index=0,
+        key="trace_pid_filter",
+    )
+    strategies = sorted({s.get("name") or "?" for s in strategy_spans})
+    strat_filter = st.multiselect(
+        "Filter by strategy",
+        strategies,
+        default=strategies,
+        key="trace_strat_filter",
+    )
+
+    shown = 0
+    for sp in strategy_spans:
+        strategy = sp.get("name") or "?"
+        if strategy not in strat_filter:
+            continue
+        pid = _span_product_id(sp)
+        if pid_filter != "(all)" and pid != pid_filter:
+            continue
+        shown += 1
+        dur = _span_duration_ms(sp)
+        header = f"`{strategy}`"
+        if pid:
+            header += f"  ·  product `{pid[:8]}…`"
+        if dur is not None:
+            header += f"  ·  {dur} ms"
+        tags = sp.get("tags") or []
+        if tags:
+            header += f"  ·  tags: {', '.join(tags[:3])}"
+        with st.expander(header, expanded=False):
+            left, right = st.columns(2)
+            with left:
+                st.markdown("**input**")
+                st.json(_jsonable(sp.get("input") or {}))
+            with right:
+                st.markdown("**output**")
+                st.json(_jsonable(sp.get("output") or {}))
+            updates = sp.get("updates") or []
+            if updates:
+                st.markdown(f"**updates** ({len(updates)})")
+                st.json(_jsonable(updates))
+            llms = [
+                llm for llm in llm_by_strategy.get(strategy, [])
+                if _span_product_id(llm) in (None, pid) or pid is None
+            ]
+            if llms:
+                st.markdown(f"**LLM calls within this strategy** ({len(llms)})")
+                for llm in llms:
+                    model = llm.get("name", "llm:?")
+                    ldur = _span_duration_ms(llm)
+                    label = f"{model}"
+                    if ldur is not None:
+                        label += f"  ·  {ldur} ms"
+                    with st.expander(label, expanded=False):
+                        li, lo = st.columns(2)
+                        with li:
+                            st.markdown("**prompt**")
+                            st.json(_jsonable(llm.get("input") or {}))
+                        with lo:
+                            st.markdown("**response**")
+                            st.json(_jsonable(llm.get("output") or {}))
+
+    if shown == 0:
+        st.info("No strategy spans match the current filters.")
+
+    if other_spans:
+        with st.expander(f"Other spans ({len(other_spans)})", expanded=False):
+            for sp in other_spans:
+                st.markdown(f"**{sp.get('name', '?')}**")
+                st.json(_jsonable(sp))
+
+
 def _jsonable(obj: Any) -> Any:
     try:
         json.dumps(obj, default=str)
@@ -783,6 +981,7 @@ def main() -> None:
             "Enriched table",
             "KG coverage",
             "Per-product drill-down",
+            "Reasoning trace",
         ]
     )
     with tabs[0]:
@@ -795,6 +994,8 @@ def main() -> None:
         render_kg_coverage(run)
     with tabs[4]:
         render_per_product(run, engine, picked_id)
+    with tabs[5]:
+        render_reasoning_trace(run)
 
 
 def _fmt_mtime(path: Path) -> str:

--- a/scripts/run_enrichment.py
+++ b/scripts/run_enrichment.py
@@ -8,9 +8,9 @@ Examples:
   python scripts/run_enrichment.py --mode fixed --strategies parser_v1,soft_tagger_v1 --dry-run
   python scripts/run_enrichment.py --ab-eval --limit 25 --eval-output runs/ab.json
 
-v1 scope: runs only against the default merchant. Reads merchants.products_default
-and writes merchants.products_enriched_default. Per-merchant enrichment is
-tracked in issue #47.
+Defaults to merchant_id='default' if --merchant is omitted. Reads
+merchants.products_<merchant> and writes merchants.products_enriched_<merchant>.
+The merchant must already be registered in merchants.registry.
 """
 
 from __future__ import annotations
@@ -35,6 +35,12 @@ def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Run multi-agent catalog enrichment.")
     p.add_argument("--mode", choices=["fixed", "orchestrated"], default="fixed")
     p.add_argument("--limit", type=int, default=10, help="Max products to process.")
+    p.add_argument(
+        "--merchant",
+        default=_V1_MERCHANT_ID,
+        help=f"Merchant slug to enrich (default {_V1_MERCHANT_ID!r}). "
+             "Must be registered in merchants.registry.",
+    )
     p.add_argument(
         "--strategies",
         type=str,
@@ -87,7 +93,7 @@ def main() -> int:
         result = run_enrichment(
             db,
             mode=args.mode,
-            merchant_id=_V1_MERCHANT_ID,
+            merchant_id=args.merchant,
             limit=args.limit,
             strategies_filter=strategies_filter,
             dry_run=args.dry_run,
@@ -117,7 +123,7 @@ def _run_ab_eval(db, args, strategies_filter) -> int:
     fixed_result = run_enrichment(
         db,
         mode="fixed",
-        merchant_id=_V1_MERCHANT_ID,
+        merchant_id=args.merchant,
         limit=args.limit,
         strategies_filter=strategies_filter,
         dry_run=True,  # eval mode never writes
@@ -126,7 +132,7 @@ def _run_ab_eval(db, args, strategies_filter) -> int:
     orch_result = run_enrichment(
         db,
         mode="orchestrated",
-        merchant_id=_V1_MERCHANT_ID,
+        merchant_id=args.merchant,
         limit=args.limit,
         strategies_filter=strategies_filter,
         dry_run=True,

--- a/scripts/seed_mock_laptops.py
+++ b/scripts/seed_mock_laptops.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Seed a mock 200-laptop catalog into a fresh merchant via direct DB insert.
+
+Provisions per-merchant tables via ``create_merchant_catalog``, inserts rows
+through the merchant's ORM model (same path the CSV loader uses, minus the
+CSV parse), and registers the merchant in ``merchants.registry``.
+
+Usage:
+  python scripts/seed_mock_laptops.py --merchant mocklaptops --count 200
+
+Re-seed:
+  ALLOW_MERCHANT_DROP=1 python scripts/seed_mock_laptops.py \
+      --merchant mocklaptops --reseed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+import uuid
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "mcp-server"))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(_ROOT / ".env")
+except ImportError:
+    pass
+
+
+BRANDS = [
+    ("Dell", ["XPS", "Inspiron", "Latitude", "Precision", "G15"]),
+    ("HP", ["Spectre", "Envy", "Pavilion", "Omen", "EliteBook"]),
+    ("Lenovo", ["ThinkPad X1", "ThinkPad T", "Yoga", "Legion", "IdeaPad"]),
+    ("Apple", ["MacBook Air", "MacBook Pro"]),
+    ("ASUS", ["ZenBook", "ROG Strix", "TUF Gaming", "VivoBook", "ProArt"]),
+    ("Acer", ["Swift", "Predator", "Aspire", "Nitro"]),
+    ("Microsoft", ["Surface Laptop", "Surface Pro", "Surface Book"]),
+    ("Razer", ["Blade 14", "Blade 15", "Blade 17"]),
+    ("MSI", ["Stealth", "Raider", "Katana", "Modern"]),
+    ("Framework", ["Laptop 13", "Laptop 16"]),
+]
+
+CPUS = [
+    ("Intel Core i5-1340P", 12, 4.6),
+    ("Intel Core i7-1360P", 12, 5.0),
+    ("Intel Core i7-13700H", 14, 5.0),
+    ("Intel Core i9-13900H", 14, 5.4),
+    ("Intel Core Ultra 7 155H", 16, 4.8),
+    ("AMD Ryzen 5 7640U", 6, 4.9),
+    ("AMD Ryzen 7 7840HS", 8, 5.1),
+    ("AMD Ryzen 9 7940HS", 8, 5.2),
+    ("Apple M2", 8, None),
+    ("Apple M2 Pro", 12, None),
+    ("Apple M3", 8, None),
+    ("Apple M3 Pro", 12, None),
+    ("Apple M3 Max", 16, None),
+    ("Qualcomm Snapdragon X Elite", 12, 4.0),
+]
+
+GPUS = [
+    "Integrated",
+    "Intel Iris Xe",
+    "Intel Arc",
+    "AMD Radeon 780M",
+    "NVIDIA RTX 4050",
+    "NVIDIA RTX 4060",
+    "NVIDIA RTX 4070",
+    "NVIDIA RTX 4080",
+    "NVIDIA RTX 4090",
+    "Apple Integrated GPU",
+]
+
+RAM_OPTIONS = [8, 16, 24, 32, 48, 64, 96, 128]
+STORAGE_OPTIONS = [256, 512, 1024, 2048, 4096, 8192]
+SCREEN_SIZES = [13.0, 13.3, 13.6, 14.0, 14.2, 15.6, 16.0, 16.2, 17.3, 18.0]
+RESOLUTIONS = ["1920x1200", "2560x1600", "2880x1800", "3024x1964", "3456x2234", "3840x2400"]
+COLORS = ["Silver", "Space Gray", "Black", "Midnight", "Platinum", "Mercury", "Eclipse"]
+OSES = ["Windows 11 Home", "Windows 11 Pro", "macOS Sonoma", "Linux (Ubuntu)", "ChromeOS"]
+
+
+def _gen_laptop(rng: random.Random, idx: int) -> dict:
+    brand, series_pool = rng.choice(BRANDS)
+    series = rng.choice(series_pool)
+    is_apple = brand == "Apple"
+
+    cpu, cores, clock = rng.choice([c for c in CPUS if (is_apple == c[0].startswith("Apple"))])
+    if is_apple:
+        gpu = "Apple Integrated GPU"
+        os_name = "macOS Sonoma"
+    else:
+        # Pair gaming CPUs with discrete GPUs more often.
+        if "i9" in cpu or "Ryzen 9" in cpu or "i7" in cpu:
+            gpu = rng.choice(GPUS[3:])
+        else:
+            gpu = rng.choice(GPUS[:6])
+        os_name = rng.choices(
+            OSES[:2] + OSES[3:],
+            weights=[5, 4, 1, 1],
+            k=1,
+        )[0]
+
+    ram = rng.choice(RAM_OPTIONS)
+    storage = rng.choice(STORAGE_OPTIONS)
+    screen = rng.choice(SCREEN_SIZES)
+    res = rng.choice(RESOLUTIONS)
+    color = rng.choice(COLORS)
+    weight = round(rng.uniform(2.2, 6.5), 2)
+    battery = rng.randint(6, 22)
+    year = rng.choice([2022, 2023, 2023, 2024, 2024, 2024])
+
+    # Price loosely correlated with RAM, storage, GPU class.
+    base = 600
+    base += ram * 18
+    base += storage * 0.35
+    if "RTX 4090" in gpu: base += 1400
+    elif "RTX 4080" in gpu: base += 900
+    elif "RTX 4070" in gpu: base += 500
+    elif "RTX 4060" in gpu: base += 250
+    elif "RTX 4050" in gpu: base += 120
+    if is_apple: base *= 1.25
+    if "Pro" in series or "Precision" in series or "EliteBook" in series:
+        base *= 1.15
+    price = round(base * rng.uniform(0.85, 1.2), 2)
+
+    title = f"{brand} {series} {idx:03d} {screen}\" {ram}GB RAM {storage}GB SSD"
+    description = (
+        f"The {brand} {series} delivers {cpu} performance with {gpu} graphics. "
+        f"{ram}GB of RAM and a {storage}GB SSD on a {screen}-inch {res} display. "
+        f"Up to {battery} hours of battery life. Ships in {color}."
+    )
+
+    attributes = {
+        "description": description,
+        "cpu": cpu,
+        "cpu_cores": cores,
+        "cpu_max_clock_ghz": clock,
+        "gpu": gpu,
+        "ram_gb": ram,
+        "storage_gb": storage,
+        "screen_size": screen,
+        "resolution": res,
+        "color": color,
+        "weight_lbs": weight,
+        "battery_life_hours": battery,
+        "os": os_name,
+        "release_year": year,
+    }
+
+    return {
+        "product_id": uuid.uuid4(),
+        "name": title,
+        "category": "electronics",
+        "product_type": "laptop",
+        "brand": brand,
+        "series": series,
+        "price_value": price,
+        "image_url": f"https://example.com/mock/laptops/{brand.lower()}/{idx:03d}.jpg",
+        "rating": round(rng.uniform(3.4, 4.9), 1),
+        "rating_count": rng.randint(5, 4200),
+        "source": "mock:seed_mock_laptops",
+        "link": f"https://example.com/mock/laptops/{idx:03d}",
+        "ref_id": f"MOCK-LAPTOP-{idx:04d}",
+        "release_year": year,
+        "attributes": attributes,
+    }
+
+
+def _maybe_drop_existing(merchant_id: str, engine) -> None:
+    from app.ingestion.schema import drop_merchant_catalog
+    raw_conn = engine.raw_connection()
+    try:
+        drop_merchant_catalog(merchant_id, raw_conn)
+    finally:
+        raw_conn.close()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Seed a mock laptop catalog (direct DB insert).")
+    p.add_argument("--merchant", default="mocklaptops",
+                   help="Merchant slug. Must match [a-z][a-z0-9_]{1,31}.")
+    p.add_argument("--count", type=int, default=200, help="Number of laptops (default 200).")
+    p.add_argument("--seed", type=int, default=42, help="RNG seed for reproducibility.")
+    p.add_argument("--reseed", action="store_true",
+                   help="Drop the merchant catalog first (requires ALLOW_MERCHANT_DROP=1).")
+    p.add_argument("--domain", default="electronics")
+    p.add_argument("--strategy", default="normalizer_v1")
+    p.add_argument("--kg-strategy", default="default_v1")
+    args = p.parse_args()
+
+    from app.database import SessionLocal
+    from app.ingestion.schema import create_merchant_catalog
+    from app.merchant_agent import (
+        MerchantAgent,
+        upsert_registry_row,
+        validate_merchant_id,
+    )
+
+    merchant_id = validate_merchant_id(args.merchant)
+
+    session = SessionLocal()
+    engine = session.get_bind()
+    session.close()
+
+    if args.reseed:
+        if os.environ.get("ALLOW_MERCHANT_DROP") != "1":
+            print("--reseed requires ALLOW_MERCHANT_DROP=1", file=sys.stderr)
+            return 2
+        _maybe_drop_existing(merchant_id, engine)
+
+    raw_conn = engine.raw_connection()
+    try:
+        create_merchant_catalog(merchant_id, raw_conn)
+    finally:
+        raw_conn.close()
+
+    agent = MerchantAgent(
+        merchant_id=merchant_id,
+        domain=args.domain,
+        strategy=args.strategy,
+        kg_strategy=args.kg_strategy,
+    )
+    Product = agent.product_model
+
+    db = SessionLocal()
+    try:
+        existing = db.query(Product).limit(1).count()
+        if existing:
+            print(
+                f"merchant {merchant_id!r} already has rows; pass --reseed "
+                f"with ALLOW_MERCHANT_DROP=1 to wipe and re-insert.",
+                file=sys.stderr,
+            )
+            return 2
+
+        rng = random.Random(args.seed)
+        rows = [_gen_laptop(rng, i + 1) for i in range(args.count)]
+        for row in rows:
+            db.add(Product(merchant_id=merchant_id, **row))
+        db.commit()
+    finally:
+        db.close()
+
+    upsert_registry_row(
+        merchant_id=merchant_id,
+        domain=args.domain,
+        strategy=args.strategy,
+        kg_strategy=args.kg_strategy,
+    )
+
+    print(json.dumps({
+        "merchant_id": merchant_id,
+        "domain": args.domain,
+        "strategy": args.strategy,
+        "kg_strategy": args.kg_strategy,
+        "catalog_table": agent.catalog_table(),
+        "enriched_table": agent.enriched_table(),
+        "inserted": args.count,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three additions that let you assess the enrichment pipeline against an arbitrary mock catalog, plus a writer-path fix surfaced by the smoke test:

- **`scripts/seed_mock_laptops.py`** (new) — generates a 200-row mock laptop catalog (10 brands, varied CPUs / GPUs / RAM / storage / price ranges) and inserts directly into `merchants.products_<merchant>` via the per-merchant ORM model. Idempotent re-seed via `--reseed` (gated on `ALLOW_MERCHANT_DROP=1`). Reproducible (seed=42).
- **`scripts/run_enrichment.py`** — adds `--merchant` flag so enrichment runs can target any registered merchant. Default is unchanged.
- **`scripts/enrichment_inspector.py`** — adds a *Reasoning trace* tab that reads `logs/enrichment_traces/<run_id>.jsonl` (opt-in via `ENRICHMENT_TRACE_JSONL=1`) and renders strategy spans grouped with their nested LLM calls, filterable by product_id and strategy. Closes the gap where traces were only viewable via Langfuse.
- **`mcp-server/app/enrichment/tools/db_writer.py` + `runner.py`** — fix: `db_writer.upsert_one/many` was hardcoded to `ProductEnriched` (the default merchant's enriched table). After migration 006 that table's FK points at `raw_products_default` (the archive), so any non-default `--merchant` enrichment failed with a FK violation. Now `db_writer` takes a required `enriched_model` kwarg, and `runner._run_inner` caches `Catalog.for_merchant(mid)` once and uses it for both reads and writes.

## End-to-end smoke (mocklaptops, 5 products, fixed mode)

```
products_processed: 5
strategies_succeeded: taxonomy_v1: 5, parser_v1: 5, specialist_v1: 5, scraper_v1: 5, soft_tagger_v1: 5
strategies_failed: {}
avg_keys_filled_per_product: 18.0
total_cost_usd: $0.0035
total_latency_ms: 68161
```

DB verification: 25 rows written to `merchants.products_enriched_mocklaptops`, `merchants.products_enriched_default` unchanged.

## Test plan

- [x] `pytest tests/enrichment/test_runner.py` — 6 passed (test stubs updated for new kwarg)
- [x] `python scripts/seed_mock_laptops.py --merchant mocklaptops --count 200` → 200 rows inserted, registry entry created
- [x] `ENRICHMENT_TRACE_JSONL=1 python scripts/run_enrichment.py --merchant mocklaptops --mode fixed --limit 5 --eval-output runs/mocklaptops_smoke.json` → eval JSON + JSONL trace written, 25 enriched rows in correct table
- [x] `streamlit run scripts/enrichment_inspector.py` boots (HTTP 200), Reasoning-trace tab parses the existing default-merchant trace (46 spans, 5 products, durations rendered)