### PR TITLE
fix(enrichment/llm_client): GPT-5 API compat (max_completion_tokens, temperature gating)

### DIFF
--- a/mcp-server/app/enrichment/tools/llm_client.py
+++ b/mcp-server/app/enrichment/tools/llm_client.py
@@ -155,9 +155,13 @@ class LLMClient:
         kwargs: dict[str, Any] = {
             "model": model_name,
             "messages": messages,
-            "max_tokens": max_tokens,
-            "temperature": temperature,
+            "max_completion_tokens": max_tokens,
         }
+        # GPT-5 family only accepts the default temperature (1). Omit the
+        # kwarg so OpenAI applies its default; pre-GPT-5 models still honor
+        # the caller-supplied value.
+        if not model_name.startswith("gpt-5"):
+            kwargs["temperature"] = temperature
         if json_mode:
             kwargs["response_format"] = {"type": "json_object"}
 


### PR DESCRIPTION
## Summary

GPT-5 rejects two kwargs that were passed unconditionally since PR #84:

- **`max_tokens` → `max_completion_tokens`**: OpenAI renamed this parameter for the GPT-5 family. Passing the old name causes a 400 from the API.
- **`temperature`**: GPT-5 only accepts the default temperature (1.0) and rejects any explicit value. The kwarg is now gated on `not model_name.startswith("gpt-5")`, so pre-GPT-5 models (gpt-4o, gpt-4o-mini) continue to receive the caller-supplied value unchanged.

Both changes are isolated to the `LLMClient.complete()` method in `mcp-server/app/enrichment/tools/llm_client.py`.

## Evidence

This exact patch was developed and validated during the in-flight diagnostic enrichment run on the mocklaptops merchant (TS=1776839379, PID 97025). The run is actively using this fix — `idss-backend-enrichment-run/` carries the uncommitted patch, confirmed byte-identical to what is committed here.

## Test plan

- [x] `python3 -m pytest mcp-server/tests -k llm_client -x -v` — 12 passed, 1 skipped (pre-existing unrelated skip), 0 failures
- [ ] Confirm enrichment run on mocklaptops completes without GPT-5 400 errors after this merges to `refactor/merchant-agent-v2`