### PR TITLE
fix(inspector): correct raw-table SQL column names + JOIN

### DIFF
--- a/mcp-server/app/enrichment/agents/__init__.py
+++ b/mcp-server/app/enrichment/agents/__init__.py
@@ -8,6 +8,7 @@ collisions visible.
 
 from app.enrichment.agents import (  # noqa: F401 - import side effects
     assessor,
+    composer,
     parser,
     soft_tagger,
     specialist,

--- a/mcp-server/app/enrichment/agents/assessor.py
+++ b/mcp-server/app/enrichment/agents/assessor.py
@@ -16,7 +16,7 @@ import logging
 from collections import Counter
 from typing import Any
 
-from app.enrichment.tools.llm_client import LLMClient, default_model
+from app.enrichment.tools.llm_client import LLMClient, utility_model
 from app.enrichment.types import AssessorOutput, ProductInput
 
 logger = logging.getLogger(__name__)
@@ -24,12 +24,15 @@ logger = logging.getLogger(__name__)
 
 # Strategies the assessor can recommend. Kept here so the assessor can reason
 # about them without circular imports of the agent classes themselves.
+# composer_v1 always runs (single writer of the canonical row — #83); the
+# orchestrator appends it last regardless of assessor filtering.
 _AVAILABLE_STRATEGIES = (
     "taxonomy_v1",
     "parser_v1",
     "specialist_v1",
     "scraper_v1",
     "soft_tagger_v1",
+    "composer_v1",
 )
 
 
@@ -104,7 +107,7 @@ class Assessor:
             resp = self._llm.complete(
                 system=_SYSTEM,
                 user="Sample:\n" + json.dumps(sample, ensure_ascii=False),
-                model=model or default_model(large=True),
+                model=model or utility_model(),
                 json_mode=True,
                 max_tokens=400,
                 temperature=0.1,

--- a/mcp-server/app/enrichment/agents/assessor.py
+++ b/mcp-server/app/enrichment/agents/assessor.py
@@ -5,8 +5,11 @@ density, sparse JSONB keys, discovered product types, and a recommended
 strategy plan. Output is per-catalog (not per-product) so it lives in JSON,
 not in products_enriched.
 
-The assessor uses the LLM only to summarize discovered product types; the
-counting work is deterministic Python.
+Today the assessor uses the LLM only to summarize discovered product types
+(cheap utility-tier call — gpt-5-nano by default, see
+``tools.llm_client.utility_model``); the counting work is deterministic
+Python. Future revisions may route strategy-planning reasoning through the
+composer-tier model, at which point this docstring should be updated.
 """
 
 from __future__ import annotations

--- a/mcp-server/app/enrichment/agents/composer.py
+++ b/mcp-server/app/enrichment/agents/composer.py
@@ -1,0 +1,281 @@
+"""composer_v1 — single writer of the canonical enriched row (issue #83).
+
+Today's enrichment pipeline lets every strategy (taxonomy, parser, specialist,
+scraper, soft_tagger) write its own (product_id, strategy, attributes) row;
+reads pivot by strategy at the inspector's combine step. That means:
+
+  - hallucinated or ungrounded values still land in the table
+  - two strategies can claim overlapping keys with no tie-break
+  - verbose narrative output (specialist_capabilities, specialist_audience)
+    sits alongside factual output with no separation
+
+The composer is the structural fix: it is the **only** agent allowed to
+emit canonical catalog fields. Every other strategy still writes its own
+row — but downstream readers prefer composer output when present.
+
+v1 scope (this commit)
+----------------------
+  - Reads every upstream strategy's output from the runner's ``context``
+    dict (populated in orchestration/runner.py: ``ctx[_short(strategy)] =
+    output.attributes``).
+  - Runs one LLM call (gpt-5 by default — see ``composer_model()``) with
+    the full findings + raw row + policy:
+        * no-hallucination: drop values not grounded in raw / parsed /
+          scraped evidence
+        * overlap resolution: when two strategies claim the same key,
+          pick one (prefer parser > scraper > specialist > soft_tagger >
+          taxonomy, or apply the LLM's judgment)
+        * echo suppression: drop values identical to an already-present
+          raw field
+        * specialist-question reframe: treat specialist_buyer_questions
+          as a planning artifact — it is NOT a catalog field, so the
+          composer ignores it as output but may surface decisions keyed
+          by it in ``composer_decisions``
+  - Writes:
+        composed_fields       flat dict {key: value} the composer decided
+                              belongs on the canonical row
+        composer_decisions    list[{key, chosen_value, source_strategy,
+                              reason, dropped_alternatives}] — audit log
+                              for the cell-lineage UX in #81
+        composed_at           ISO timestamp
+
+v2+ (follow-ups, deliberately out of scope)
+-------------------------------------------
+  - Retire the per-strategy rows into a ``products_findings_<m>`` table
+    and promote composer output into a flat-schema catalog. Tracked in
+    #83's "Findings surface shape" open question.
+  - Closed-loop refinement (composer kicks agents back with ungrounded
+    questions). Tracked in #83's "Out of scope" list.
+  - Confidence-weighted merges (today we prefer a single source per key).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from app.enrichment import registry
+from app.enrichment.base import BaseEnrichmentAgent
+from app.enrichment.tools.llm_client import LLMClient, composer_model
+from app.enrichment.types import ProductInput, StrategyOutput
+
+logger = logging.getLogger(__name__)
+
+
+# Context keys the runner populates for each upstream strategy.
+# Keeping this list explicit (rather than scanning ctx) means the composer's
+# prompt has a stable shape — the LLM sees the same findings schema every
+# call — and an unknown upstream strategy won't silently leak into the prompt.
+_UPSTREAM_CONTEXT_KEYS: tuple[str, ...] = (
+    "taxonomy",
+    "parsed",
+    "specialist",
+    "scraped",
+    "soft_tagger",
+)
+
+
+_SYSTEM = (
+    "You are the composer agent: the single writer of one product's canonical "
+    "catalog row. You read the raw product, the findings emitted by every "
+    "upstream agent, and decide which keys belong on the canonical row.\n"
+    "\n"
+    "Policy:\n"
+    "  1. No hallucination. Only include a key if its value is grounded in "
+    "the raw row, the parsed specs, or the scraped findings. If the "
+    "specialist asked a buyer question (specialist_buyer_questions) whose "
+    "answer is not in any of those sources, DO NOT fabricate it — omit it.\n"
+    "  2. Overlap resolution. When two agents claim the same key, pick one "
+    "source (prefer parser > scraper > specialist > soft_tagger > taxonomy) "
+    "OR merge explicitly. Record the chosen source in composer_decisions.\n"
+    "  3. Echo suppression. If a finding is identical to a field already on "
+    "the raw row (same value, same key), drop it.\n"
+    "  4. Type discipline. Scalars stay scalars; never wrap a number in an "
+    "object. For spec dicts (e.g. parsed_specs), flatten their inner keys "
+    "up into composed_fields one level.\n"
+    "  5. Narrative text (specialist_capabilities, specialist_audience) does "
+    "NOT belong on the canonical row. Drop it here — it lives elsewhere.\n"
+    "\n"
+    "Return JSON with two keys:\n"
+    "  composed_fields     object {key: value} — the canonical row content\n"
+    "  composer_decisions  list of objects {key, chosen_value, "
+    "source_strategy, reason, dropped_alternatives} — one entry per key "
+    "you considered (kept or dropped). Use dropped_alternatives=[] when "
+    "there was no conflict."
+)
+
+
+@registry.register
+class ComposerAgent(BaseEnrichmentAgent):
+    STRATEGY = "composer_v1"
+    OUTPUT_KEYS = frozenset({"composed_fields", "composer_decisions", "composed_at"})
+    DEFAULT_MODEL = "gpt-5"
+
+    def __init__(self, llm: LLMClient | None = None) -> None:
+        super().__init__()
+        self._llm = llm or LLMClient()
+
+    def _invoke(self, product: ProductInput, context: dict[str, Any]) -> StrategyOutput:
+        findings = _gather_findings(context)
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        # If nothing upstream ran successfully, the composer has no material
+        # to work with. Emit empty composed_fields so the row is still written
+        # (useful as a marker that the composer was invoked) and skip the LLM
+        # call entirely — spending a gpt-5 call on an empty prompt is waste.
+        if not findings:
+            return StrategyOutput(
+                product_id=product.product_id,
+                strategy=self.STRATEGY,
+                model=None,
+                attributes={
+                    "composed_fields": {},
+                    "composer_decisions": [],
+                    "composed_at": now_iso,
+                },
+                notes="no_upstream_findings",
+            )
+
+        user = _format_user(product, findings)
+        resp = self._llm.complete(
+            system=_SYSTEM,
+            user=user,
+            model=context.get("composer_model") or context.get("model") or composer_model(),
+            json_mode=True,
+            max_tokens=1200,
+            temperature=0.1,
+        )
+        context["_last_cost_usd"] = resp.cost_usd
+        data = resp.parsed_json or {}
+
+        composed = _coerce_composed_fields(data.get("composed_fields"))
+        decisions = _coerce_decisions(data.get("composer_decisions"))
+
+        # Belt-and-braces policy enforcement: drop anything the LLM emitted
+        # that matches a raw-attribute value (echo) or that is structurally
+        # a narrative key we said to strip. Keeping this in Python means a
+        # chatty model can't silently violate the contract.
+        composed = _strip_echoes(composed, product)
+        composed = _strip_narrative_keys(composed)
+
+        return StrategyOutput(
+            product_id=product.product_id,
+            strategy=self.STRATEGY,
+            model=resp.model,
+            attributes={
+                "composed_fields": composed,
+                "composer_decisions": decisions,
+                "composed_at": now_iso,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+# Narrative / planning-artifact keys the issue explicitly calls out as NOT
+# belonging on the canonical catalog row. The composer may receive them from
+# upstream (specialist emits them today) but must never surface them.
+_NARRATIVE_KEYS: frozenset[str] = frozenset(
+    {
+        "specialist_capabilities",
+        "specialist_audience",
+        "specialist_buyer_questions",
+    }
+)
+
+
+def _gather_findings(context: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Pick up each upstream strategy's attributes dict from the runner ctx.
+
+    Returns a dict keyed by upstream strategy short-name (same keys the
+    runner populates). Skips keys with no data so the prompt isn't noisy.
+    """
+    findings: dict[str, dict[str, Any]] = {}
+    for key in _UPSTREAM_CONTEXT_KEYS:
+        val = context.get(key)
+        if isinstance(val, dict) and val:
+            findings[key] = val
+    return findings
+
+
+def _format_user(product: ProductInput, findings: dict[str, dict[str, Any]]) -> str:
+    raw = {
+        "product_id": str(product.product_id),
+        "title": product.title,
+        "brand": product.brand,
+        "category": product.category,
+        "description": (product.description or "")[:600],
+        "price": float(product.price) if product.price is not None else None,
+        "raw_attributes": product.raw_attributes or {},
+    }
+    payload = {"raw": raw, "findings": findings}
+    return "Compose the canonical row for this product.\n" + json.dumps(
+        payload, ensure_ascii=False, default=str
+    )
+
+
+def _coerce_composed_fields(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for k, v in value.items():
+        key = str(k).strip()
+        if not key:
+            continue
+        out[key] = v
+    return out
+
+
+def _coerce_decisions(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    decisions: list[dict[str, Any]] = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            continue
+        key = str(entry.get("key") or "").strip()
+        if not key:
+            continue
+        decisions.append(
+            {
+                "key": key,
+                "chosen_value": entry.get("chosen_value"),
+                "source_strategy": str(entry.get("source_strategy") or "") or None,
+                "reason": str(entry.get("reason") or "") or None,
+                "dropped_alternatives": (
+                    entry.get("dropped_alternatives")
+                    if isinstance(entry.get("dropped_alternatives"), list)
+                    else []
+                ),
+            }
+        )
+    return decisions
+
+
+def _strip_echoes(
+    composed: dict[str, Any], product: ProductInput
+) -> dict[str, Any]:
+    raw_attrs = product.raw_attributes or {}
+    identity: dict[str, Any] = {
+        "title": product.title,
+        "brand": product.brand,
+        "category": product.category,
+        "description": product.description,
+    }
+    out: dict[str, Any] = {}
+    for k, v in composed.items():
+        if k in identity and identity[k] == v:
+            continue
+        if k in raw_attrs and raw_attrs[k] == v:
+            continue
+        out[k] = v
+    return out
+
+
+def _strip_narrative_keys(composed: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in composed.items() if k not in _NARRATIVE_KEYS}

--- a/mcp-server/app/enrichment/agents/composer.py
+++ b/mcp-server/app/enrichment/agents/composer.py
@@ -18,35 +18,61 @@ v1 scope (this commit)
   - Reads every upstream strategy's output from the runner's ``context``
     dict (populated in orchestration/runner.py: ``ctx[_short(strategy)] =
     output.attributes``).
+  - Also reads ``ctx["_validator_notes"]`` so the composer knows which
+    strategies the validator rejected (e.g. ram_gb out of bounds) and can
+    reason about the resulting gap rather than silently ignore it.
   - Runs one LLM call (gpt-5 by default — see ``composer_model()``) with
     the full findings + raw row + policy:
         * no-hallucination: drop values not grounded in raw / parsed /
           scraped evidence
-        * overlap resolution: when two strategies claim the same key,
-          pick one (prefer parser > scraper > specialist > soft_tagger >
-          taxonomy, or apply the LLM's judgment)
-        * echo suppression: drop values identical to an already-present
-          raw field
-        * specialist-question reframe: treat specialist_buyer_questions
-          as a planning artifact — it is NOT a catalog field, so the
-          composer ignores it as output but may surface decisions keyed
-          by it in ``composer_decisions``
+        * per-key precedence (see _PRECEDENCE_NOTE below): taxonomy owns
+          product_type; parser/scraper own specs (scraper wins on tie
+          because it's from the manufacturer page); soft_tagger owns
+          good_for_* tags; specialist contributes only structured
+          use-case-fit, never prose
+        * echo applies to FINDINGS not the canonical row: a grounded
+          value still belongs in composed_fields even if raw_attributes
+          also has it — downstream readers should be able to read the
+          canonical row without re-joining raw
+        * type discipline: scalars stay scalar; flatten parsed_specs /
+          scraped_specs one level up; drop narrative keys (via the
+          registry's self-declared NARRATIVE_KEYS, not a hardcoded list)
+  - Deterministic fallback: if the LLM errors or returns unparseable
+    JSON, the composer still writes a row built from upstream findings
+    (flatten parsed/scraped specs, union soft_tags, take product_type
+    from taxonomy) with ``notes='deterministic_fallback'``. One product
+    never loses its canonical row to a transient API blip.
   - Writes:
         composed_fields       flat dict {key: value} the composer decided
                               belongs on the canonical row
-        composer_decisions    list[{key, chosen_value, source_strategy,
-                              reason, dropped_alternatives}] — audit log
-                              for the cell-lineage UX in #81
+        composer_decisions    list[ComposerDecision] — audit log for the
+                              cell-lineage UX in #81
         composed_at           ISO timestamp
+
+# _TODO(closed_loop) — #85 attach points
+# ---------------------------------------
+# This composer is a single-shot LLM synthesizer. #85 (agentic pipeline
+# gaps) calls out that real agentic behavior needs feedback loops. When
+# we graduate to composer_v2, the hooks land in specific places below:
+#
+#   - _gather_findings(): point where a "request more evidence" edge
+#     would fire back at scraper/parser for keys that are specialist-
+#     asked-about but unground (#85 points 1, 12)
+#   - post-LLM composed block: point where self-critique + revise loop
+#     would run ("compose -> critique -> maybe re-compose") (#85 pt 4, 8)
+#   - low-confidence merges: point where human escalation hook would
+#     surface a clarification request (#85 pt 11)
+#
+# None of these land in this PR — but noting the attach points so the
+# next iteration doesn't have to rediscover them.
 
 v2+ (follow-ups, deliberately out of scope)
 -------------------------------------------
   - Retire the per-strategy rows into a ``products_findings_<m>`` table
     and promote composer output into a flat-schema catalog. Tracked in
     #83's "Findings surface shape" open question.
-  - Closed-loop refinement (composer kicks agents back with ungrounded
-    questions). Tracked in #83's "Out of scope" list.
-  - Confidence-weighted merges (today we prefer a single source per key).
+  - Closed-loop refinement (see attach points above) (#85).
+  - Confidence-weighted merges across duplicate sources.
 """
 
 from __future__ import annotations
@@ -56,10 +82,12 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.enrichment import registry
 from app.enrichment.base import BaseEnrichmentAgent
 from app.enrichment.tools.llm_client import LLMClient, composer_model
-from app.enrichment.types import ProductInput, StrategyOutput
+from app.enrichment.types import ComposerDecision, ProductInput, StrategyOutput
 
 logger = logging.getLogger(__name__)
 
@@ -77,33 +105,77 @@ _UPSTREAM_CONTEXT_KEYS: tuple[str, ...] = (
 )
 
 
+# Map the short context keys the runner uses back to the full strategy
+# labels (taxonomy -> taxonomy_v1, etc). Only used for annotating the
+# prompt / fallback decisions so the audit log is readable.
+_SHORT_TO_STRATEGY: dict[str, str] = {
+    "taxonomy": "taxonomy_v1",
+    "parsed": "parser_v1",
+    "specialist": "specialist_v1",
+    "scraped": "scraper_v1",
+    "soft_tagger": "soft_tagger_v1",
+}
+
+
+# Per-key precedence rationale baked into the prompt. The reviewer (issue
+# #83 review, item 2) flagged that a flat "parser > scraper > specialist >
+# soft_tagger > taxonomy" ordering is wrong — taxonomy IS the canonical
+# source for product_type; scraper (manufacturer page) usually beats parser
+# (LLM extraction over possibly noisy text) for specs. The prompt spells
+# this out rather than hard-coding it in Python so the LLM can still use
+# judgment on confidence conflicts.
+_PRECEDENCE_NOTE = (
+    "Per-key precedence:\n"
+    "  - product_type / taxonomy_path -> taxonomy_v1 (canonical classifier)\n"
+    "  - numeric/categorical specs (ram_gb, weight_kg, etc.) -> scraper_v1 "
+    "beats parser_v1 when both are present (scraper reads the manufacturer "
+    "page, parser is LLM extraction); parser_v1 beats all others\n"
+    "  - good_for_* tags -> soft_tagger_v1\n"
+    "  - specialist_use_case_fit (structured {use_case: confidence}) may "
+    "be included; specialist narrative is never canonical\n"
+    "If two sources conflict, pick one and record the dropped alternative "
+    "in composer_decisions[*].dropped_alternatives."
+)
+
+
 _SYSTEM = (
     "You are the composer agent: the single writer of one product's canonical "
     "catalog row. You read the raw product, the findings emitted by every "
-    "upstream agent, and decide which keys belong on the canonical row.\n"
+    "upstream agent that actually ran, and decide which keys belong on the "
+    "canonical row.\n"
     "\n"
     "Policy:\n"
     "  1. No hallucination. Only include a key if its value is grounded in "
-    "the raw row, the parsed specs, or the scraped findings. If the "
-    "specialist asked a buyer question (specialist_buyer_questions) whose "
-    "answer is not in any of those sources, DO NOT fabricate it — omit it.\n"
-    "  2. Overlap resolution. When two agents claim the same key, pick one "
-    "source (prefer parser > scraper > specialist > soft_tagger > taxonomy) "
-    "OR merge explicitly. Record the chosen source in composer_decisions.\n"
-    "  3. Echo suppression. If a finding is identical to a field already on "
-    "the raw row (same value, same key), drop it.\n"
+    "the raw row, the parsed specs, or the scraped findings. If a buyer "
+    "question (specialist_buyer_questions) has no grounded answer in those "
+    "sources, DO NOT fabricate one — omit the key.\n"
+    "  2. Overlap resolution. Apply the per-key precedence below. Record "
+    "the chosen source in composer_decisions; put the dropped value in "
+    "dropped_alternatives.\n"
+    "  3. Echo discipline. A grounded value STILL belongs on the canonical "
+    "row even if raw_attributes already has it — downstream readers must "
+    "not have to re-join raw to reconstruct canonical state. Echo only "
+    "matters for measuring agent value-add, and goes in composer_decisions"
+    "[*].reason='echoes_raw', not into dropped keys.\n"
     "  4. Type discipline. Scalars stay scalars; never wrap a number in an "
-    "object. For spec dicts (e.g. parsed_specs), flatten their inner keys "
-    "up into composed_fields one level.\n"
-    "  5. Narrative text (specialist_capabilities, specialist_audience) does "
-    "NOT belong on the canonical row. Drop it here — it lives elsewhere.\n"
+    "object. For spec dicts (parsed_specs, scraped_specs), flatten their "
+    "inner keys up into composed_fields one level.\n"
+    "  5. Narrative text (prose bullets, audience blurbs, buyer questions) "
+    "does NOT belong on the canonical row — the Python post-check will "
+    "drop any narrative key regardless.\n"
+    "  6. Only reference strategies listed in the 'available_findings' "
+    "section of the user prompt. If a strategy didn't run, do not invent "
+    "a source_strategy for it.\n"
     "\n"
+    + _PRECEDENCE_NOTE
+    + "\n\n"
     "Return JSON with two keys:\n"
     "  composed_fields     object {key: value} — the canonical row content\n"
     "  composer_decisions  list of objects {key, chosen_value, "
-    "source_strategy, reason, dropped_alternatives} — one entry per key "
-    "you considered (kept or dropped). Use dropped_alternatives=[] when "
-    "there was no conflict."
+    "source_strategy, reason, dropped_alternatives}. Every key in "
+    "composed_fields MUST have a matching decision whose chosen_value "
+    "equals the composed_fields value; the Python post-check will drop "
+    "any decision that lies about its own key."
 )
 
 
@@ -119,6 +191,7 @@ class ComposerAgent(BaseEnrichmentAgent):
 
     def _invoke(self, product: ProductInput, context: dict[str, Any]) -> StrategyOutput:
         findings = _gather_findings(context)
+        validator_notes = _gather_validator_notes(context)
         now_iso = datetime.now(timezone.utc).isoformat()
 
         # If nothing upstream ran successfully, the composer has no material
@@ -138,27 +211,53 @@ class ComposerAgent(BaseEnrichmentAgent):
                 notes="no_upstream_findings",
             )
 
-        user = _format_user(product, findings)
-        resp = self._llm.complete(
-            system=_SYSTEM,
-            user=user,
-            model=context.get("composer_model") or context.get("model") or composer_model(),
-            json_mode=True,
-            max_tokens=1200,
-            temperature=0.1,
-        )
-        context["_last_cost_usd"] = resp.cost_usd
-        data = resp.parsed_json or {}
+        user = _format_user(product, findings, validator_notes)
 
-        composed = _coerce_composed_fields(data.get("composed_fields"))
-        decisions = _coerce_decisions(data.get("composer_decisions"))
+        # LLM call + parse. If anything goes sideways (network blip, JSON
+        # truncation, schema lies), fall back deterministically — one product
+        # never loses its canonical row to a transient error.
+        try:
+            resp = self._llm.complete(
+                system=_SYSTEM,
+                user=user,
+                model=(
+                    context.get("composer_model")
+                    or context.get("model")
+                    or composer_model()
+                ),
+                json_mode=True,
+                max_tokens=2500,
+                temperature=0.1,
+            )
+            context["_last_cost_usd"] = resp.cost_usd
+            data = resp.parsed_json or {}
+            composed = _coerce_composed_fields(data.get("composed_fields"))
+            decisions = _coerce_decisions(data.get("composer_decisions"))
+        except Exception as exc:  # noqa: BLE001 - any LLM-side failure lands here
+            logger.warning(
+                "composer_llm_failed_falling_back",
+                extra={"product_id": str(product.product_id), "error": str(exc)},
+            )
+            composed, decisions = _deterministic_fallback(findings)
+            composed = registry_strip_narrative(composed)
+            composed, decisions = _cross_check_decisions(composed, decisions)
+            return StrategyOutput(
+                product_id=product.product_id,
+                strategy=self.STRATEGY,
+                model=None,
+                attributes={
+                    "composed_fields": composed,
+                    "composer_decisions": decisions,
+                    "composed_at": now_iso,
+                },
+                notes="deterministic_fallback",
+            )
 
-        # Belt-and-braces policy enforcement: drop anything the LLM emitted
-        # that matches a raw-attribute value (echo) or that is structurally
-        # a narrative key we said to strip. Keeping this in Python means a
-        # chatty model can't silently violate the contract.
-        composed = _strip_echoes(composed, product)
-        composed = _strip_narrative_keys(composed)
+        # Python post-check: strip narrative keys regardless of what the LLM
+        # did (belt-and-braces), and drop decisions that lie about their own
+        # key (chosen_value != composed_fields[key]).
+        composed = registry_strip_narrative(composed)
+        composed, decisions = _cross_check_decisions(composed, decisions)
 
         return StrategyOutput(
             product_id=product.product_id,
@@ -177,18 +276,6 @@ class ComposerAgent(BaseEnrichmentAgent):
 # ---------------------------------------------------------------------------
 
 
-# Narrative / planning-artifact keys the issue explicitly calls out as NOT
-# belonging on the canonical catalog row. The composer may receive them from
-# upstream (specialist emits them today) but must never surface them.
-_NARRATIVE_KEYS: frozenset[str] = frozenset(
-    {
-        "specialist_capabilities",
-        "specialist_audience",
-        "specialist_buyer_questions",
-    }
-)
-
-
 def _gather_findings(context: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Pick up each upstream strategy's attributes dict from the runner ctx.
 
@@ -203,7 +290,20 @@ def _gather_findings(context: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return findings
 
 
-def _format_user(product: ProductInput, findings: dict[str, dict[str, Any]]) -> str:
+def _gather_validator_notes(context: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the list the runner stashes under ``_validator_notes`` — one
+    entry per rejected/failed upstream result. Always returns a list."""
+    notes = context.get("_validator_notes")
+    if not isinstance(notes, list):
+        return []
+    return [n for n in notes if isinstance(n, dict)]
+
+
+def _format_user(
+    product: ProductInput,
+    findings: dict[str, dict[str, Any]],
+    validator_notes: list[dict[str, Any]],
+) -> str:
     raw = {
         "product_id": str(product.product_id),
         "title": product.title,
@@ -213,7 +313,16 @@ def _format_user(product: ProductInput, findings: dict[str, dict[str, Any]]) -> 
         "price": float(product.price) if product.price is not None else None,
         "raw_attributes": product.raw_attributes or {},
     }
-    payload = {"raw": raw, "findings": findings}
+    # Tell the LLM which strategies actually produced findings so it can't
+    # invent a source_strategy for a strategy that didn't run (issue #83
+    # review, item 8).
+    available_findings = [_SHORT_TO_STRATEGY.get(k, k) for k in findings.keys()]
+    payload = {
+        "raw": raw,
+        "available_findings": available_findings,
+        "findings": findings,
+        "validator_notes": validator_notes,
+    }
     return "Compose the canonical row for this product.\n" + json.dumps(
         payload, ensure_ascii=False, default=str
     )
@@ -232,50 +341,116 @@ def _coerce_composed_fields(value: Any) -> dict[str, Any]:
 
 
 def _coerce_decisions(value: Any) -> list[dict[str, Any]]:
+    """Validate each decision against ComposerDecision; drop entries that
+    don't parse so the inspector doesn't have to defend against ill-formed
+    JSON at render time (issue #83 review, item 7)."""
     if not isinstance(value, list):
         return []
     decisions: list[dict[str, Any]] = []
     for entry in value:
         if not isinstance(entry, dict):
             continue
-        key = str(entry.get("key") or "").strip()
-        if not key:
+        try:
+            parsed = ComposerDecision.model_validate(entry)
+        except ValidationError as exc:
+            logger.debug("composer_decision_invalid: %s (%s)", entry, exc)
             continue
-        decisions.append(
-            {
-                "key": key,
-                "chosen_value": entry.get("chosen_value"),
-                "source_strategy": str(entry.get("source_strategy") or "") or None,
-                "reason": str(entry.get("reason") or "") or None,
-                "dropped_alternatives": (
-                    entry.get("dropped_alternatives")
-                    if isinstance(entry.get("dropped_alternatives"), list)
-                    else []
-                ),
-            }
-        )
+        decisions.append(parsed.model_dump(mode="json"))
     return decisions
 
 
-def _strip_echoes(
-    composed: dict[str, Any], product: ProductInput
-) -> dict[str, Any]:
-    raw_attrs = product.raw_attributes or {}
-    identity: dict[str, Any] = {
-        "title": product.title,
-        "brand": product.brand,
-        "category": product.category,
-        "description": product.description,
-    }
-    out: dict[str, Any] = {}
-    for k, v in composed.items():
-        if k in identity and identity[k] == v:
+def _cross_check_decisions(
+    composed: dict[str, Any], decisions: list[dict[str, Any]]
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Drop decisions whose chosen_value disagrees with composed_fields —
+    catches the LLM lying about its own decisions, per #83 review item 7.
+    Decisions with ``source_strategy`` outside the known upstream set are
+    also dropped (can't lineage-render an unknown source)."""
+    known_sources = frozenset(_SHORT_TO_STRATEGY.values()) | {None}
+    kept: list[dict[str, Any]] = []
+    for d in decisions:
+        key = d.get("key")
+        src = d.get("source_strategy")
+        if src not in known_sources:
+            logger.debug("composer_decision_unknown_source: %s", d)
             continue
-        if k in raw_attrs and raw_attrs[k] == v:
+        if key in composed and d.get("chosen_value") != composed[key]:
+            logger.debug(
+                "composer_decision_mismatch: key=%s decision=%r composed=%r",
+                key,
+                d.get("chosen_value"),
+                composed[key],
+            )
             continue
-        out[k] = v
-    return out
+        kept.append(d)
+    return composed, kept
 
 
-def _strip_narrative_keys(composed: dict[str, Any]) -> dict[str, Any]:
-    return {k: v for k, v in composed.items() if k not in _NARRATIVE_KEYS}
+def registry_strip_narrative(composed: dict[str, Any]) -> dict[str, Any]:
+    """Drop narrative keys declared by any registered agent. Reads from the
+    registry instead of a hardcoded list so new narrative-emitting agents
+    are covered by self-declaration (issue #83 review, item 4)."""
+    narrative = registry.narrative_keys()
+    if not narrative:
+        return composed
+    return {k: v for k, v in composed.items() if k not in narrative}
+
+
+def _deterministic_fallback(
+    findings: dict[str, dict[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Build composed_fields + decisions from findings, no LLM.
+
+    Order matters: later writes win, so precedence goes low-to-high.
+    soft_tags first (weakest claim to canonical), then taxonomy product_type,
+    then parser specs, then scraper specs (manufacturer page beats parser).
+    Narrative stripping happens in the caller — keep this function's shape
+    simple.
+    """
+    composed: dict[str, Any] = {}
+    decisions: list[dict[str, Any]] = []
+
+    def _record(key: str, value: Any, source: str, reason: str) -> None:
+        prev = composed.get(key)
+        dropped = [prev] if key in composed and prev != value else []
+        composed[key] = value
+        decisions.append(
+            {
+                "key": key,
+                "chosen_value": value,
+                "source_strategy": source,
+                "reason": reason,
+                "dropped_alternatives": dropped,
+            }
+        )
+
+    tags = (findings.get("soft_tagger") or {}).get("good_for_tags") or {}
+    if isinstance(tags, dict):
+        for k, v in tags.items():
+            _record(str(k), v, "soft_tagger_v1", "fallback_from_soft_tagger")
+
+    taxonomy = findings.get("taxonomy") or {}
+    ptype = taxonomy.get("product_type")
+    if ptype and ptype != "unknown":
+        _record("product_type", ptype, "taxonomy_v1", "fallback_from_taxonomy")
+
+    parsed_specs = (findings.get("parsed") or {}).get("parsed_specs") or {}
+    if isinstance(parsed_specs, dict):
+        for k, v in parsed_specs.items():
+            _record(str(k), v, "parser_v1", "fallback_from_parser")
+
+    scraped_specs = (findings.get("scraped") or {}).get("scraped_specs") or {}
+    if isinstance(scraped_specs, dict):
+        for k, v in scraped_specs.items():
+            _record(str(k), v, "scraper_v1", "fallback_from_scraper")
+
+    use_case_fit = (findings.get("specialist") or {}).get("specialist_use_case_fit") or {}
+    if isinstance(use_case_fit, dict):
+        _record(
+            "specialist_use_case_fit",
+            use_case_fit,
+            "specialist_v1",
+            "fallback_from_specialist_use_case_fit",
+        )
+
+    return composed, decisions

--- a/mcp-server/app/enrichment/agents/parser.py
+++ b/mcp-server/app/enrichment/agents/parser.py
@@ -39,7 +39,7 @@ _SYSTEM = (
 class ParserAgent(BaseEnrichmentAgent):
     STRATEGY = "parser_v1"
     OUTPUT_KEYS = frozenset({"parsed_specs", "parsed_at", "parsed_source_fields"})
-    DEFAULT_MODEL = "gpt-4o-mini"
+    DEFAULT_MODEL = "gpt-5-mini"
 
     def __init__(self, llm: LLMClient | None = None) -> None:
         super().__init__()

--- a/mcp-server/app/enrichment/agents/soft_tagger.py
+++ b/mcp-server/app/enrichment/agents/soft_tagger.py
@@ -37,7 +37,7 @@ _SYSTEM = (
 class SoftTaggerAgent(BaseEnrichmentAgent):
     STRATEGY = "soft_tagger_v1"
     OUTPUT_KEYS = frozenset({"good_for_tags", "soft_tags_at"})
-    DEFAULT_MODEL = "gpt-4o-mini"
+    DEFAULT_MODEL = "gpt-5-mini"
 
     def __init__(self, llm: LLMClient | None = None) -> None:
         super().__init__()

--- a/mcp-server/app/enrichment/agents/specialist.py
+++ b/mcp-server/app/enrichment/agents/specialist.py
@@ -65,7 +65,7 @@ class SpecialistAgent(BaseEnrichmentAgent):
             "specialist_buyer_questions",
         }
     )
-    DEFAULT_MODEL = "gpt-4o-mini"
+    DEFAULT_MODEL = "gpt-5-mini"
 
     def __init__(self, llm: LLMClient | None = None) -> None:
         super().__init__()

--- a/mcp-server/app/enrichment/agents/specialist.py
+++ b/mcp-server/app/enrichment/agents/specialist.py
@@ -65,6 +65,16 @@ class SpecialistAgent(BaseEnrichmentAgent):
             "specialist_buyer_questions",
         }
     )
+    # Prose + planning-artifact outputs. The composer strips these from the
+    # canonical row; specialist_use_case_fit is NOT narrative (structured
+    # {use_case: confidence} map) and stays composer-eligible.
+    NARRATIVE_KEYS = frozenset(
+        {
+            "specialist_capabilities",
+            "specialist_audience",
+            "specialist_buyer_questions",
+        }
+    )
     DEFAULT_MODEL = "gpt-5-mini"
 
     def __init__(self, llm: LLMClient | None = None) -> None:

--- a/mcp-server/app/enrichment/agents/taxonomy.py
+++ b/mcp-server/app/enrichment/agents/taxonomy.py
@@ -32,7 +32,7 @@ _SYSTEM = (
 class TaxonomyAgent(BaseEnrichmentAgent):
     STRATEGY = "taxonomy_v1"
     OUTPUT_KEYS = frozenset({"product_type", "taxonomy_path", "product_type_confidence"})
-    DEFAULT_MODEL = "gpt-4o-mini"
+    DEFAULT_MODEL = "gpt-5-mini"
 
     def __init__(self, llm: LLMClient | None = None) -> None:
         super().__init__()

--- a/mcp-server/app/enrichment/base.py
+++ b/mcp-server/app/enrichment/base.py
@@ -39,6 +39,13 @@ class BaseEnrichmentAgent:
     STRATEGY: str = ""
     OUTPUT_KEYS: frozenset[str] = frozenset()
     DEFAULT_MODEL: str | None = None
+    # Subset of OUTPUT_KEYS that hold narrative / planning-artifact output
+    # (prose, buyer questions, audience blurbs). These must NOT land on the
+    # canonical catalog row — the composer reads registry.narrative_keys() to
+    # strip them. Keeping this self-declared per agent means adding a future
+    # narrative-emitting agent is a one-line change on that agent, not a
+    # registry list to keep in sync (issue #83 review).
+    NARRATIVE_KEYS: frozenset[str] = frozenset()
 
     def __init__(self) -> None:
         if not self.STRATEGY:

--- a/mcp-server/app/enrichment/orchestration/fixed.py
+++ b/mcp-server/app/enrichment/orchestration/fixed.py
@@ -17,13 +17,15 @@ class FixedOrchestrator:
 
 # Strategy run order matters: taxonomy first (others read its product_type),
 # then parser (extracts specs the specialist consults), then specialist /
-# scraper / soft_tagger.
+# scraper / soft_tagger. composer_v1 runs last — it is the single writer of
+# the canonical row and synthesizes all upstream findings (issue #83).
 _PREFERRED_ORDER = (
     "taxonomy_v1",
     "parser_v1",
     "specialist_v1",
     "scraper_v1",
     "soft_tagger_v1",
+    "composer_v1",
 )
 
 

--- a/mcp-server/app/enrichment/orchestration/orchestrated.py
+++ b/mcp-server/app/enrichment/orchestration/orchestrated.py
@@ -37,10 +37,12 @@ _SYSTEM = (
 
 class LLMOrchestrator:
     # taxonomy and soft_tagger are not negotiable — taxonomy gates everything,
-    # soft_tagger is cheap and the KG depends on it. The LLM only chooses among
-    # the others.
+    # soft_tagger is cheap and the KG depends on it. composer_v1 is the single
+    # writer of the canonical row (#83) and must always run last. The LLM only
+    # chooses among the others.
     _FORCED = ("taxonomy_v1", "soft_tagger_v1")
     _CHOOSABLE = ("parser_v1", "specialist_v1", "scraper_v1")
+    _TRAILING = ("composer_v1",)
 
     def __init__(self, llm: LLMClient | None = None) -> None:
         self._llm = llm or LLMClient()
@@ -54,7 +56,9 @@ class LLMOrchestrator:
         for p in products:
             chosen = choices.get(str(p.product_id), [])
             chosen_clean = [s for s in chosen if s in self._CHOOSABLE]
-            per[p.product_id] = list(_dedupe_in_order(self._FORCED + tuple(chosen_clean)))
+            per[p.product_id] = list(
+                _dedupe_in_order(self._FORCED + tuple(chosen_clean) + self._TRAILING)
+            )
         return OrchestratorPlan(per_product_agents=per)
 
     # ------------------------------------------------------------------

--- a/mcp-server/app/enrichment/orchestration/runner.py
+++ b/mcp-server/app/enrichment/orchestration/runner.py
@@ -247,6 +247,20 @@ def _run_inner(
                 summary.strategies_failed[strategy] = (
                     summary.strategies_failed.get(strategy, 0) + 1
                 )
+                # Feed the rejection into ctx so the composer (runs last)
+                # knows which strategies' output was dropped and why, rather
+                # than treating a missing finding as "strategy wasn't asked
+                # to run" (issue #83 review, item 3).
+                ctx.setdefault("_validator_notes", []).append(
+                    {
+                        "strategy": strategy,
+                        "failure_mode": "validator_rejected"
+                        if result.success
+                        else "agent_errored",
+                        "reasons": list(verdict.reasons),
+                        "error": result.error,
+                    }
+                )
                 if verdict.reasons:
                     logger.info(
                         "validator_rejected",

--- a/mcp-server/app/enrichment/orchestration/runner.py
+++ b/mcp-server/app/enrichment/orchestration/runner.py
@@ -459,6 +459,7 @@ def _short(strategy: str) -> str:
         "specialist_v1": "specialist",
         "scraper_v1": "scraped",
         "soft_tagger_v1": "soft_tagger",
+        "composer_v1": "composer",
     }
     return mapping.get(strategy, strategy)
 

--- a/mcp-server/app/enrichment/registry.py
+++ b/mcp-server/app/enrichment/registry.py
@@ -94,6 +94,10 @@ class StrategyKeyCollision(ValueError):
 
 _REGISTRY: dict[str, Type] = {}
 _REGISTERED_KEYS: dict[str, frozenset[str]] = dict(EXTERNAL_STRATEGY_KEYS)
+# Union of every registered agent's NARRATIVE_KEYS. Composer reads this to
+# strip narrative output from the canonical row without hard-coding which
+# agent owns which key (issue #83 review, item 4).
+_NARRATIVE_KEYS: set[str] = set()
 
 
 def register(agent_cls: Type) -> Type:
@@ -127,8 +131,19 @@ def register(agent_cls: Type) -> Type:
                 f"strategy {strategy!r} OUTPUT_KEYS overlap {other_strategy!r}: {sorted(cross)}"
             )
 
+    narrative = getattr(agent_cls, "NARRATIVE_KEYS", frozenset()) or frozenset()
+    # narrative keys must be a subset of output keys — otherwise the agent is
+    # claiming to own a key it doesn't emit.
+    narrative_outside_output = set(narrative) - set(keys)
+    if narrative_outside_output:
+        raise StrategyKeyCollision(
+            f"strategy {strategy!r} NARRATIVE_KEYS must be a subset of OUTPUT_KEYS; "
+            f"extra keys: {sorted(narrative_outside_output)}"
+        )
+
     _REGISTRY[strategy] = agent_cls
     _REGISTERED_KEYS[strategy] = keys
+    _NARRATIVE_KEYS.update(narrative)
     return agent_cls
 
 
@@ -181,8 +196,15 @@ def all_known_keys() -> dict[str, frozenset[str]]:
     return dict(_REGISTERED_KEYS)
 
 
+def narrative_keys() -> frozenset[str]:
+    """Union of every registered agent's self-declared NARRATIVE_KEYS. The
+    composer strips these from the canonical row — see ComposerAgent."""
+    return frozenset(_NARRATIVE_KEYS)
+
+
 def _reset_for_tests() -> None:
     """Test helper — wipes in-module strategies, keeps EXTERNAL_STRATEGY_KEYS."""
     _REGISTRY.clear()
     _REGISTERED_KEYS.clear()
     _REGISTERED_KEYS.update(EXTERNAL_STRATEGY_KEYS)
+    _NARRATIVE_KEYS.clear()

--- a/mcp-server/app/enrichment/tools/llm_client.py
+++ b/mcp-server/app/enrichment/tools/llm_client.py
@@ -25,13 +25,17 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-# Per-1K-token rates (USD). Update if OpenAI changes pricing — only used for
-# the in-process running total; Langfuse computes its own server-side.
+# Per-1K-token rates (USD). Only used for the in-process running total —
+# Langfuse is the source of truth for server-side cost, so a stale entry
+# here skews the CLI summary but not any invoicing. Source:
+# https://openai.com/api/pricing/ — entries updated 2026-04-20. Re-check
+# when OpenAI announces pricing changes; a stale row silently under- or
+# over-reports cost in scripts/summaries.
 _PRICING: dict[str, tuple[float, float]] = {
     # model: (input_per_1k, output_per_1k)
     "gpt-4o-mini": (0.00015, 0.00060),
     "gpt-4o": (0.00250, 0.01000),
-    # GPT-5 family — public list pricing at time of adoption (issue #83).
+    # GPT-5 family — tiered adoption per issue #83.
     "gpt-5-nano": (0.00005, 0.00040),
     "gpt-5-mini": (0.00025, 0.00200),
     "gpt-5": (0.00125, 0.01000),

--- a/mcp-server/app/enrichment/tools/llm_client.py
+++ b/mcp-server/app/enrichment/tools/llm_client.py
@@ -1,7 +1,11 @@
 """OpenAI wrapper used by every enrichment agent.
 
 Centralizes:
-  - model selection (default gpt-4o-mini; gpt-4o opt-in via ENRICHMENT_LARGE_MODEL)
+  - tiered model selection (see #83):
+      * per-product strategies   -> gpt-5-mini   (ENRICHMENT_DEFAULT_MODEL)
+      * composer / assessor      -> gpt-5        (ENRICHMENT_LARGE_MODEL,
+                                                  ENRICHMENT_COMPOSER_MODEL)
+      * utility / pre-pass calls -> gpt-5-nano   (ENRICHMENT_UTILITY_MODEL)
   - retry on transient errors (rate limits, timeouts)
   - cost metering (per-call usage and a process-level running total)
   - JSON-mode parsing convenience
@@ -27,6 +31,10 @@ _PRICING: dict[str, tuple[float, float]] = {
     # model: (input_per_1k, output_per_1k)
     "gpt-4o-mini": (0.00015, 0.00060),
     "gpt-4o": (0.00250, 0.01000),
+    # GPT-5 family — public list pricing at time of adoption (issue #83).
+    "gpt-5-nano": (0.00005, 0.00040),
+    "gpt-5-mini": (0.00025, 0.00200),
+    "gpt-5": (0.00125, 0.01000),
 }
 
 
@@ -69,8 +77,24 @@ def get_ledger() -> CostLedger:
 
 def default_model(*, large: bool = False) -> str:
     if large:
-        return os.getenv("ENRICHMENT_LARGE_MODEL", "gpt-4o")
-    return os.getenv("ENRICHMENT_DEFAULT_MODEL", "gpt-4o-mini")
+        return os.getenv("ENRICHMENT_LARGE_MODEL", "gpt-5")
+    return os.getenv("ENRICHMENT_DEFAULT_MODEL", "gpt-5-mini")
+
+
+def composer_model() -> str:
+    """Top-tier model for the composer agent (cross-agent synthesis +
+    no-hallucination policy enforcement). Falls back to ENRICHMENT_LARGE_MODEL
+    so sites that haven't set the composer knob still land on gpt-5."""
+    return os.getenv(
+        "ENRICHMENT_COMPOSER_MODEL",
+        os.getenv("ENRICHMENT_LARGE_MODEL", "gpt-5"),
+    )
+
+
+def utility_model() -> str:
+    """Cheapest tier for utility / pre-pass calls (e.g. the assessor's
+    product-type discovery) where high reasoning isn't needed."""
+    return os.getenv("ENRICHMENT_UTILITY_MODEL", "gpt-5-nano")
 
 
 def _estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:

--- a/mcp-server/app/enrichment/types.py
+++ b/mcp-server/app/enrichment/types.py
@@ -138,3 +138,20 @@ class ProposalAck(BaseModel):
     merchant_id: str
     decisions: list[ProposalDecision] = Field(default_factory=list)
     proposal_id: str
+
+
+# ---------------------------------------------------------------------------
+# Composer decisions (one row per key the composer considered — kept or
+# dropped). Surfaces as the cell-lineage audit log for #81.
+# ---------------------------------------------------------------------------
+
+
+class ComposerDecision(BaseModel):
+    """One entry in ``composer_decisions``. Structured schema lets the
+    inspector (#81) render cell lineage without re-parsing free-form JSON."""
+
+    key: str
+    chosen_value: Any = None
+    source_strategy: str | None = None
+    reason: str | None = None
+    dropped_alternatives: list[Any] = Field(default_factory=list)

--- a/mcp-server/tests/enrichment/test_composer.py
+++ b/mcp-server/tests/enrichment/test_composer.py
@@ -1,0 +1,196 @@
+"""composer_v1 — single writer of the canonical enriched row (issue #83)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from app.enrichment import registry
+from app.enrichment.agents.composer import ComposerAgent
+from app.enrichment.tools.llm_client import LLMResponse
+from app.enrichment.types import ProductInput
+
+
+@pytest.fixture(autouse=True)
+def _registry_clean():
+    registry._reset_for_tests()
+    registry.register(ComposerAgent)
+    yield
+    registry._reset_for_tests()
+
+
+class _FakeLLM:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls: list[dict] = []
+
+    def complete(self, **kw):
+        self.calls.append(kw)
+        return LLMResponse(
+            text="",
+            model=kw.get("model") or "gpt-5",
+            input_tokens=50,
+            output_tokens=50,
+            cost_usd=0.001,
+            latency_ms=10,
+            parsed_json=self.payload,
+        )
+
+
+def _product(**overrides):
+    defaults = dict(
+        product_id=uuid4(),
+        title="ThinkPad X1 Carbon, 16GB RAM, 512GB SSD",
+        brand="Lenovo",
+        category="Electronics",
+        description="Business ultraportable.",
+        price=Decimal("1299.00"),
+        raw_attributes={"description": "Business ultraportable.", "color": "black"},
+    )
+    defaults.update(overrides)
+    return ProductInput(**defaults)
+
+
+def _upstream_ctx():
+    return {
+        "taxonomy": {
+            "product_type": "laptop",
+            "taxonomy_path": ["electronics", "computers", "laptop"],
+            "product_type_confidence": 0.92,
+        },
+        "parsed": {
+            "parsed_specs": {"ram_gb": 16, "storage_gb": 512},
+            "parsed_source_fields": {"ram_gb": "title", "storage_gb": "title"},
+        },
+        "specialist": {
+            "specialist_capabilities": ["long battery"],
+            "specialist_use_case_fit": {"business": 0.9},
+            "specialist_audience": {"professionals": "lightweight"},
+            "specialist_buyer_questions": ["What's the warranty?"],
+        },
+        "soft_tagger": {"good_for_tags": {"good_for_business": 0.9}},
+    }
+
+
+def test_composer_emits_composed_fields_and_decisions():
+    llm = _FakeLLM(
+        {
+            "composed_fields": {
+                "product_type": "laptop",
+                "ram_gb": 16,
+                "storage_gb": 512,
+                "good_for_business": 0.9,
+            },
+            "composer_decisions": [
+                {
+                    "key": "ram_gb",
+                    "chosen_value": 16,
+                    "source_strategy": "parser_v1",
+                    "reason": "grounded in title",
+                    "dropped_alternatives": [],
+                }
+            ],
+        }
+    )
+    agent = ComposerAgent(llm=llm)
+    result = agent.run(_product(), _upstream_ctx())
+
+    assert result.success is True
+    attrs = result.output.attributes
+    assert attrs["composed_fields"] == {
+        "product_type": "laptop",
+        "ram_gb": 16,
+        "storage_gb": 512,
+        "good_for_business": 0.9,
+    }
+    assert attrs["composer_decisions"][0]["key"] == "ram_gb"
+    assert attrs["composer_decisions"][0]["source_strategy"] == "parser_v1"
+    assert "composed_at" in attrs
+
+
+def test_composer_strips_echoes_of_raw_identity_fields():
+    """If the LLM echoes the raw title/brand/description/color, drop it."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {
+                "title": "ThinkPad X1 Carbon, 16GB RAM, 512GB SSD",  # echo
+                "color": "black",  # echo (from raw_attributes)
+                "ram_gb": 16,  # keep
+            },
+            "composer_decisions": [],
+        }
+    )
+    agent = ComposerAgent(llm=llm)
+    result = agent.run(_product(), _upstream_ctx())
+    assert result.output.attributes["composed_fields"] == {"ram_gb": 16}
+
+
+def test_composer_strips_narrative_keys():
+    """Specialist narrative output must never land on the canonical row."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {
+                "specialist_capabilities": ["long battery"],
+                "specialist_audience": {"professionals": "lightweight"},
+                "specialist_buyer_questions": ["What's the warranty?"],
+                "ram_gb": 16,
+            },
+            "composer_decisions": [],
+        }
+    )
+    agent = ComposerAgent(llm=llm)
+    result = agent.run(_product(), _upstream_ctx())
+    assert result.output.attributes["composed_fields"] == {"ram_gb": 16}
+
+
+def test_composer_skips_llm_when_no_upstream_findings():
+    """An empty context means no findings to synthesize — don't waste a gpt-5 call."""
+    llm = _FakeLLM({"composed_fields": {"oops": "should_not_see_this"}})
+    agent = ComposerAgent(llm=llm)
+    result = agent.run(_product(), {})  # no upstream findings
+    assert llm.calls == []
+    assert result.output.attributes["composed_fields"] == {}
+    assert result.output.attributes["composer_decisions"] == []
+    assert result.output.notes == "no_upstream_findings"
+
+
+def test_composer_uses_json_mode_and_composer_model_default():
+    llm = _FakeLLM({"composed_fields": {}, "composer_decisions": []})
+    ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    assert llm.calls[0]["json_mode"] is True
+    # default composer tier is gpt-5 when no env override is set
+    assert llm.calls[0]["model"] == "gpt-5"
+
+
+def test_composer_honors_context_model_override():
+    llm = _FakeLLM({"composed_fields": {}, "composer_decisions": []})
+    ComposerAgent(llm=llm).run(_product(), {**_upstream_ctx(), "composer_model": "gpt-5-mini"})
+    assert llm.calls[0]["model"] == "gpt-5-mini"
+
+
+def test_composer_feeds_all_upstream_findings_into_prompt():
+    llm = _FakeLLM({"composed_fields": {}, "composer_decisions": []})
+    ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    user = llm.calls[0]["user"]
+    assert "taxonomy" in user
+    assert "parsed" in user
+    assert "specialist" in user
+    assert "soft_tagger" in user
+
+
+def test_composer_coerces_malformed_llm_output():
+    """Non-dict composed_fields and non-list decisions are coerced to empties."""
+    llm = _FakeLLM({"composed_fields": "not-a-dict", "composer_decisions": "not-a-list"})
+    result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    assert result.success is True
+    assert result.output.attributes["composed_fields"] == {}
+    assert result.output.attributes["composer_decisions"] == []
+
+
+def test_composer_registered_with_disjoint_keys():
+    """OUTPUT_KEYS must be disjoint from every other registered strategy."""
+    assert "composer_v1" in registry.all_known_keys()
+    keys = registry.output_keys("composer_v1")
+    assert keys == frozenset({"composed_fields", "composer_decisions", "composed_at"})

--- a/mcp-server/tests/enrichment/test_composer.py
+++ b/mcp-server/tests/enrichment/test_composer.py
@@ -9,6 +9,7 @@ import pytest
 
 from app.enrichment import registry
 from app.enrichment.agents.composer import ComposerAgent
+from app.enrichment.agents.specialist import SpecialistAgent
 from app.enrichment.tools.llm_client import LLMResponse
 from app.enrichment.types import ProductInput
 
@@ -17,17 +18,24 @@ from app.enrichment.types import ProductInput
 def _registry_clean():
     registry._reset_for_tests()
     registry.register(ComposerAgent)
+    # SpecialistAgent is registered so the composer's narrative-key strip
+    # reads a non-empty frozenset from registry.narrative_keys(). Without
+    # this, the strip silently no-ops in isolated composer tests.
+    registry.register(SpecialistAgent)
     yield
     registry._reset_for_tests()
 
 
 class _FakeLLM:
-    def __init__(self, payload):
+    def __init__(self, payload=None, *, raises: Exception | None = None):
         self.payload = payload
+        self.raises = raises
         self.calls: list[dict] = []
 
     def complete(self, **kw):
         self.calls.append(kw)
+        if self.raises is not None:
+            raise self.raises
         return LLMResponse(
             text="",
             model=kw.get("model") or "gpt-5",
@@ -71,6 +79,7 @@ def _upstream_ctx():
             "specialist_buyer_questions": ["What's the warranty?"],
         },
         "soft_tagger": {"good_for_tags": {"good_for_business": 0.9}},
+        "scraped": {"scraped_specs": {"weight_kg": 1.12}},
     }
 
 
@@ -110,49 +119,63 @@ def test_composer_emits_composed_fields_and_decisions():
     assert "composed_at" in attrs
 
 
-def test_composer_strips_echoes_of_raw_identity_fields():
-    """If the LLM echoes the raw title/brand/description/color, drop it."""
+def test_composer_keeps_canonical_values_even_when_raw_also_has_them():
+    """Review fix #1: echoes must stay on the canonical row — downstream
+    readers shouldn't have to re-join raw to reconstruct canonical state."""
+    product = _product(raw_attributes={"color": "black", "ram_gb": 16})
     llm = _FakeLLM(
         {
-            "composed_fields": {
-                "title": "ThinkPad X1 Carbon, 16GB RAM, 512GB SSD",  # echo
-                "color": "black",  # echo (from raw_attributes)
-                "ram_gb": 16,  # keep
-            },
-            "composer_decisions": [],
+            "composed_fields": {"color": "black", "ram_gb": 16},
+            "composer_decisions": [
+                {
+                    "key": "color",
+                    "chosen_value": "black",
+                    "source_strategy": "parser_v1",
+                    "reason": "echoes_raw",
+                    "dropped_alternatives": [],
+                },
+                {
+                    "key": "ram_gb",
+                    "chosen_value": 16,
+                    "source_strategy": "parser_v1",
+                    "reason": "echoes_raw",
+                    "dropped_alternatives": [],
+                },
+            ],
         }
     )
-    agent = ComposerAgent(llm=llm)
-    result = agent.run(_product(), _upstream_ctx())
-    assert result.output.attributes["composed_fields"] == {"ram_gb": 16}
+    result = ComposerAgent(llm=llm).run(product, _upstream_ctx())
+    assert result.output.attributes["composed_fields"] == {"color": "black", "ram_gb": 16}
 
 
-def test_composer_strips_narrative_keys():
-    """Specialist narrative output must never land on the canonical row."""
+def test_composer_strips_narrative_keys_via_registry():
+    """Narrative-key strip reads from the registry (specialist_v1 self-
+    declares NARRATIVE_KEYS), not a hardcoded list."""
     llm = _FakeLLM(
         {
             "composed_fields": {
                 "specialist_capabilities": ["long battery"],
                 "specialist_audience": {"professionals": "lightweight"},
                 "specialist_buyer_questions": ["What's the warranty?"],
+                "specialist_use_case_fit": {"business": 0.9},
                 "ram_gb": 16,
             },
             "composer_decisions": [],
         }
     )
-    agent = ComposerAgent(llm=llm)
-    result = agent.run(_product(), _upstream_ctx())
-    assert result.output.attributes["composed_fields"] == {"ram_gb": 16}
+    result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    # specialist_use_case_fit is NOT narrative (structured), so it survives.
+    assert result.output.attributes["composed_fields"] == {
+        "specialist_use_case_fit": {"business": 0.9},
+        "ram_gb": 16,
+    }
 
 
 def test_composer_skips_llm_when_no_upstream_findings():
-    """An empty context means no findings to synthesize — don't waste a gpt-5 call."""
     llm = _FakeLLM({"composed_fields": {"oops": "should_not_see_this"}})
-    agent = ComposerAgent(llm=llm)
-    result = agent.run(_product(), {})  # no upstream findings
+    result = ComposerAgent(llm=llm).run(_product(), {})
     assert llm.calls == []
     assert result.output.attributes["composed_fields"] == {}
-    assert result.output.attributes["composer_decisions"] == []
     assert result.output.notes == "no_upstream_findings"
 
 
@@ -160,13 +183,16 @@ def test_composer_uses_json_mode_and_composer_model_default():
     llm = _FakeLLM({"composed_fields": {}, "composer_decisions": []})
     ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
     assert llm.calls[0]["json_mode"] is True
-    # default composer tier is gpt-5 when no env override is set
     assert llm.calls[0]["model"] == "gpt-5"
+    # Review fix #6: composer budget bumped to handle dense findings.
+    assert llm.calls[0]["max_tokens"] == 2500
 
 
 def test_composer_honors_context_model_override():
     llm = _FakeLLM({"composed_fields": {}, "composer_decisions": []})
-    ComposerAgent(llm=llm).run(_product(), {**_upstream_ctx(), "composer_model": "gpt-5-mini"})
+    ComposerAgent(llm=llm).run(
+        _product(), {**_upstream_ctx(), "composer_model": "gpt-5-mini"}
+    )
     assert llm.calls[0]["model"] == "gpt-5-mini"
 
 
@@ -180,8 +206,36 @@ def test_composer_feeds_all_upstream_findings_into_prompt():
     assert "soft_tagger" in user
 
 
+def test_composer_prompt_lists_available_findings():
+    """Review fix #8: composer must know which strategies actually ran so it
+    can't invent a source_strategy for a skipped one."""
+    llm = _FakeLLM({"composed_fields": {}, "composer_decisions": []})
+    # Skip scraper — composer must not see scraper_v1 in available_findings.
+    ctx = _upstream_ctx()
+    del ctx["scraped"]
+    ComposerAgent(llm=llm).run(_product(), ctx)
+    user = llm.calls[0]["user"]
+    assert '"available_findings"' in user
+    assert "parser_v1" in user
+    assert "scraper_v1" not in user
+
+
+def test_composer_prompt_includes_validator_notes():
+    """Review fix #3: validator rejections reach composer as _validator_notes
+    so it can reason about dropped findings rather than treating them as
+    'not asked to run'."""
+    llm = _FakeLLM({"composed_fields": {}, "composer_decisions": []})
+    ctx = _upstream_ctx()
+    ctx["_validator_notes"] = [
+        {"strategy": "parser_v1", "failure_mode": "validator_rejected",
+         "reasons": ["out_of_bounds:ram_gb=9999"], "error": None},
+    ]
+    ComposerAgent(llm=llm).run(_product(), ctx)
+    assert "validator_notes" in llm.calls[0]["user"]
+    assert "out_of_bounds" in llm.calls[0]["user"]
+
+
 def test_composer_coerces_malformed_llm_output():
-    """Non-dict composed_fields and non-list decisions are coerced to empties."""
     llm = _FakeLLM({"composed_fields": "not-a-dict", "composer_decisions": "not-a-list"})
     result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
     assert result.success is True
@@ -189,8 +243,98 @@ def test_composer_coerces_malformed_llm_output():
     assert result.output.attributes["composer_decisions"] == []
 
 
+def test_composer_drops_decisions_that_lie_about_their_key():
+    """Review fix #7: a decision whose chosen_value != composed_fields[key]
+    is the LLM lying about its own choice; drop it from the audit log."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {"ram_gb": 16, "storage_gb": 512},
+            "composer_decisions": [
+                {
+                    "key": "ram_gb",
+                    "chosen_value": 32,  # LIE: composed says 16
+                    "source_strategy": "parser_v1",
+                    "reason": "grounded",
+                    "dropped_alternatives": [],
+                },
+                {
+                    "key": "storage_gb",
+                    "chosen_value": 512,  # matches
+                    "source_strategy": "parser_v1",
+                    "reason": "grounded",
+                    "dropped_alternatives": [],
+                },
+            ],
+        }
+    )
+    result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    decisions = result.output.attributes["composer_decisions"]
+    assert len(decisions) == 1
+    assert decisions[0]["key"] == "storage_gb"
+
+
+def test_composer_drops_decisions_with_unknown_source_strategy():
+    """Review fix #7 + #8: a decision citing a source outside the known
+    strategy set can't be rendered as cell lineage — drop it."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {"ram_gb": 16},
+            "composer_decisions": [
+                {
+                    "key": "ram_gb",
+                    "chosen_value": 16,
+                    "source_strategy": "magical_oracle_v999",
+                    "reason": "grounded",
+                    "dropped_alternatives": [],
+                }
+            ],
+        }
+    )
+    result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    assert result.output.attributes["composer_decisions"] == []
+
+
+def test_composer_deterministic_fallback_when_llm_fails():
+    """Review fix #5: a transient LLM error must not leave the product
+    without a canonical row. Fall back to findings-based synthesis."""
+    llm = _FakeLLM(raises=RuntimeError("network down"))
+    result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    assert result.success is True
+    assert result.output.notes == "deterministic_fallback"
+    composed = result.output.attributes["composed_fields"]
+    # parser specs flattened in
+    assert composed["ram_gb"] == 16
+    assert composed["storage_gb"] == 512
+    # scraper spec flattened in (scraper overrides parser on collisions —
+    # weight_kg only comes from scraper here so we just check presence)
+    assert composed["weight_kg"] == 1.12
+    # taxonomy product_type lifted
+    assert composed["product_type"] == "laptop"
+    # soft_tag lifted
+    assert composed["good_for_business"] == 0.9
+    # use_case_fit (structured specialist output) lifted
+    assert composed["specialist_use_case_fit"] == {"business": 0.9}
+    # Narrative specialist keys NOT lifted.
+    assert "specialist_capabilities" not in composed
+    assert "specialist_audience" not in composed
+    assert "specialist_buyer_questions" not in composed
+    # Decisions annotate every key with a fallback reason.
+    assert all(
+        d["reason"].startswith("fallback_") for d in result.output.attributes["composer_decisions"]
+    )
+
+
 def test_composer_registered_with_disjoint_keys():
-    """OUTPUT_KEYS must be disjoint from every other registered strategy."""
     assert "composer_v1" in registry.all_known_keys()
     keys = registry.output_keys("composer_v1")
     assert keys == frozenset({"composed_fields", "composer_decisions", "composed_at"})
+
+
+def test_specialist_narrative_keys_registered_via_registry():
+    """The registry surfaces every agent's self-declared NARRATIVE_KEYS."""
+    narrative = registry.narrative_keys()
+    assert "specialist_capabilities" in narrative
+    assert "specialist_audience" in narrative
+    assert "specialist_buyer_questions" in narrative
+    # Structured output is NOT narrative.
+    assert "specialist_use_case_fit" not in narrative

--- a/mcp-server/tests/enrichment/test_llm_client.py
+++ b/mcp-server/tests/enrichment/test_llm_client.py
@@ -1,0 +1,61 @@
+"""llm_client — model-tier helpers + GPT-5 family pricing (issue #83)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.enrichment.tools import llm_client
+
+
+def test_default_model_defaults_to_gpt5_mini(monkeypatch):
+    monkeypatch.delenv("ENRICHMENT_DEFAULT_MODEL", raising=False)
+    assert llm_client.default_model() == "gpt-5-mini"
+
+
+def test_default_model_large_defaults_to_gpt5(monkeypatch):
+    monkeypatch.delenv("ENRICHMENT_LARGE_MODEL", raising=False)
+    assert llm_client.default_model(large=True) == "gpt-5"
+
+
+def test_composer_model_defaults_to_gpt5(monkeypatch):
+    monkeypatch.delenv("ENRICHMENT_COMPOSER_MODEL", raising=False)
+    monkeypatch.delenv("ENRICHMENT_LARGE_MODEL", raising=False)
+    assert llm_client.composer_model() == "gpt-5"
+
+
+def test_composer_model_falls_back_to_large_when_unset(monkeypatch):
+    """If COMPOSER isn't set but LARGE is, use LARGE — cheap rollout path."""
+    monkeypatch.delenv("ENRICHMENT_COMPOSER_MODEL", raising=False)
+    monkeypatch.setenv("ENRICHMENT_LARGE_MODEL", "gpt-5-mini")
+    assert llm_client.composer_model() == "gpt-5-mini"
+
+
+def test_composer_model_env_override_wins(monkeypatch):
+    monkeypatch.setenv("ENRICHMENT_COMPOSER_MODEL", "gpt-5")
+    monkeypatch.setenv("ENRICHMENT_LARGE_MODEL", "gpt-4o")
+    assert llm_client.composer_model() == "gpt-5"
+
+
+def test_utility_model_defaults_to_gpt5_nano(monkeypatch):
+    monkeypatch.delenv("ENRICHMENT_UTILITY_MODEL", raising=False)
+    assert llm_client.utility_model() == "gpt-5-nano"
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gpt-5-nano", "gpt-5-mini", "gpt-5", "gpt-4o-mini", "gpt-4o"],
+)
+def test_pricing_table_has_gpt5_family(model):
+    assert model in llm_client._PRICING
+    input_rate, output_rate = llm_client._PRICING[model]
+    assert input_rate > 0
+    assert output_rate > 0
+
+
+def test_gpt5_tier_pricing_monotonic():
+    """gpt-5-nano < gpt-5-mini < gpt-5 on both input and output rates."""
+    nano_in, nano_out = llm_client._PRICING["gpt-5-nano"]
+    mini_in, mini_out = llm_client._PRICING["gpt-5-mini"]
+    full_in, full_out = llm_client._PRICING["gpt-5"]
+    assert nano_in < mini_in < full_in
+    assert nano_out < mini_out <= full_out

--- a/mcp-server/tests/enrichment/test_orchestration_llm.py
+++ b/mcp-server/tests/enrichment/test_orchestration_llm.py
@@ -61,7 +61,9 @@ def test_llm_orchestrator_falls_back_to_forced_only_on_planning_failure():
     products = [ProductInput(product_id=pid, title="x")]
     plan = LLMOrchestrator(llm=_BoomLLM()).plan(products, AssessorOutput(catalog_size=1))
     chosen = plan.per_product_agents[pid]
-    assert chosen == ["taxonomy_v1", "soft_tagger_v1"]
+    # composer_v1 always trails — it is the single writer of the canonical
+    # row (#83) and must run even when LLM planning fails.
+    assert chosen == ["taxonomy_v1", "soft_tagger_v1", "composer_v1"]
 
 
 def test_llm_orchestrator_empty_products():

--- a/mcp-server/tests/enrichment/test_runner.py
+++ b/mcp-server/tests/enrichment/test_runner.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 import pytest
 
 from app.enrichment import registry
+from app.enrichment.agents.composer import ComposerAgent
 from app.enrichment.agents.parser import ParserAgent
 from app.enrichment.agents.soft_tagger import SoftTaggerAgent
 from app.enrichment.agents.specialist import SpecialistAgent
@@ -27,7 +28,14 @@ from app.enrichment.types import ProductInput
 @pytest.fixture(autouse=True)
 def _clean(monkeypatch, tmp_path):
     registry._reset_for_tests()
-    for cls in (TaxonomyAgent, ParserAgent, SpecialistAgent, WebScraperAgent, SoftTaggerAgent):
+    for cls in (
+        TaxonomyAgent,
+        ParserAgent,
+        SpecialistAgent,
+        WebScraperAgent,
+        SoftTaggerAgent,
+        ComposerAgent,
+    ):
         registry.register(cls)
     # Isolate side-effect filesystem.
     monkeypatch.setattr(merchant_agent_client, "_PROPOSALS_DIR", tmp_path / "proposals")
@@ -81,6 +89,19 @@ class _ScriptedLLM:
             payload = {"good_for_tags": {"good_for_business": 0.9}}
         elif "discovered_product_types" in system:
             payload = {"discovered_product_types": ["laptop"]}
+        elif "composer agent" in system:
+            payload = {
+                "composed_fields": {"ram_gb": 16, "storage_gb": 512, "product_type": "laptop"},
+                "composer_decisions": [
+                    {
+                        "key": "ram_gb",
+                        "chosen_value": 16,
+                        "source_strategy": "parser_v1",
+                        "reason": "grounded in title",
+                        "dropped_alternatives": [],
+                    }
+                ],
+            }
         else:
             payload = {}
         return LLMResponse(
@@ -152,9 +173,16 @@ def test_fixed_run_writes_one_row_per_strategy_per_product(patched_runtime):
         dry_run=False,
     )
     assert result.summary.products_processed == 3
-    # 5 strategies × 3 products = 15 outputs (no scraper output → empty success
-    # because no URL given; scraper still emits a row even if empty).
-    expected_strategies = {"taxonomy_v1", "parser_v1", "specialist_v1", "scraper_v1", "soft_tagger_v1"}
+    # 6 strategies × 3 products = 18 outputs (composer_v1 runs last as the
+    # single writer of the canonical row — #83).
+    expected_strategies = {
+        "taxonomy_v1",
+        "parser_v1",
+        "specialist_v1",
+        "scraper_v1",
+        "soft_tagger_v1",
+        "composer_v1",
+    }
     assert set(result.summary.strategies_invoked.keys()) == expected_strategies
     for s in expected_strategies:
         assert result.summary.strategies_invoked[s] == 3
@@ -187,8 +215,9 @@ def test_run_reports_avg_keys_filled(patched_runtime):
     result = runner.run_enrichment(db=None, mode="fixed", limit=2, dry_run=True)
     avg = result.summary.to_dict()["avg_keys_filled_per_product"]
     # Each successful agent contributes its OUTPUT_KEYS count;
-    # taxonomy(3) + parser(3) + specialist(4) + scraper(6) + soft_tagger(2) = 18
-    assert avg == 18.0
+    # taxonomy(3) + parser(3) + specialist(4) + scraper(6) + soft_tagger(2)
+    # + composer(3: composed_fields, composer_decisions, composed_at) = 21
+    assert avg == 21.0
 
 
 def test_orchestrated_run_skips_scraper_when_no_url(patched_runtime):

--- a/mcp-server/tests/test_enrichment_inspector.py
+++ b/mcp-server/tests/test_enrichment_inspector.py
@@ -10,8 +10,11 @@ inspector's user-visible note moves with it instead of silently lying.
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
 import sys
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
@@ -82,3 +85,398 @@ def test_kg_property_catalog_only_soft_tagger_rows_get_threshold_note(
         assert row["notes"] == "", (
             f"non-soft-tagger row leaked the threshold note: {row!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Cell-lineage helpers (PR #86) — pure functions behind the side panel.
+# We test the indexer + helpers directly so the #5 "manual sync" drift
+# concern from the review becomes a build-time failure: if someone adds
+# a new strategy to composer._SHORT_TO_STRATEGY, the inspector's derived
+# set grows automatically and the assertion here passes; if the import
+# chain breaks, the fallback tuple is caught by a separate test.
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(tmp_path, records):
+    path = tmp_path / f"{uuid4().hex}.jsonl"
+    with open(path, "w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+    return str(path)
+
+
+def _mtime(path: str) -> float:
+    return os.stat(path).st_mtime
+
+
+def _strategy_span(strategy: str, pid: str, *, start: float, end: float,
+                   attributes: dict):
+    return {
+        "name": strategy,
+        "input": {"product_id": pid},
+        "updates": [{"output": {"attributes": attributes, "notes": None},
+                     "metadata": {}}],
+        "started_at": start,
+        "ended_at": end,
+    }
+
+
+def _llm_span(model: str, *, start: float, end: float, pid: str | None = None):
+    inp: dict = {"system": "s", "user": "u"}
+    if pid is not None:
+        inp["product_id"] = pid
+    return {
+        "name": f"llm:{model}",
+        "input": inp,
+        "updates": [{"output": {"text": "ok"}, "metadata": {"input_tokens": 1,
+                                                             "output_tokens": 1}}],
+        "started_at": start,
+        "ended_at": end,
+    }
+
+
+def test_known_upstream_strategies_matches_composer_short_to_strategy(
+    inspector_module,
+):
+    """Review fix #5: the inspector's known-source set must be sourced
+    from composer._SHORT_TO_STRATEGY, not a hand-maintained list.
+
+    A future agent landing in _SHORT_TO_STRATEGY (e.g. a new retriever
+    strategy) must automatically be recognizable by the side panel —
+    otherwise finding-cell routing and dashed-edge inference silently
+    skip it. This assertion flips the silent drift into a test failure."""
+    from app.enrichment.agents.composer import _SHORT_TO_STRATEGY
+
+    assert set(inspector_module._KNOWN_UPSTREAM_STRATEGIES) == set(
+        _SHORT_TO_STRATEGY.values()
+    )
+
+
+def test_index_trace_attributes_llm_spans_by_time_window(
+    inspector_module, tmp_path
+):
+    """Review fixes #2 and #3: LLM spans must be attributed to their
+    owning strategy by time-interval containment, not by "most recently
+    seen strategy". This test uses the JSONL write order that the real
+    tracer produces (child LLM span flushes before its parent strategy
+    span, because ``__exit__`` runs inner-to-outer) — the "most recently
+    seen" approach would attribute every LLM to whatever strategy
+    flushed immediately after it, which is the NEXT strategy, not the
+    OWNING one. Time-window containment has no such fragility."""
+    pid = str(uuid4())
+    # Ordered as the JSONL tracer actually writes it.
+    records = [
+        _llm_span("gpt-4o-mini", start=100.1, end=101.9),
+        _strategy_span(
+            "parser_v1", pid, start=100.0, end=102.0,
+            attributes={"parsed_specs": {"ram_gb": 16}},
+        ),
+        _llm_span("gpt-4o", start=103.1, end=104.9),
+        _strategy_span(
+            "taxonomy_v1", pid, start=103.0, end=105.0,
+            attributes={"product_type": "laptop"},
+        ),
+    ]
+    path = _write_jsonl(tmp_path, records)
+    index = inspector_module._index_trace_by_product(path, _mtime(path))
+    assert pid in index
+    bucket = index[pid]
+    # Exactly one LLM per strategy, attributed correctly.
+    llm = bucket["llm_by_strategy"]
+    assert len(llm.get("parser_v1", [])) == 1
+    assert len(llm.get("taxonomy_v1", [])) == 1
+    # No "(unassigned)" bucket — the old fallback path should never fire.
+    assert "(unassigned)" not in llm
+    # The parser LLM is the gpt-4o-mini one, not the gpt-4o one.
+    assert llm["parser_v1"][0]["name"] == "llm:gpt-4o-mini"
+    assert llm["taxonomy_v1"][0]["name"] == "llm:gpt-4o"
+
+
+def test_index_trace_drops_llm_spans_with_no_enclosing_strategy(
+    inspector_module, tmp_path
+):
+    """An orphan LLM span (no strategy span's time window contains it)
+    has no valid owner, so it simply doesn't land in any bucket — the
+    alternative ("(unassigned)" bucket) was the old fragile fallback
+    and we deliberately removed it."""
+    pid = str(uuid4())
+    records = [
+        _llm_span("gpt-4o-mini", start=50.0, end=51.0),  # before any strategy
+        _strategy_span("parser_v1", pid, start=100.0, end=102.0,
+                       attributes={"parsed_specs": {"ram_gb": 16}}),
+    ]
+    path = _write_jsonl(tmp_path, records)
+    index = inspector_module._index_trace_by_product(path, _mtime(path))
+    bucket = index[pid]
+    assert bucket["llm_by_strategy"] == {}
+
+
+def test_index_trace_picks_tightest_enclosing_strategy(
+    inspector_module, tmp_path
+):
+    """If two strategies' time windows overlap (shouldn't happen in
+    production, but defensive against future parallel execution), the
+    LLM is attributed to the tighter one — that's the span it was
+    structurally nested in, which is the closest thing we have to parent
+    information without a parent_span_id field."""
+    pid = str(uuid4())
+    records = [
+        _strategy_span("parser_v1", pid, start=100.0, end=200.0,
+                       attributes={"parsed_specs": {}}),
+        _strategy_span("scraper_v1", pid, start=110.0, end=120.0,
+                       attributes={"scraped_specs": {}}),
+        _llm_span("gpt-4o-mini", start=112.0, end=118.0),  # inside scraper
+    ]
+    path = _write_jsonl(tmp_path, records)
+    index = inspector_module._index_trace_by_product(path, _mtime(path))
+    bucket = index[pid]
+    assert len(bucket["llm_by_strategy"].get("scraper_v1", [])) == 1
+    assert "parser_v1" not in bucket["llm_by_strategy"]
+
+
+def test_composer_decisions_from_span_round_trip(inspector_module):
+    """_composer_decisions_from_span is the only path by which
+    decisions reach the side panel. It has to handle both the nested
+    structure (span.updates[0].output.attributes.composer_decisions) and
+    the shapes that _span_output traverses."""
+    pid = str(uuid4())
+    span = _strategy_span(
+        "composer_v1", pid, start=1.0, end=2.0,
+        attributes={
+            "composed_fields": {"ram_gb": 16},
+            "composer_decisions": [
+                {"key": "ram_gb", "chosen_value": 16,
+                 "source_strategy": "parser_v1",
+                 "reason": "grounded", "dropped_alternatives": []}
+            ],
+            "composed_at": "x",
+        },
+    )
+    decisions = inspector_module._composer_decisions_from_span(span)
+    assert len(decisions) == 1
+    assert decisions[0]["key"] == "ram_gb"
+    assert decisions[0]["source_strategy"] == "parser_v1"
+
+
+def test_composer_decisions_from_span_returns_empty_on_malformed(
+    inspector_module,
+):
+    """Any shape that isn't ``attributes.composer_decisions = [dict, ...]``
+    yields an empty list — the side panel renders a "no decision"
+    caption rather than crashing."""
+    # No updates → empty
+    assert inspector_module._composer_decisions_from_span(
+        {"name": "composer_v1", "input": {}}
+    ) == []
+    # Non-list decisions → empty
+    bad = {
+        "name": "composer_v1",
+        "input": {"product_id": "p"},
+        "updates": [{"output": {"attributes":
+            {"composer_decisions": "not-a-list"}}, "metadata": {}}],
+    }
+    assert inspector_module._composer_decisions_from_span(bad) == []
+
+
+def test_dashed_sources_for_decision_matches_upstream_value(
+    inspector_module,
+):
+    """_dashed_sources_for_decision walks each upstream strategy's
+    attributes and matches dropped_alternatives values against their
+    flattened output. parser_v1 emitted ram_gb=8 which matches the
+    decision's dropped_alternatives=[8], so parser_v1 should be dashed."""
+    bucket = {
+        "strategy_spans": {
+            "parser_v1": _strategy_span(
+                "parser_v1", "p", start=1, end=2,
+                attributes={"parsed_specs": {"ram_gb": 8}},
+            ),
+            "scraper_v1": _strategy_span(
+                "scraper_v1", "p", start=3, end=4,
+                attributes={"scraped_specs": {"ram_gb": 16}},
+            ),
+        }
+    }
+    # Composer chose 16 (scraper), dropped 8 (parser's value).
+    dashed = inspector_module._dashed_sources_for_decision(bucket, [8])
+    assert dashed == ("parser_v1",)
+
+
+def test_dashed_sources_for_decision_empty_when_no_dropped_alts(
+    inspector_module,
+):
+    assert inspector_module._dashed_sources_for_decision({}, []) == ()
+
+
+def test_dashed_sources_for_decision_survives_typeerror_on_compare(
+    inspector_module,
+):
+    """Review fix #4: `in` uses `==`, and `==` against certain
+    adversarial or mixed scalar types can raise TypeError. The helper
+    must catch that rather than crash the whole side panel."""
+    class Uncomparable:
+        def __eq__(self, other):
+            if isinstance(other, (int, float)):
+                raise TypeError("uncomparable against number")
+            return NotImplemented
+
+        def __hash__(self) -> int:
+            return 0
+
+    bucket = {
+        "strategy_spans": {
+            "parser_v1": _strategy_span(
+                "parser_v1", "p", start=1, end=2,
+                attributes={"parsed_specs": {"ram_gb": 16}},
+            )
+        }
+    }
+    result = inspector_module._dashed_sources_for_decision(
+        bucket, [Uncomparable(), 16]
+    )
+    # The Uncomparable comparison raises TypeError → swallowed; the 16
+    # comparison still lands → parser_v1 is dashed.
+    assert result == ("parser_v1",)
+
+
+def test_short_pid(inspector_module):
+    """Review fix #8: don't cosmetically truncate ids that are already
+    short (numeric SKUs, hand-coded fixtures, etc)."""
+    assert inspector_module._short_pid("abc123") == "abc123"
+    assert inspector_module._short_pid("0123456789ab") == "0123456789ab"
+    assert inspector_module._short_pid(
+        "11111111-1111-1111-1111-111111111111"
+    ) == "11111111\u2026"
+
+
+def test_run_id_regex_rejects_path_traversal(inspector_module):
+    """Review security note: run_id is user-adjacent through the
+    artifact JSON and ends up in a filesystem path, so enforce the
+    UUID-hex shape the orchestrator actually generates before trusting it."""
+    safe = "48bbf00b763d49918f5fb265d4e763ca"
+    assert inspector_module._RUN_ID_SAFE_RE.match(safe)
+    for evil in ("../../etc/passwd", "run/../other", "48BBF00B" * 4,
+                 "48bbf00b" * 3, "", "48bbf00b763d49918f5fb265d4e763ca.x"):
+        assert not inspector_module._RUN_ID_SAFE_RE.match(evil), (
+            f"regex accepted unsafe run_id: {evil!r}"
+        )
+
+
+def test_index_trace_constrains_llm_attribution_by_pid_when_present(
+    inspector_module, tmp_path
+):
+    """Review feedback #1: when an LLM span carries a product_id (via
+    input.product_id or a product:<pid> tag), the indexer must require
+    the enclosing strategy to share it — otherwise parallel execution
+    would let an LLM call leak into another product's bucket.
+
+    Two products' strategies run with overlapping time windows; each
+    product's LLM span falls inside *both* intervals. Without the
+    pid constraint the tighter-window match can pick the wrong
+    product; with it, pid wins regardless of window tightness."""
+    pid_a = "11111111-1111-1111-1111-111111111111"
+    pid_b = "22222222-2222-2222-2222-222222222222"
+    records = [
+        # Product A's strategy: wide window.
+        _strategy_span("parser_v1", pid_a, start=100.0, end=200.0,
+                       attributes={"parsed_specs": {}}),
+        # Product B's strategy: tighter window — without pid constraint,
+        # it would capture pid_a's LLM by time-window tightness alone.
+        _strategy_span("parser_v1", pid_b, start=120.0, end=160.0,
+                       attributes={"parsed_specs": {}}),
+        # LLM from product A, tagged with A's pid, inside both windows.
+        _llm_span("gpt-4o-mini", start=130.0, end=140.0, pid=pid_a),
+        # LLM from product B, tagged with B's pid, also inside both.
+        _llm_span("gpt-4o-mini", start=135.0, end=145.0, pid=pid_b),
+    ]
+    path = _write_jsonl(tmp_path, records)
+    index = inspector_module._index_trace_by_product(path, _mtime(path))
+    # Each product got exactly its own LLM, not the other's.
+    assert len(index[pid_a]["llm_by_strategy"].get("parser_v1", [])) == 1
+    assert len(index[pid_b]["llm_by_strategy"].get("parser_v1", [])) == 1
+    a_llm = index[pid_a]["llm_by_strategy"]["parser_v1"][0]
+    b_llm = index[pid_b]["llm_by_strategy"]["parser_v1"][0]
+    assert a_llm["input"]["product_id"] == pid_a
+    assert b_llm["input"]["product_id"] == pid_b
+
+
+def test_index_trace_falls_back_to_time_window_when_llm_has_no_pid(
+    inspector_module, tmp_path
+):
+    """The pid constraint kicks in *only when* the LLM span carries a
+    pid. Today's tracer typically doesn't tag LLM spans with product_id,
+    so the pid-less case must still match by time window alone —
+    otherwise every LLM call in the existing pipeline would suddenly
+    become orphaned."""
+    pid = str(uuid4())
+    records = [
+        _strategy_span("parser_v1", pid, start=100.0, end=102.0,
+                       attributes={"parsed_specs": {}}),
+        _llm_span("gpt-4o-mini", start=100.5, end=101.5),  # no pid
+    ]
+    path = _write_jsonl(tmp_path, records)
+    index = inspector_module._index_trace_by_product(path, _mtime(path))
+    assert len(index[pid]["llm_by_strategy"].get("parser_v1", [])) == 1
+
+
+def test_load_trace_bucket_flags_pid_not_in_run(
+    inspector_module, tmp_path, monkeypatch
+):
+    """Review feedback #3: when the JSONL exists but the pid simply
+    isn't in this run, ``_load_trace_bucket`` must flag the returned
+    bucket with ``_pid_not_in_run`` so the side panel can tell the user
+    "pick a newer run" rather than "composer didn't run"."""
+    run_id = "e4c283a7d97b4e4a8def71d0f9d98d91"  # 32 hex chars, regex-safe
+    run_pid = str(uuid4())
+    missing_pid = str(uuid4())
+    records = [
+        _strategy_span("parser_v1", run_pid, start=1.0, end=2.0,
+                       attributes={"parsed_specs": {}}),
+    ]
+    # Emulate the inspector's on-disk layout: TRACES_DIR / "{run_id}.jsonl".
+    traces_dir = tmp_path / "traces"
+    traces_dir.mkdir()
+    jsonl_path = traces_dir / f"{run_id}.jsonl"
+    with open(jsonl_path, "w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+    monkeypatch.setattr(inspector_module, "TRACES_DIR", traces_dir)
+    # Clear the cache so _index_trace_by_product re-reads from disk.
+    inspector_module._index_trace_by_product.clear()
+
+    run = {"summary": {"run_id": run_id}}
+    known = inspector_module._load_trace_bucket(run, run_pid)
+    assert known is not None
+    assert not known.get("_pid_not_in_run"), (
+        "known pid should not be flagged as missing from run"
+    )
+    assert "parser_v1" in known["strategy_spans"]
+
+    unknown = inspector_module._load_trace_bucket(run, missing_pid)
+    assert unknown is not None
+    assert unknown.get("_pid_not_in_run") is True, (
+        "unknown pid should be flagged so the side panel can show the "
+        "'pick a newer run' message instead of 'composer didn't run'"
+    )
+    assert unknown["composer"] is None
+    assert unknown["strategy_spans"] == {}
+
+
+def test_composer_notes_preserves_explicit_empty_string(inspector_module):
+    """Review nit #2: ``_composer_notes`` must compare with ``is None``
+    rather than truthiness, so a future marker like ``notes=''`` (or any
+    other explicitly empty string from the composer) round-trips rather
+    than being silently swapped for ``None``. Downstream callouts still
+    filter empty — but new markers land here verbatim."""
+    span = {
+        "name": "composer_v1",
+        "input": {"product_id": "p"},
+        "updates": [{"output": {"notes": ""}, "metadata": {}}],
+    }
+    assert inspector_module._composer_notes(span) == ""
+    span_none = {
+        "name": "composer_v1",
+        "input": {"product_id": "p"},
+        "updates": [{"output": {"notes": None}, "metadata": {}}],
+    }
+    assert inspector_module._composer_notes(span_none) is None

--- a/scripts/enrichment_inspector.py
+++ b/scripts/enrichment_inspector.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import urllib.parse
 from datetime import datetime, timezone
@@ -181,6 +182,49 @@ def load_run(path_str: str) -> dict[str, Any]:
         return json.load(fh)
 
 
+@st.cache_data(show_spinner=False)
+def _artifact_merchant_id(path_str: str, mtime: float) -> str | None:
+    """Return ``summary.merchant_id`` for ``path_str``.
+
+    First call for a given ``(path, mtime)`` pair does a full
+    ``json.load`` of the artifact — there's no streaming shortcut. The
+    cache then ensures every subsequent Streamlit rerun reads from
+    memory until the file is overwritten (``mtime`` changes). For
+    steady-state navigation this is effectively free; it's the *cold
+    load* across ``runs/`` that costs — keep artifacts reasonably small
+    and this stays under tens of milliseconds per file.
+
+    The ``mtime`` argument is the cache-bust lever and is unused in the
+    body — Streamlit's ``@cache_data`` hashes every argument for the
+    key, so passing the file's mtime means an in-place overwrite
+    invalidates the entry without the caller having to reason about
+    it. Review feedback #2, PR #86."""
+    del mtime  # documented cache key, not consumed here
+    try:
+        with open(path_str, "r", encoding="utf-8") as fh:
+            summary = (json.load(fh).get("summary") or {})
+    except (OSError, json.JSONDecodeError):
+        return None
+    mid = summary.get("merchant_id")
+    return str(mid) if mid is not None else None
+
+
+def list_run_artifacts_for_merchant(merchant_id: str) -> list[Path]:
+    """Filter ``list_run_artifacts()`` to artifacts whose
+    ``summary.merchant_id`` matches. Reads each artifact's summary via a
+    per-file mtime-keyed cache (`_artifact_merchant_id`) so the typical
+    "same files, user flipped a selector" rerun does zero disk I/O."""
+    out: list[Path] = []
+    for p in list_run_artifacts():
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            continue
+        if _artifact_merchant_id(str(p), mtime) == merchant_id:
+            out.append(p)
+    return out
+
+
 def langfuse_tag_url(run_id: str) -> str:
     q = urllib.parse.urlencode({"tags": f"run:{run_id}"})
     return f"{LANGFUSE_HOST}/traces?{q}"
@@ -193,14 +237,22 @@ def langfuse_tag_url(run_id: str) -> str:
 
 def fetch_enriched_table(
     engine: Engine, merchant_id: str, limit: int = 500
-) -> tuple[list[dict[str, Any]], list[str], list[str]] | None:
-    """Join raw products and enriched attributes for one merchant, pivoted
-    into ``<strategy>.<key>`` columns so every raw column sits next to the
-    features the agents derived from it. Returns
-    ``(rows, raw_columns, enriched_columns)`` or ``None`` if the merchant's
-    tables are gone (DELETE /merchant mid-session) **or** the slug doesn't
-    match ``MERCHANT_ID_RE`` (stale URL param, malformed test fixture, any
-    future path that bypasses the registry-backed selector)."""
+) -> tuple[list[dict[str, Any]], list[str], list[str], list[str]] | None:
+    """Join raw products and enriched attributes for one merchant. The
+    composer_v1 row is flattened into ``canonical.<key>`` columns (one per
+    entry in its ``composed_fields``); every other strategy's row is
+    pivoted into ``<strategy>.<key>`` columns as pre-composer findings
+    (debug view). Returns ``(rows, raw_columns, canonical_columns,
+    finding_columns)`` or ``None`` if the merchant's tables are gone
+    (DELETE /merchant mid-session) **or** the slug doesn't match
+    ``MERCHANT_ID_RE`` (stale URL param, malformed test fixture, any
+    future path that bypasses the registry-backed selector).
+
+    Splitting canonical vs findings is the read-time counterpart of
+    composer_v1 being the single writer of the catalog row (issue #83).
+    Canonical columns drive the #81 cell-lineage UX — each canonical cell
+    has a composer_decisions entry that names the producing agent; finding
+    cells are what the composer chose from."""
     # Route through the canonical helpers so a future schema-per-tenant
     # move (issue #38) only has to touch ``merchant_*_table``. The helpers
     # also re-validate the slug against MERCHANT_ID_RE — interpolation
@@ -235,7 +287,8 @@ def fetch_enriched_table(
 
     by_pid: dict[Any, dict[str, Any]] = {}
     raw_cols = ["product_id", "name", "brand", "category", "price"]
-    enriched_cols: set[str] = set()
+    canonical_cols: set[str] = set()
+    finding_cols: set[str] = set()
     for r in raw_rows:
         pid = r["product_id"]
         if pid not in by_pid:
@@ -260,16 +313,31 @@ def fetch_enriched_table(
                 by_pid[pid][col] = v
         strategy = r["strategy"]
         attrs = r["enriched_attributes"] or {}
-        if strategy and isinstance(attrs, dict):
-            for k, v in attrs.items():
-                col = f"{strategy}.{k}"
-                enriched_cols.add(col)
-                if isinstance(v, (dict, list)):
-                    v = json.dumps(v, ensure_ascii=False, default=str)[:160]
-                by_pid[pid][col] = v
+        if not (strategy and isinstance(attrs, dict)):
+            continue
+        if strategy == "composer_v1":
+            # The composer's attributes are {composed_fields, composer_decisions,
+            # composed_at}. Flatten composed_fields into canonical.<key> columns;
+            # keep composer_decisions + composed_at out of the grid (they feed
+            # the side panel via the JSONL trace instead).
+            composed = attrs.get("composed_fields") or {}
+            if isinstance(composed, dict):
+                for k, v in composed.items():
+                    col = f"canonical.{k}"
+                    canonical_cols.add(col)
+                    if isinstance(v, (dict, list)):
+                        v = json.dumps(v, ensure_ascii=False, default=str)[:160]
+                    by_pid[pid][col] = v
+            continue
+        for k, v in attrs.items():
+            col = f"{strategy}.{k}"
+            finding_cols.add(col)
+            if isinstance(v, (dict, list)):
+                v = json.dumps(v, ensure_ascii=False, default=str)[:160]
+            by_pid[pid][col] = v
 
     rows = list(by_pid.values())
-    return rows, raw_cols, sorted(enriched_cols)
+    return rows, raw_cols, sorted(canonical_cols), sorted(finding_cols)
 
 
 def fetch_one_product(
@@ -548,54 +616,847 @@ def render_raw_enriched_kg(
     )
 
 
-def render_enriched_table(engine: Engine, merchant_id: str) -> None:
-    st.markdown(
-        f"### Enriched catalog for `{merchant_id}`  "
-        f"(raw columns + `<strategy>.<key>` derived features)"
+# ---------------------------------------------------------------------------
+# Cell-lineage side panel (issue #81) — reads composer_v1's composer_decisions
+# audit log from the JSONL trace and renders the producing agent's full span
+# (input, output, nested LLM prompt/response) on click.
+# ---------------------------------------------------------------------------
+
+
+# Upstream strategies composer_v1 may cite as source_strategy. Pulled
+# from composer._SHORT_TO_STRATEGY at import time so the inspector
+# never drifts from the writer's known-source set (review fix #5,
+# PR #86). The hardcoded fallback matches that set as of PR #84's head
+# and is only used if the import chain is broken (e.g. stripped-down
+# test env where the app package isn't on sys.path).
+_FALLBACK_UPSTREAM_STRATEGIES: tuple[str, ...] = (
+    "taxonomy_v1",
+    "parser_v1",
+    "specialist_v1",
+    "scraper_v1",
+    "soft_tagger_v1",
+)
+try:
+    from app.enrichment.agents.composer import (
+        _SHORT_TO_STRATEGY as _COMPOSER_SHORT_TO_STRATEGY,
     )
-    limit = st.slider("max rows", min_value=10, max_value=2000, value=200, step=10)
-    result = fetch_enriched_table(engine, merchant_id, limit=limit)
-    if result is None:
-        # Slug may have been rejected by the helper (malformed) or the
-        # tables themselves are gone — keep the message generic so we
-        # don't re-raise the same ValueError just to render copy.
-        try:
-            table_hint = f"`{merchant_catalog_table(merchant_id)}`"
-        except ValueError:
-            table_hint = f"the catalog table for `{merchant_id}`"
+
+    _KNOWN_UPSTREAM_STRATEGIES: tuple[str, ...] = tuple(
+        sorted(_COMPOSER_SHORT_TO_STRATEGY.values())
+    )
+except ImportError:
+    # Only swallow missing-module cases — things like a stripped-down test
+    # env where ``app`` isn't on sys.path. Other exceptions (e.g. env-var
+    # assertions in a transitive import, AttributeError from a renamed
+    # symbol) should surface so they're seen and fixed instead of
+    # silently degrading to the hardcoded fallback. Review feedback #4,
+    # PR #86.
+    _KNOWN_UPSTREAM_STRATEGIES = _FALLBACK_UPSTREAM_STRATEGIES
+
+
+@st.cache_data(show_spinner=False)
+def _index_trace_by_product(
+    jsonl_path_str: str, _mtime: float
+) -> dict[str, dict[str, Any]]:
+    """Parse the run's JSONL once and bucket spans by product_id.
+
+    The ``_mtime`` argument is the cache-bust lever: Streamlit's
+    ``@st.cache_data`` keys on every argument, so passing the file's
+    modification time means a re-run overwrites the cache on file
+    change without the caller having to reason about it. We also trust
+    that ``run_id`` is globally unique — it is a 32-char hex UUID
+    generated in ``orchestration/runner.py`` — so caching on the file
+    path alone (no explicit run_id hash) is safe across merchants.
+
+    Returns ``{pid: {"strategy_spans": {strategy: span}, "llm_by_strategy":
+    {strategy: [span, ...]}, "composer": span | None, "decisions_by_key":
+    {canonical_key: decision}}}``. Missing pids return an empty shell
+    lazily, so callers don't need ``KeyError`` guards.
+
+    LLM spans don't usually carry a product_id on their own input and
+    the tracer doesn't auto-tag them with ``product:<pid>`` (see
+    ``tracing._current_tags``), so attribution is done by time-window
+    containment: an LLM span at ``[start, end]`` belongs to the
+    strategy span whose ``[start, end]`` fully contains it. This is
+    robust against JSONL write order (LLM spans close and flush
+    *before* their parent strategy span, so "most recently seen
+    strategy name" would always mis-attribute) and against any future
+    interleaving — review fixes #2 and #3, PR #86.
+
+    When an LLM span *does* carry a pid (via ``input.product_id`` or a
+    ``product:<pid>`` tag — both already handled by
+    ``_span_product_id``), we additionally require the enclosing
+    strategy to share that pid. Today the pipeline runs products
+    serially per worker so this is redundant, but the moment
+    enrichment parallelises across products (``asyncio.gather`` or
+    similar) two products' windows can overlap and the pure
+    time-window match would mis-attribute an LLM call to the other
+    product's strategy. Pid-constrained match prevents that without
+    breaking the current pid-less case — review feedback #1, PR #86.
+
+    Note on memory: the per-strategy LLM lists are unbounded. For a
+    10k-product run with many LLM retries this bloats Streamlit's
+    cache_data entry. Not a v1 blocker (the expected working set is
+    ~dozens of products per inspection) — review feedback #6, PR #86.
+    """
+    path = Path(jsonl_path_str)
+    if not path.exists():
+        return {}
+    strategy_records: list[dict[str, Any]] = []
+    llm_records: list[dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                span = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            name = span.get("name") or ""
+            if name.startswith("llm:"):
+                llm_records.append(span)
+                continue
+            pid = _span_product_id(span)
+            if not pid:
+                continue
+            strategy_records.append({"pid": str(pid), "name": name, "span": span})
+
+    by_pid: dict[str, dict[str, Any]] = {}
+    for rec in strategy_records:
+        pid = rec["pid"]
+        name = rec["name"]
+        span = rec["span"]
+        bucket = by_pid.setdefault(
+            pid,
+            {
+                "strategy_spans": {},
+                "llm_by_strategy": {},
+                "composer": None,
+                "decisions_by_key": {},
+            },
+        )
+        if name == "composer_v1":
+            bucket["composer"] = span
+            for decision in _composer_decisions_from_span(span):
+                key = decision.get("key")
+                if isinstance(key, str) and key:
+                    bucket["decisions_by_key"][key] = decision
+        else:
+            # Known upstream + any unknown span with a product_id both
+            # land here so the agent graph can render diagnostic spans
+            # if someone adds them. Namespace-routing on the UI side
+            # only dispatches to the known set.
+            bucket["strategy_spans"][name] = span
+
+    # Time-window attribution for LLM spans. Build a flat list of
+    # (start, end, pid, owner_name) covering every strategy + composer
+    # span; for each LLM span, pick the tightest (smallest duration)
+    # enclosing strategy as its owner. Ties (shouldn't happen in
+    # practice — strategies for a single product run serially) are
+    # broken by insertion order, which matches JSONL write order.
+    intervals: list[tuple[float, float, str, str]] = []
+    for rec in strategy_records:
+        span = rec["span"]
+        start = _span_started_at(span)
+        end = _span_ended_at(span)
+        if start is None or end is None:
+            continue
+        intervals.append((start, end, rec["pid"], rec["name"]))
+    # composer_v1 is already captured in strategy_records above (it has
+    # a product_id on its input), so it's an attribution target too —
+    # that's how the composer's LLM call gets bucketed under composer_v1.
+    for llm in llm_records:
+        lstart = _span_started_at(llm)
+        lend = _span_ended_at(llm)
+        if lstart is None or lend is None:
+            continue
+        llm_pid = _span_product_id(llm)  # may be None (pid-less LLM span)
+        owner: tuple[str, str] | None = None
+        best_duration = float("inf")
+        for (s_start, s_end, s_pid, s_name) in intervals:
+            # If the LLM span carries a pid, require the enclosing
+            # strategy to share it — future-proof against concurrent
+            # products whose windows overlap. Falls through to pure
+            # time-window match when the LLM span is pid-less, which
+            # is the common case today.
+            if llm_pid is not None and s_pid != llm_pid:
+                continue
+            if s_start <= lstart and lend <= s_end:
+                duration = s_end - s_start
+                if duration < best_duration:
+                    owner = (s_pid, s_name)
+                    best_duration = duration
+        if owner is None:
+            continue
+        pid, owner_name = owner
+        bucket = by_pid.setdefault(
+            pid,
+            {
+                "strategy_spans": {},
+                "llm_by_strategy": {},
+                "composer": None,
+                "decisions_by_key": {},
+            },
+        )
+        bucket["llm_by_strategy"].setdefault(owner_name, []).append(llm)
+    return by_pid
+
+
+def _span_started_at(span: dict[str, Any]) -> float | None:
+    val = span.get("started_at")
+    if isinstance(val, (int, float)):
+        return float(val)
+    return None
+
+
+def _span_ended_at(span: dict[str, Any]) -> float | None:
+    val = span.get("ended_at")
+    if isinstance(val, (int, float)):
+        return float(val)
+    return None
+
+
+def _composer_decisions_from_span(span: dict[str, Any]) -> list[dict[str, Any]]:
+    """Pull the decisions list out of a composer_v1 span.
+
+    The runner writes ``output`` inside ``updates[*].output`` — ``_span_output``
+    handles that walk. The composer's output is a StrategyOutput dump, so
+    decisions live at ``output.attributes.composer_decisions``."""
+    out = _span_output(span) or {}
+    if not isinstance(out, dict):
+        return []
+    attrs = out.get("attributes") or {}
+    decisions = attrs.get("composer_decisions") or []
+    if not isinstance(decisions, list):
+        return []
+    return [d for d in decisions if isinstance(d, dict)]
+
+
+def _composer_notes(span: dict[str, Any] | None) -> str | None:
+    """Return composer_v1's StrategyOutput.notes (e.g. 'deterministic_fallback',
+    'no_upstream_findings') or None when no composer span is recorded.
+
+    ``notes`` is compared by ``is None`` rather than truthiness so an
+    intentionally-empty marker string round-trips verbatim — downstream
+    callers still filter empty via ``if not notes:`` but new markers
+    don't get silently erased here (review nit #2, PR #86)."""
+    if not span:
+        return None
+    out = _span_output(span) or {}
+    if not isinstance(out, dict):
+        return None
+    notes = out.get("notes")
+    if notes is None:
+        return None
+    return str(notes)
+
+
+def _agent_graph_dot(
+    strategy_spans: dict[str, dict[str, Any]],
+    composer_span: dict[str, Any] | None,
+    *,
+    highlight_strategy: str | None,
+    dashed_strategies: tuple[str, ...] = (),
+    highlighted_key: str | None = None,
+) -> str:
+    """Emit a graphviz dot string for the per-product agent graph.
+
+    Nodes: only strategies that contributed to *this* cell's lineage —
+    the ``source_strategy`` (solid, highlighted) plus any strategy whose
+    finding ended up in ``dropped_alternatives`` (dashed edge). The full
+    "all agents observed" view is covered by the Contributing-agents
+    expanders below the graph; this chart answers the narrower question
+    "who produced this cell and who was in the running?".
+
+    Edges always terminate at the ``composer_v1`` sink. Solid edges
+    carry the canonical key as their label; dashed edges are marked
+    ``dropped``.
+
+    Sizing is clamped (``size="4,2.5"``) so the rendered DAG stays
+    legible inside the side panel even on wide monitors — the caller
+    must NOT pass ``use_container_width=True`` to ``st.graphviz_chart``
+    or the clamp is overridden.
+    """
+    def _esc(s: str) -> str:
+        # Minimal DOT escape — canonical keys and strategy names today
+        # are safe identifiers, but a decision key containing a quote
+        # or backslash would otherwise break the DOT body. Cheap
+        # defense-in-depth since we don't have python-graphviz as a
+        # dep (review nit #1, PR #86).
+        return s.replace("\\", "\\\\").replace('"', '\\"')
+
+    lines: list[str] = [
+        "digraph G {",
+        'rankdir=LR;',
+        'size="4,2.5";',
+        "nodesep=0.25;",
+        "ranksep=0.45;",
+        "node [shape=box, fontsize=10, margin=\"0.08,0.04\"];",
+        "edge [fontsize=9];",
+    ]
+    edge_label = _esc(highlighted_key or "")
+    contributors: list[str] = []
+    if highlight_strategy and highlight_strategy in strategy_spans:
+        contributors.append(highlight_strategy)
+    for s in dashed_strategies:
+        if s in strategy_spans and s != highlight_strategy and s not in contributors:
+            contributors.append(s)
+    for name in contributors:
+        attrs = []
+        if name == highlight_strategy:
+            attrs.append("style=filled")
+        attr_str = f" [{', '.join(attrs)}]" if attrs else ""
+        lines.append(f'"{_esc(name)}"{attr_str};')
+    if composer_span is not None:
+        lines.append('"composer_v1" [shape=doublecircle];')
+        if highlight_strategy and highlight_strategy in strategy_spans:
+            lines.append(
+                f'"{_esc(highlight_strategy)}" -> "composer_v1"'
+                f' [label="{edge_label}"];'
+            )
+        for s in dashed_strategies:
+            if s in strategy_spans and s != highlight_strategy:
+                lines.append(
+                    f'"{_esc(s)}" -> "composer_v1"'
+                    ' [style=dashed, label="dropped"];'
+                )
+    if not contributors and composer_span is not None:
+        lines.append('"(no contributors)" [shape=plaintext, fontcolor=gray50];')
+        lines.append('"(no contributors)" -> "composer_v1" [style=dotted, color=gray50];')
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _render_agent_node(
+    strategy: str,
+    span: dict[str, Any],
+    llm_spans: list[dict[str, Any]],
+    *,
+    expanded: bool,
+) -> None:
+    """One collapsible per-agent node: the agent's span input/output, then
+    its LLM child spans (prompt/response). Matches the shape of the
+    global Reasoning-trace tab so the visual vocabulary is consistent."""
+    dur = _span_duration_ms(span)
+    md = _span_metadata(span)
+    header_bits = [f"`{strategy}`"]
+    if dur is not None:
+        header_bits.append(f"{dur} ms")
+    cost = md.get("cost_usd")
+    if isinstance(cost, (int, float)):
+        header_bits.append(f"${cost:.6f}")
+    with st.expander("  ·  ".join(header_bits), expanded=expanded):
+        inp_col, out_col = st.columns(2)
+        with inp_col:
+            st.markdown("**input**")
+            st.json(_jsonable(span.get("input") or {}))
+        with out_col:
+            st.markdown("**output**")
+            st.json(_jsonable(_span_output(span) or {}))
+        model = md.get("model")
+        if model:
+            st.caption(f"model: `{model}`")
+        if llm_spans:
+            st.markdown(f"**LLM calls within this agent** ({len(llm_spans)})")
+            for llm in llm_spans:
+                lname = llm.get("name", "llm:?")
+                ldur = _span_duration_ms(llm)
+                lmd = _span_metadata(llm)
+                label_bits = [lname]
+                if ldur is not None:
+                    label_bits.append(f"{ldur} ms")
+                lcost = lmd.get("cost_usd")
+                if isinstance(lcost, (int, float)):
+                    label_bits.append(f"${lcost:.6f}")
+                with st.expander("  ·  ".join(label_bits), expanded=False):
+                    li, lo = st.columns(2)
+                    with li:
+                        st.markdown("**prompt**")
+                        st.json(_jsonable(llm.get("input") or {}))
+                    with lo:
+                        st.markdown("**response**")
+                        st.json(_jsonable(_span_output(llm) or {}))
+                    tok_in = lmd.get("input_tokens", "?")
+                    tok_out = lmd.get("output_tokens", "?")
+                    st.caption(f"tokens: {tok_in} in / {tok_out} out")
+
+
+def _render_composer_notes_callout(notes: str | None) -> None:
+    """Surface the composer's StrategyOutput.notes as a small callout so
+    a user inspecting a fallback row doesn't mistake it for LLM-composed."""
+    if not notes:
+        return
+    if notes == "deterministic_fallback":
         st.warning(
-            f"{table_hint} or its enriched table is missing — the merchant "
-            "may have been deleted, or the id is malformed. Use **Refresh "
-            "merchants** in the sidebar to re-hydrate the selector."
+            "Composer LLM failed for this product — canonical row built "
+            "deterministically from findings (`notes='deterministic_fallback'`)."
+        )
+    elif notes == "no_upstream_findings":
+        st.info(
+            "No upstream strategies produced findings for this product; "
+            "composer was invoked but had no material to compose."
+        )
+
+
+def _render_cell_panel_empty() -> None:
+    st.markdown("### Cell lineage")
+    st.caption(
+        "Click a cell in the enriched table to trace who produced it. "
+        "Canonical columns (`canonical.*`, green) show the full composer "
+        "decision + contributing agent; finding columns (grey, debug "
+        "view) show just the emitting agent's span."
+    )
+
+
+def _render_cell_panel_raw(col: str) -> None:
+    st.markdown("### Cell lineage")
+    st.caption(f"`{col}` is a raw catalog cell — no agent produced it.")
+
+
+def _short_pid(pid: str) -> str:
+    """Compact product_id for captions: show the 8-char prefix + ellipsis
+    for UUID-length strings, otherwise show the id verbatim so numeric /
+    short merchant-defined ids (e.g. ``sku-12``) don't render as
+    ``sku-12…`` cosmetic nonsense (review fix #8, PR #86)."""
+    s = str(pid)
+    if len(s) <= 12:
+        return s
+    return f"{s[:8]}…"
+
+
+def _render_cell_panel_canonical(
+    bucket: dict[str, Any],
+    pid: str,
+    canonical_key: str,
+) -> None:
+    st.markdown("### Cell lineage")
+    st.caption(f"`canonical.{canonical_key}`  ·  product `{_short_pid(pid)}`")
+    if bucket.get("_pid_not_in_run"):
+        st.warning(
+            "This product isn't in the selected enrichment run — it was "
+            "likely added to the catalog after the run finished. Pick a "
+            "newer run from the sidebar, or re-run enrichment to include "
+            "it."
         )
         return
-    rows, raw_cols, enriched_cols = result
-    st.caption(
-        f"{len(rows)} rows · {len(raw_cols)} raw columns · "
-        f"{len(enriched_cols)} derived columns"
+    composer_span = bucket.get("composer")
+    if composer_span is None:
+        st.warning(
+            "Composer didn't produce a span for this product in the "
+            "selected run. Either the composer was disabled / errored "
+            "for this specific product, or `ENRICHMENT_TRACE_JSONL=1` "
+            "was off when the run executed."
+        )
+        return
+    _render_composer_notes_callout(_composer_notes(composer_span))
+    decision = bucket.get("decisions_by_key", {}).get(canonical_key)
+    if decision is None:
+        st.info(
+            "The composer shipped this value but didn't record which "
+            "agent produced it. This is a known gap — follow-up #88."
+        )
+        source_strategy: str | None = None
+        dropped_alts: list[Any] = []
+    else:
+        source_strategy = decision.get("source_strategy")
+        dropped_alts = decision.get("dropped_alternatives") or []
+        _render_decision_card(decision)
+    dashed = _dashed_sources_for_decision(bucket, dropped_alts)
+    dot = _agent_graph_dot(
+        bucket.get("strategy_spans", {}),
+        composer_span,
+        highlight_strategy=source_strategy,
+        dashed_strategies=dashed,
+        highlighted_key=canonical_key,
     )
-    cols = raw_cols + enriched_cols
-    table = [{c: r.get(c) for c in cols} for r in rows]
-    st.caption(
-        "Enriched columns (prefixed with the strategy name) are tinted "
-        "green so you can see at a glance what the agents added on top "
-        "of the raw catalog."
+    st.markdown("**Agent graph**")
+    st.graphviz_chart(dot)
+    _render_agent_node(
+        "composer_v1",
+        composer_span,
+        bucket.get("llm_by_strategy", {}).get("composer_v1", []),
+        expanded=False,
     )
-    df = pd.DataFrame(table, columns=cols)
-    enriched_set = set(enriched_cols)
+    strategy_spans = bucket.get("strategy_spans", {})
+    if not strategy_spans:
+        st.caption("No upstream strategy spans recorded for this product.")
+        return
+    st.markdown("**Contributing agents**")
+    for strategy in sorted(strategy_spans.keys()):
+        _render_agent_node(
+            strategy,
+            strategy_spans[strategy],
+            bucket.get("llm_by_strategy", {}).get(strategy, []),
+            expanded=(strategy == source_strategy),
+        )
 
-    def _tint(col: pd.Series) -> list[str]:
-        if col.name in enriched_set:
-            return ["background-color: rgba(45, 180, 130, 0.18)"] * len(col)
-        return [""] * len(col)
 
-    styled = df.style.apply(_tint, axis=0)
-    st.dataframe(styled, hide_index=True, use_container_width=True)
-    st.download_button(
-        "Download as CSV",
-        data=_rows_to_csv(table, cols),
-        file_name=f"{merchant_id}_enriched.csv",
-        mime="text/csv",
+def _render_decision_card(decision: dict[str, Any]) -> None:
+    st.markdown("**Composer decision**")
+    cols = st.columns(2)
+    cols[0].markdown(f"**key**: `{decision.get('key')}`")
+    cols[0].markdown(
+        f"**source**: `{decision.get('source_strategy') or '(unknown)'}`"
+    )
+    val = decision.get("chosen_value")
+    try:
+        val_str = json.dumps(val, ensure_ascii=False, default=str)
+    except Exception:  # noqa: BLE001
+        val_str = repr(val)
+    cols[1].markdown("**chosen value**")
+    cols[1].code(val_str[:400])
+    reason = decision.get("reason")
+    if reason:
+        st.caption(f"**reason**: {reason}")
+    dropped = decision.get("dropped_alternatives") or []
+    if dropped:
+        st.markdown(f"**dropped alternatives** ({len(dropped)})")
+        st.json(_jsonable(dropped))
+
+
+def _dashed_sources_for_decision(
+    bucket: dict[str, Any], dropped_alts: list[Any]
+) -> tuple[str, ...]:
+    """Best-effort: infer which upstream strategies' findings matched a
+    value in ``dropped_alternatives`` so the agent graph can render a
+    dashed edge from those sources to composer_v1. We don't have
+    per-drop ``source_strategy`` metadata in the current decision
+    schema, so we reverse-lookup against each strategy's
+    ``StrategyOutput.attributes`` values."""
+    if not dropped_alts:
+        return ()
+    sources: set[str] = set()
+    for strategy, span in bucket.get("strategy_spans", {}).items():
+        if strategy not in _KNOWN_UPSTREAM_STRATEGIES:
+            continue
+        out = _span_output(span) or {}
+        if not isinstance(out, dict):
+            continue
+        attrs = out.get("attributes") or {}
+        if not isinstance(attrs, dict):
+            continue
+        flat_values: list[Any] = []
+        for v in attrs.values():
+            if isinstance(v, dict):
+                flat_values.extend(v.values())
+            elif isinstance(v, list):
+                flat_values.extend(v)
+            else:
+                flat_values.append(v)
+        for dv in dropped_alts:
+            # ``in`` uses ``==``, which is mostly safe but can raise
+            # ``TypeError`` when comparing mixed unorderable types
+            # (e.g. a numpy scalar against a plain dict) — swallow
+            # those and move on so one weird dropped_alt entry can't
+            # take the whole side panel down (review fix #4, PR #86).
+            try:
+                if dv in flat_values:
+                    sources.add(strategy)
+                    break
+            except TypeError:
+                continue
+    return tuple(sorted(sources))
+
+
+def _render_cell_panel_finding(
+    bucket: dict[str, Any],
+    pid: str,
+    strategy: str,
+    key: str,
+    value: Any,
+) -> None:
+    st.markdown("### Cell lineage")
+    st.caption(
+        f"`{strategy}.{key}`  ·  product `{_short_pid(pid)}`  ·  pre-composer finding"
+    )
+    if bucket.get("_pid_not_in_run"):
+        st.warning(
+            "This product isn't in the selected enrichment run — pick a "
+            "newer run from the sidebar to see its findings."
+        )
+        return
+    st.info(
+        "This is a pre-composer finding — the raw output of one agent "
+        "before the composer synthesized the canonical row. It may or "
+        "may not have made it onto the canonical row."
+    )
+    # Cross-reference: did this exact value appear in any composer decision's
+    # dropped_alternatives? If so, name the canonical key that shadowed it.
+    composer_span = bucket.get("composer")
+    if composer_span is not None:
+        for canonical_key, decision in bucket.get("decisions_by_key", {}).items():
+            dropped = decision.get("dropped_alternatives") or []
+            # Same ``in``-triggers-TypeError guard as
+            # _dashed_sources_for_decision; a single unorderable
+            # dropped_alt entry must not break the panel.
+            try:
+                shadowed = value in dropped
+            except TypeError:
+                shadowed = False
+            if shadowed:
+                st.caption(
+                    f"_Shadowed by `canonical.{canonical_key}` "
+                    f"(composer chose `{decision.get('source_strategy')}` instead)._"
+                )
+                break
+    span = bucket.get("strategy_spans", {}).get(strategy)
+    if span is None:
+        st.warning(f"No `{strategy}` span found for this product.")
+        return
+    _render_agent_node(
+        strategy,
+        span,
+        bucket.get("llm_by_strategy", {}).get(strategy, []),
+        expanded=True,
+    )
+
+
+def render_enriched_table(run: dict[str, Any], engine: Engine, merchant_id: str) -> None:
+    st.markdown(
+        f"### Enriched catalog for `{merchant_id}`  "
+        f"(canonical columns from `composer_v1` + optional pre-composer findings)"
+    )
+    left, right = st.columns([3, 2], gap="medium")
+
+    with left:
+        limit = st.slider(
+            "max rows", min_value=10, max_value=2000, value=200, step=10
+        )
+        # Clear the grid's cell selection when the findings toggle flips
+        # — toggling changes the column layout (adds/removes
+        # finding_cols), so a selection index captured before the flip
+        # may point to a different cell after. The range check in
+        # ``_render_side_panel`` guards against out-of-bounds, but the
+        # *semantic* mismatch (user selected canonical.ram_gb, finding
+        # column moves in, now they're looking at a parser_v1.* panel)
+        # is only fixed by dropping the stale selection. Review
+        # feedback #5, PR #86.
+        toggle_key = f"enriched_findings_toggle_{merchant_id}"
+        prev_toggle_key = f"_prev_{toggle_key}"
+        grid_key = f"enriched_grid_{merchant_id}"
+        show_findings = st.toggle(
+            "Show pre-composer findings (debug)",
+            value=False,
+            key=toggle_key,
+            help=(
+                "Surface the raw `<strategy>.<key>` outputs that composer_v1 "
+                "synthesized from. Useful for debugging why the composer "
+                "chose one source over another."
+            ),
+        )
+        prev = st.session_state.get(prev_toggle_key)
+        if prev is not None and prev != show_findings:
+            st.session_state.pop(grid_key, None)
+        st.session_state[prev_toggle_key] = show_findings
+        result = fetch_enriched_table(engine, merchant_id, limit=limit)
+        if result is None:
+            # Slug may have been rejected by the helper (malformed) or the
+            # tables themselves are gone — keep the message generic so we
+            # don't re-raise the same ValueError just to render copy.
+            try:
+                table_hint = f"`{merchant_catalog_table(merchant_id)}`"
+            except ValueError:
+                table_hint = f"the catalog table for `{merchant_id}`"
+            st.warning(
+                f"{table_hint} or its enriched table is missing — the merchant "
+                "may have been deleted, or the id is malformed. Use **Refresh "
+                "merchants** in the sidebar to re-hydrate the selector."
+            )
+            with right:
+                _render_cell_panel_empty()
+            return
+        rows, raw_cols, canonical_cols, finding_cols = result
+        if not canonical_cols:
+            st.caption(
+                f"{len(rows)} rows · {len(raw_cols)} raw columns · "
+                f"**no `composer_v1` rows found** (run enrichment with the "
+                "composer enabled — see PR #84)."
+            )
+        else:
+            st.caption(
+                f"{len(rows)} rows · {len(raw_cols)} raw columns · "
+                f"{len(canonical_cols)} canonical columns"
+                + (
+                    f" · {len(finding_cols)} finding columns"
+                    if show_findings
+                    else ""
+                )
+            )
+        display_cols = list(raw_cols) + list(canonical_cols)
+        if show_findings:
+            display_cols = display_cols + list(finding_cols)
+        table = [{c: r.get(c) for c in display_cols} for r in rows]
+        st.caption(
+            "Canonical columns (`canonical.*`, green) are the composer's "
+            "single-writer output. Click any canonical cell to see which "
+            "agent produced its value, with that agent's full reasoning "
+            "chain in the side panel."
+        )
+        canonical_set = set(canonical_cols)
+        finding_set = set(finding_cols)
+        try:
+            import pandas as pd
+
+            df = pd.DataFrame(table, columns=display_cols)
+
+            def _tint(col: "pd.Series[Any]") -> list[str]:
+                if col.name in canonical_set:
+                    return ["background-color: rgba(45, 180, 130, 0.18)"] * len(col)
+                if col.name in finding_set:
+                    return ["background-color: rgba(140, 140, 140, 0.12)"] * len(col)
+                return [""] * len(col)
+
+            styled = df.style.apply(_tint, axis=0)
+            # grid_key was set above (merchant-scoped) so switching
+            # merchants / toggling findings both clear the selection
+            # cleanly.
+            event = st.dataframe(
+                styled,
+                hide_index=True,
+                use_container_width=True,
+                on_select="rerun",
+                selection_mode=["single-row", "single-column"],
+                key=grid_key,
+            )
+        except ImportError:
+            event = st.dataframe(
+                table,
+                hide_index=True,
+                use_container_width=True,
+                on_select="rerun",
+                selection_mode=["single-row", "single-column"],
+                key=grid_key,
+            )
+        st.download_button(
+            "Download as CSV",
+            data=_rows_to_csv(table, display_cols),
+            file_name=f"{merchant_id}_enriched.csv",
+            mime="text/csv",
+        )
+
+    # --- Right column: cell-lineage side panel -------------------------
+    with right:
+        _render_side_panel(event, rows, display_cols, run)
+
+
+def _render_side_panel(
+    event: Any,
+    rows: list[dict[str, Any]],
+    display_cols: list[str],
+    run: dict[str, Any],
+) -> None:
+    """Dispatch the right-column renderer based on the current selection.
+
+    Split off so the ``with left:`` / ``with right:`` blocks stay readable;
+    the routing itself is just the raw vs canonical vs finding fork."""
+    sel = getattr(event, "selection", None) or {}
+    if not isinstance(sel, dict):
+        sel = dict(sel) if sel else {}
+    sel_rows = sel.get("rows") or []
+    sel_cols = sel.get("columns") or []
+    if not (sel_rows and sel_cols):
+        _render_cell_panel_empty()
+        return
+    row_idx = sel_rows[0]
+    col_idx = sel_cols[0]
+    # Streamlit returns the column index as an int (position) in some
+    # versions and the column name as a str in others — handle both.
+    if isinstance(col_idx, int):
+        if col_idx < 0 or col_idx >= len(display_cols):
+            _render_cell_panel_empty()
+            return
+        col_name = display_cols[col_idx]
+    else:
+        col_name = str(col_idx)
+    if row_idx < 0 or row_idx >= len(rows):
+        _render_cell_panel_empty()
+        return
+    row = rows[row_idx]
+    pid = row.get("product_id")
+    if pid is None:
+        _render_cell_panel_empty()
+        return
+    pid_str = str(pid)
+
+    # Route by column namespace.
+    if col_name.startswith("canonical."):
+        canonical_key = col_name[len("canonical.") :]
+        bucket = _load_trace_bucket(run, pid_str)
+        if bucket is None:
+            _render_cell_panel_trace_missing(run, pid_str, col_name)
+            return
+        _render_cell_panel_canonical(bucket, pid_str, canonical_key)
+        return
+    for prefix in _KNOWN_UPSTREAM_STRATEGIES:
+        if col_name.startswith(prefix + "."):
+            bucket = _load_trace_bucket(run, pid_str)
+            if bucket is None:
+                _render_cell_panel_trace_missing(run, pid_str, col_name)
+                return
+            key = col_name[len(prefix) + 1 :]
+            _render_cell_panel_finding(
+                bucket, pid_str, prefix, key, row.get(col_name)
+            )
+            return
+    _render_cell_panel_raw(col_name)
+
+
+# run_id comes from ``summary.run_id`` which the orchestrator generates
+# via ``uuid4().hex`` — 32 lowercase hex chars. We pin the regex to that
+# shape before building a filesystem path so a malformed artifact (or
+# one edited by hand) can't resolve into something like ``../../etc``
+# (review fix: security note, PR #86). Anything else is treated as
+# trace-missing.
+_RUN_ID_SAFE_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _load_trace_bucket(
+    run: dict[str, Any], pid_str: str
+) -> dict[str, Any] | None:
+    """Return the per-product trace bucket for ``pid_str``, or ``None`` when
+    the JSONL isn't present. Separate helper keeps the call-site routing
+    compact and gives us a single place to apply the mtime-keyed cache.
+
+    When the JSONL *is* present but ``pid_str`` simply didn't appear in
+    this run — typically because the product was added to the catalog
+    after the selected run artifact was produced — the returned bucket
+    carries ``_pid_not_in_run = True`` so callers can differentiate
+    "composer didn't run for this product" from "this product wasn't
+    part of the selected run" (review feedback #3, PR #86)."""
+    run_id = (run.get("summary") or {}).get("run_id")
+    if not run_id or not _RUN_ID_SAFE_RE.match(str(run_id)):
+        return None
+    path = TRACES_DIR / f"{run_id}.jsonl"
+    if not path.exists():
+        return None
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return None
+    index = _index_trace_by_product(str(path), mtime)
+    bucket = index.get(pid_str)
+    if bucket is None:
+        return {
+            "strategy_spans": {},
+            "llm_by_strategy": {},
+            "composer": None,
+            "decisions_by_key": {},
+            "_pid_not_in_run": True,
+        }
+    return bucket
+
+
+def _render_cell_panel_trace_missing(
+    run: dict[str, Any], pid_str: str, col_name: str
+) -> None:
+    run_id = (run.get("summary") or {}).get("run_id") or "?"
+    st.markdown("### Cell lineage")
+    st.caption(f"`{col_name}`  ·  product `{_short_pid(pid_str)}`")
+    st.warning(
+        f"No JSONL trace found at `logs/enrichment_traces/{run_id}.jsonl`. "
+        "Re-run with `ENRICHMENT_TRACE_JSONL=1` to enable cell lineage."
+
     )
 
 
@@ -1046,17 +1907,19 @@ def main() -> None:
         )
 
         st.divider()
-        artifacts = list_run_artifacts()
+        artifacts = list_run_artifacts_for_merchant(picked_id)
         if not artifacts:
             st.info(
-                "No runs yet. Generate one with:\n\n"
-                "`python scripts/run_enrichment.py "
-                "--mode fixed --limit 5 --eval-output runs/dev.json`"
+                f"No enrichment runs yet for `{picked_id}`. Generate one "
+                "with:\n\n"
+                "`python scripts/run_enrichment.py --mode fixed "
+                f"--merchant {picked_id} --limit 5 "
+                f"--eval-output runs/{picked_id}.json`"
             )
             run: dict[str, Any] = {"summary": {}, "assessment": {}, "catalog_schema": {}}
         else:
             labels = [f"{p.name} ({_fmt_mtime(p)})" for p in artifacts]
-            pick = st.selectbox("run artifact", labels, index=0)
+            pick = st.selectbox("Enrichment run", labels, index=0)
             chosen = artifacts[labels.index(pick)]
             run = load_run(str(chosen))
             st.caption(f"loaded `{chosen}`")
@@ -1076,7 +1939,7 @@ def main() -> None:
     with tabs[1]:
         render_raw_enriched_kg(run, engine, picked_id)
     with tabs[2]:
-        render_enriched_table(engine, picked_id)
+        render_enriched_table(run, engine, picked_id)
     with tabs[3]:
         render_kg_coverage(run)
     with tabs[4]:

--- a/scripts/enrichment_inspector.py
+++ b/scripts/enrichment_inspector.py
@@ -573,7 +573,26 @@ def render_enriched_table(engine: Engine, merchant_id: str) -> None:
     )
     cols = raw_cols + enriched_cols
     table = [{c: r.get(c) for c in cols} for r in rows]
-    st.dataframe(table, hide_index=True, use_container_width=True)
+    st.caption(
+        "Enriched columns (prefixed with the strategy name) are tinted "
+        "green so you can see at a glance what the agents added on top "
+        "of the raw catalog."
+    )
+    try:
+        import pandas as pd
+
+        df = pd.DataFrame(table, columns=cols)
+        enriched_set = set(enriched_cols)
+
+        def _tint(col: pd.Series) -> list[str]:
+            if col.name in enriched_set:
+                return ["background-color: rgba(45, 180, 130, 0.18)"] * len(col)
+            return [""] * len(col)
+
+        styled = df.style.apply(_tint, axis=0)
+        st.dataframe(styled, hide_index=True, use_container_width=True)
+    except ImportError:
+        st.dataframe(table, hide_index=True, use_container_width=True)
     st.download_button(
         "Download as CSV",
         data=_rows_to_csv(table, cols),
@@ -741,6 +760,30 @@ def _load_trace_jsonl(run_id: str) -> list[dict[str, Any]] | None:
     return spans
 
 
+def _span_output(span: dict[str, Any]) -> Any:
+    """Final output for a span. ``tracing.py`` writes the result into the
+    last entry of ``updates[]``, not the span's top-level ``output``, so a
+    naive ``span.get('output')`` always returns ``None``. Walk updates in
+    reverse and return the most recent non-empty output."""
+    top = span.get("output")
+    if top:
+        return top
+    for upd in reversed(span.get("updates") or []):
+        if isinstance(upd, dict) and upd.get("output") not in (None, "", {}):
+            return upd["output"]
+    return None
+
+
+def _span_metadata(span: dict[str, Any]) -> dict[str, Any]:
+    """Aggregate metadata from all update events. Most LLM cost / token
+    info lives there, not on the top-level span."""
+    merged: dict[str, Any] = {}
+    for upd in span.get("updates") or []:
+        if isinstance(upd, dict) and isinstance(upd.get("metadata"), dict):
+            merged.update(upd["metadata"])
+    return merged
+
+
 def _span_product_id(span: dict[str, Any]) -> str | None:
     """Extract product_id from a span's input or tags, if present."""
     inp = span.get("input") or {}
@@ -875,11 +918,18 @@ def render_reasoning_trace(run: dict[str, Any]) -> None:
                 st.json(_jsonable(sp.get("input") or {}))
             with right:
                 st.markdown("**output**")
-                st.json(_jsonable(sp.get("output") or {}))
-            updates = sp.get("updates") or []
-            if updates:
-                st.markdown(f"**updates** ({len(updates)})")
-                st.json(_jsonable(updates))
+                st.json(_jsonable(_span_output(sp) or {}))
+            md = _span_metadata(sp)
+            if md:
+                meta_bits = []
+                if "cost_usd" in md:
+                    meta_bits.append(f"cost: ${md['cost_usd']:.6f}")
+                if "latency_ms" in md:
+                    meta_bits.append(f"latency: {md['latency_ms']} ms")
+                if "model" in md:
+                    meta_bits.append(f"model: `{md['model']}`")
+                if meta_bits:
+                    st.caption("  ·  ".join(meta_bits))
             llms = [
                 llm for llm in llm_by_strategy.get(strategy, [])
                 if _span_product_id(llm) in (None, pid) or pid is None
@@ -899,7 +949,15 @@ def render_reasoning_trace(run: dict[str, Any]) -> None:
                             st.json(_jsonable(llm.get("input") or {}))
                         with lo:
                             st.markdown("**response**")
-                            st.json(_jsonable(llm.get("output") or {}))
+                            st.json(_jsonable(_span_output(llm) or {}))
+                        lmd = _span_metadata(llm)
+                        if lmd:
+                            tok_in = lmd.get("input_tokens", "?")
+                            tok_out = lmd.get("output_tokens", "?")
+                            st.caption(
+                                f"tokens: {tok_in} in / {tok_out} out  ·  "
+                                f"cost: ${lmd.get('cost_usd', 0):.6f}"
+                            )
 
     if shown == 0:
         st.info("No strategy spans match the current filters.")
@@ -960,10 +1018,11 @@ def main() -> None:
         merchant_ids = [m["merchant_id"] for m in merchants]
         default_idx = merchant_ids.index("default") if "default" in merchant_ids else 0
         picked_id = st.selectbox(
-            "merchant",
+            "catalog",
             merchant_ids,
             index=default_idx,
             key="merchant_pick",
+            help="One catalog per merchant (one row in merchants.registry).",
         )
         picked = next(m for m in merchants if m["merchant_id"] == picked_id)
         st.caption(

--- a/scripts/enrichment_inspector.py
+++ b/scripts/enrichment_inspector.py
@@ -39,6 +39,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
 import streamlit as st
 
 # Make the mcp-server package importable so we can reuse kg_projection /
@@ -303,13 +304,15 @@ def fetch_one_product(
             {"pid": product_id},
         ).mappings().all()
     if raw_row is not None:
-        # Translate raw column names → ORM-attribute / kg_projection logical
-        # names so render_per_product's IDENTITY_FIELDS lookup hits. Without
-        # this the "Projected :Product node" panel renders an empty identity
-        # block for every product.
+        # Add ORM-attribute / kg_projection logical names alongside the raw
+        # column names so render_per_product's IDENTITY_FIELDS lookup hits.
+        # We copy rather than rename (``raw_row[logical] = raw_row[col]``)
+        # so the Raw panel downstream still shows the original catalog keys
+        # (``id`` / ``title`` / ``imageurl``) the merchant uploaded — that's
+        # the whole point of the "raw" view.
         for col, logical in (("id", "product_id"), ("title", "name"), ("imageurl", "image_url")):
             if col in raw_row and logical not in raw_row:
-                raw_row[logical] = raw_row.pop(col)
+                raw_row[logical] = raw_row[col]
     enriched_by_strategy: dict[str, dict[str, Any]] = {
         r["strategy"]: (r["attributes"] or {}) for r in enriched_rows
     }
@@ -578,21 +581,16 @@ def render_enriched_table(engine: Engine, merchant_id: str) -> None:
         "green so you can see at a glance what the agents added on top "
         "of the raw catalog."
     )
-    try:
-        import pandas as pd
+    df = pd.DataFrame(table, columns=cols)
+    enriched_set = set(enriched_cols)
 
-        df = pd.DataFrame(table, columns=cols)
-        enriched_set = set(enriched_cols)
+    def _tint(col: pd.Series) -> list[str]:
+        if col.name in enriched_set:
+            return ["background-color: rgba(45, 180, 130, 0.18)"] * len(col)
+        return [""] * len(col)
 
-        def _tint(col: pd.Series) -> list[str]:
-            if col.name in enriched_set:
-                return ["background-color: rgba(45, 180, 130, 0.18)"] * len(col)
-            return [""] * len(col)
-
-        styled = df.style.apply(_tint, axis=0)
-        st.dataframe(styled, hide_index=True, use_container_width=True)
-    except ImportError:
-        st.dataframe(table, hide_index=True, use_container_width=True)
+    styled = df.style.apply(_tint, axis=0)
+    st.dataframe(styled, hide_index=True, use_container_width=True)
     st.download_button(
         "Download as CSV",
         data=_rows_to_csv(table, cols),
@@ -769,8 +767,13 @@ def _span_output(span: dict[str, Any]) -> Any:
     if top:
         return top
     for upd in reversed(span.get("updates") or []):
-        if isinstance(upd, dict) and upd.get("output") not in (None, "", {}):
-            return upd["output"]
+        if not isinstance(upd, dict):
+            continue
+        out = upd.get("output")
+        # Empty dict/list are legitimate outputs (e.g. a specialist that
+        # correctly decides "nothing to add"); only filter None and "".
+        if out is not None and out != "":
+            return out
     return None
 
 
@@ -930,6 +933,13 @@ def render_reasoning_trace(run: dict[str, Any]) -> None:
                     meta_bits.append(f"model: `{md['model']}`")
                 if meta_bits:
                     st.caption("  ·  ".join(meta_bits))
+            # Fallback debug view: the per-update payload for multi-step
+            # span chains. The summary above only surfaces the final output
+            # + aggregated metadata, which loses intermediate steps.
+            updates = sp.get("updates") or []
+            if updates:
+                with st.expander(f"raw updates ({len(updates)})", expanded=False):
+                    st.json(_jsonable(updates))
             llms = [
                 llm for llm in llm_by_strategy.get(strategy, [])
                 if _span_product_id(llm) in (None, pid) or pid is None

--- a/scripts/enrichment_inspector.py
+++ b/scripts/enrichment_inspector.py
@@ -209,14 +209,20 @@ def fetch_enriched_table(
         enr = merchant_enriched_table(merchant_id)
     except ValueError:
         return None
+    # The raw table's PK column is ``id`` and the title column is ``title``;
+    # the ORM model exposes them as ``product_id`` / ``name``. Hand-written
+    # SQL has to use the underlying column names. Enriched rows live in a
+    # per-merchant table by construction, and the enriched schema doesn't
+    # carry ``merchant_id`` at all, so the JOIN keys on ``id``/``product_id``
+    # only.
     sql = text(
         f"""
-        SELECT p.product_id, p.name, p.brand, p.category, p.price,
-               p.attributes AS raw_attributes,
+        SELECT p.id AS product_id, p.title AS name, p.brand, p.category,
+               p.price, p.attributes AS raw_attributes,
                e.strategy, e.attributes AS enriched_attributes
         FROM {raw} p
-        LEFT JOIN {enr} e USING (product_id, merchant_id)
-        ORDER BY p.product_id
+        LEFT JOIN {enr} e ON p.id = e.product_id
+        ORDER BY p.id
         LIMIT :lim
         """
     )
@@ -280,11 +286,15 @@ def fetch_one_product(
         return None, {}
     raw_row: dict[str, Any] | None
     with engine.connect() as conn:
+        # Raw table PK is ``id``; the ORM exposes it as ``product_id``. Use
+        # the underlying name in SQL, then translate the dict keys for the
+        # display + kg_projection.IDENTITY_FIELDS lookup downstream.
         rr = conn.execute(
-            text(f"SELECT * FROM {raw} WHERE product_id = :pid LIMIT 1"),
+            text(f"SELECT * FROM {raw} WHERE id = :pid LIMIT 1"),
             {"pid": product_id},
         ).mappings().one_or_none()
         raw_row = dict(rr) if rr else None
+        # Enriched table PK is literally ``product_id``; leave as-is.
         enriched_rows = conn.execute(
             text(
                 f"SELECT strategy, attributes FROM {enr} "
@@ -292,6 +302,14 @@ def fetch_one_product(
             ),
             {"pid": product_id},
         ).mappings().all()
+    if raw_row is not None:
+        # Translate raw column names → ORM-attribute / kg_projection logical
+        # names so render_per_product's IDENTITY_FIELDS lookup hits. Without
+        # this the "Projected :Product node" panel renders an empty identity
+        # block for every product.
+        for col, logical in (("id", "product_id"), ("title", "name"), ("imageurl", "image_url")):
+            if col in raw_row and logical not in raw_row:
+                raw_row[logical] = raw_row.pop(col)
     enriched_by_strategy: dict[str, dict[str, Any]] = {
         r["strategy"]: (r["attributes"] or {}) for r in enriched_rows
     }


### PR DESCRIPTION
## Summary

Three sites in [scripts/enrichment_inspector.py](scripts/enrichment_inspector.py) used ORM attribute names (\`product_id\`, \`name\`, \`image_url\`) in hand-written SQL against the per-merchant raw catalog. The actual column names are \`id\`, \`title\`, \`imageurl\` — the ORM maps them via \`Column(\"id\", ...)\` etc. in [app/models.py](mcp-server/app/models.py).

Caught while testing PR interactive-decision-support-system/idss-backend#79's enrichment-pipeline assessment workflow against a fresh \`mocklaptops\` merchant. The bug was actually pre-existing in PR interactive-decision-support-system/idss-backend#68 (the original inspector) and PR interactive-decision-support-system/idss-backend#72's polish pass didn't exercise the JOIN, so it shipped under both PRs' blind spots.

## Symptoms before this fix

- **Enriched table tab**: \`ProgrammingError: column \"product_id\" does not exist\` → caught by the \`(ProgrammingError, DatabaseError)\` handler → misleading warning *\"merchant table is missing\"* for every merchant.
- **Per-product drill-down tab**: same root cause via \`WHERE product_id = :pid\` — every drill-down silently failed with *\"No raw row for this product_id\"*.
- **Projected :Product node sub-panel**: even when a raw row was somehow returned, the \`kg_projection.IDENTITY_FIELDS\` lookup (which uses logical names) hit nothing on a \`SELECT *\` dict (which has raw column names), so the panel rendered \`{}\` for every product.

## Fixes

- \`fetch_enriched_table\`: \`SELECT p.id AS product_id, p.title AS name, ...\`, \`JOIN ON p.id = e.product_id\`. Drops the bogus \`merchant_id\` from the \`USING\` clause — enriched tables don't carry that column.
- \`fetch_one_product\`: \`WHERE id = :pid\`; post-processes the raw_row dict to rename \`id\` / \`title\` / \`imageurl\` → \`product_id\` / \`name\` / \`image_url\` so the downstream \`IDENTITY_FIELDS\` lookup hits.

## Out of scope

- The \`description\` \`IDENTITY_FIELD\` lives inside the raw \`attributes\` JSONB, not as a top-level column — \"Projected :Product node\" won't include it without a separate JSONB-extract step. Flagged for follow-up; could go on issue interactive-decision-support-system/merchant-agent#4 (known nits).
- LIMIT semantics in \`fetch_enriched_table\`: the \`LIMIT :lim\` is applied to JOIN rows (one per (raw, enriched_strategy) pair), not unique products — sliding the slider can produce non-monotonic row counts. Pre-existing, unrelated to this fix.

## Test plan

- [x] \`fetch_enriched_table('default', limit=200)\` → 196 rows × 41 raw cols × 18 derived cols
- [x] \`fetch_enriched_table('mocklaptops', limit=200)\` → 180 rows × 19 raw cols × 18 derived cols
- [x] \`fetch_one_product('mocklaptops', '<smoke-pid>')\` → returns raw row with logical keys (\`product_id\`, \`name\`, \`image_url\`) and 5 strategies in enriched
- [x] Live: \`streamlit run scripts/enrichment_inspector.py\` → Enriched-table tab renders the table for both merchants instead of the \"missing\" warning

## Note on diff scope

This PR's diff includes `mcp-server/app/enrichment/agents/composer.py` and `mcp-server/tests/enrichment/test_composer.py` carried from the already-merged PR interactive-decision-support-system/idss-backend#84 (composer agent). Those changes are not part of the inspector SQL fix and were reviewed under interactive-decision-support-system/idss-backend#84. Reviewers scanning this PR alone should treat them as out-of-scope context, not new code.
