### PR TITLE
fix(composer): 1:1 enforcement + source_kind provenance (closes #88 in part)

### DIFF
--- a/mcp-server/app/enrichment/agents/composer.py
+++ b/mcp-server/app/enrichment/agents/composer.py
@@ -1,4 +1,4 @@
-"""composer_v1 — single writer of the canonical enriched row (issue #83).
+"""composer_v1 — single writer of the canonical enriched row (issues #83, #88).
 
 Today's enrichment pipeline lets every strategy (taxonomy, parser, specialist,
 scraper, soft_tagger) write its own (product_id, strategy, attributes) row;
@@ -13,8 +13,8 @@ The composer is the structural fix: it is the **only** agent allowed to
 emit canonical catalog fields. Every other strategy still writes its own
 row — but downstream readers prefer composer output when present.
 
-v1 scope (this commit)
-----------------------
+v1 scope
+--------
   - Reads every upstream strategy's output from the runner's ``context``
     dict (populated in orchestration/runner.py: ``ctx[_short(strategy)] =
     output.attributes``).
@@ -48,6 +48,37 @@ v1 scope (this commit)
         composer_decisions    list[ComposerDecision] — audit log for the
                               cell-lineage UX in #81
         composed_at           ISO timestamp
+
+1:1 enforcement policy (issue #88)
+------------------------------------
+Every key in ``composed_fields`` MUST have a matching entry in
+``composer_decisions``. The composer instructs the LLM to comply, but compliance
+is not guaranteed. After the LLM returns, ``_reconcile_composer_output`` enforces
+this **leniently with synthesis**: any composed key that has no decision gets a
+synthesized ``ComposerDecision`` marked ``source_kind=PARAMETRIC`` and
+``reason='decision_synthesized_from_composed_fields'``. The row ships in full;
+``attributes['incomplete_decisions'] = True`` flags the gap for the inspector.
+
+source_kind provenance taxonomy (vision bullet 3 / #88)
+--------------------------------------------------------
+``ComposerDecision.source_kind`` (a ``SourceKind`` enum) classifies each
+composed field by how its value was obtained:
+
+  RAW_PARSE            — parser_v1 extracted it from raw catalog text
+  SCRAPE               — scraper_v1 crawled the manufacturer page
+  PARAMETRIC           — LLM world knowledge (specialist_v1, taxonomy_v1,
+                         soft_tagger_v1, composer alone, or echoes from raw)
+  DETERMINISTIC_FALLBACK — rule-based pass-through (no LLM inference)
+
+The reconciler infers ``source_kind`` from ``source_strategy`` via
+``_STRATEGY_TO_SOURCE_KIND``. If ``source_strategy`` is unknown, the field
+defaults to ``PARAMETRIC`` and a warning is logged so the gap is visible.
+
+Live validation caveat
+-----------------------
+The live mocklaptops enrichment run currently returns uniformly empty composer
+output (task #12 investigates root cause). All validation for this PR is
+therefore synthetic-fixture-only — see ``tests/enrichment/test_composer.py``.
 
 # _TODO(closed_loop) — #85 attach points
 # ---------------------------------------
@@ -87,7 +118,7 @@ from pydantic import ValidationError
 from app.enrichment import registry
 from app.enrichment.base import BaseEnrichmentAgent
 from app.enrichment.tools.llm_client import LLMClient, composer_model
-from app.enrichment.types import ComposerDecision, ProductInput, StrategyOutput
+from app.enrichment.types import ComposerDecision, ProductInput, SourceKind, StrategyOutput
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +145,31 @@ _SHORT_TO_STRATEGY: dict[str, str] = {
     "specialist": "specialist_v1",
     "scraped": "scraper_v1",
     "soft_tagger": "soft_tagger_v1",
+}
+
+
+# Maps each known source_strategy to its SourceKind provenance bucket.
+# Used by _reconcile_composer_output to populate source_kind on each
+# ComposerDecision without requiring the LLM to do so (it often omits it).
+# Unknown source_strategy values fall back to PARAMETRIC with a warning.
+#
+# Mapping rationale:
+#   parser_v1      — LLM extraction from raw text → RAW_PARSE
+#   scraper_v1     — crawled manufacturer page → SCRAPE
+#   specialist_v1  — LLM world knowledge, no direct evidence → PARAMETRIC
+#   taxonomy_v1    — LLM classifier, no raw evidence → PARAMETRIC
+#   soft_tagger_v1 — LLM soft-tag inference → PARAMETRIC
+#   composer_v1    — composer acting alone (no upstream contributed) → PARAMETRIC
+#   echoes_raw     — literal pass-through reason from echo discipline → RAW_PARSE
+#                    (the value came from raw_attributes, which is raw catalog input)
+_STRATEGY_TO_SOURCE_KIND: dict[str, SourceKind] = {
+    "parser_v1": SourceKind.RAW_PARSE,
+    "scraper_v1": SourceKind.SCRAPE,
+    "specialist_v1": SourceKind.PARAMETRIC,
+    "taxonomy_v1": SourceKind.PARAMETRIC,
+    "soft_tagger_v1": SourceKind.PARAMETRIC,
+    "composer_v1": SourceKind.PARAMETRIC,
+    "echoes_raw": SourceKind.RAW_PARSE,
 }
 
 
@@ -166,6 +222,12 @@ _SYSTEM = (
     "  6. Only reference strategies listed in the 'available_findings' "
     "section of the user prompt. If a strategy didn't run, do not invent "
     "a source_strategy for it.\n"
+    "  7. 1:1 requirement. For every key you emit in `composed_fields`, "
+    "you MUST emit a matching entry in `composer_decisions` with `key` "
+    "equal to that field name. Do not ship a composed value without a "
+    "decision — the Python post-check will synthesize missing decisions "
+    "and flag the gap, but a missing decision breaks cell lineage in the "
+    "inspector.\n"
     "\n"
     + _PRECEDENCE_NOTE
     + "\n\n"
@@ -182,7 +244,13 @@ _SYSTEM = (
 @registry.register
 class ComposerAgent(BaseEnrichmentAgent):
     STRATEGY = "composer_v1"
-    OUTPUT_KEYS = frozenset({"composed_fields", "composer_decisions", "composed_at"})
+    OUTPUT_KEYS = frozenset({
+        "composed_fields", "composer_decisions", "composed_at",
+        # incomplete_decisions is set to True when the reconciler had to
+        # synthesize decisions for keys the LLM omitted from composer_decisions.
+        # Presence flags the gap for the inspector (#88).
+        "incomplete_decisions",
+    })
     DEFAULT_MODEL = "gpt-5"
 
     def __init__(self, llm: LLMClient | None = None) -> None:
@@ -241,6 +309,7 @@ class ComposerAgent(BaseEnrichmentAgent):
             composed, decisions = _deterministic_fallback(findings)
             composed = registry_strip_narrative(composed)
             composed, decisions = _cross_check_decisions(composed, decisions)
+            decisions, notes_payload = _reconcile_composer_output(composed, decisions)
             return StrategyOutput(
                 product_id=product.product_id,
                 strategy=self.STRATEGY,
@@ -249,6 +318,7 @@ class ComposerAgent(BaseEnrichmentAgent):
                     "composed_fields": composed,
                     "composer_decisions": decisions,
                     "composed_at": now_iso,
+                    **notes_payload,
                 },
                 notes="deterministic_fallback",
             )
@@ -259,6 +329,10 @@ class ComposerAgent(BaseEnrichmentAgent):
         composed = registry_strip_narrative(composed)
         composed, decisions = _cross_check_decisions(composed, decisions)
 
+        # 1:1 enforcement (issue #88): synthesize missing decisions and infer
+        # source_kind for all existing decisions.
+        decisions, notes_payload = _reconcile_composer_output(composed, decisions)
+
         return StrategyOutput(
             product_id=product.product_id,
             strategy=self.STRATEGY,
@@ -267,6 +341,7 @@ class ComposerAgent(BaseEnrichmentAgent):
                 "composed_fields": composed,
                 "composer_decisions": decisions,
                 "composed_at": now_iso,
+                **notes_payload,
             },
         )
 
@@ -366,7 +441,7 @@ def _cross_check_decisions(
     catches the LLM lying about its own decisions, per #83 review item 7.
     Decisions with ``source_strategy`` outside the known upstream set are
     also dropped (can't lineage-render an unknown source)."""
-    known_sources = frozenset(_SHORT_TO_STRATEGY.values()) | {None}
+    known_sources = frozenset(_STRATEGY_TO_SOURCE_KIND.keys()) | {None}
     kept: list[dict[str, Any]] = []
     for d in decisions:
         key = d.get("key")
@@ -384,6 +459,73 @@ def _cross_check_decisions(
             continue
         kept.append(d)
     return composed, kept
+
+
+def _reconcile_composer_output(
+    composed_fields: dict[str, Any],
+    composer_decisions: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Enforce 1:1 between composed_fields keys and composer_decisions entries.
+
+    Policy: lenient with synthesis. For any composed key without a decision,
+    synthesize a ComposerDecision marked source_kind=PARAMETRIC and
+    reason='decision_synthesized_from_composed_fields'. The output ships in
+    full but the gap is visible in the trace and surfaceable in the inspector.
+
+    Also ensures source_kind is populated on every existing decision:
+    inferred from source_strategy via _STRATEGY_TO_SOURCE_KIND. If the
+    source_strategy is not in the mapping, defaults to PARAMETRIC and emits
+    a warning.
+
+    Returns (reconciled_decisions, notes_payload). notes_payload contains
+    'incomplete_decisions': True if any synthesis happened.
+    """
+    # Index existing decisions by key for O(1) lookup.
+    decision_by_key: dict[str, dict[str, Any]] = {
+        d["key"]: d for d in composer_decisions if isinstance(d.get("key"), str)
+    }
+
+    reconciled: list[dict[str, Any]] = []
+    synthesized_any = False
+
+    for key, value in composed_fields.items():
+        if key in decision_by_key:
+            d = dict(decision_by_key[key])
+        else:
+            # Orphan composed key — synthesize a decision.
+            logger.warning(
+                "composer_missing_decision_synthesized",
+                extra={"key": key},
+            )
+            d = {
+                "key": key,
+                "chosen_value": value,
+                "source_strategy": None,
+                "reason": "decision_synthesized_from_composed_fields",
+                "dropped_alternatives": [],
+            }
+            synthesized_any = True
+
+        # Always infer source_kind from source_strategy so the authoritative
+        # mapping drives provenance (not the LLM's or pydantic's default).
+        src = d.get("source_strategy")
+        if src is not None and src not in _STRATEGY_TO_SOURCE_KIND:
+            logger.warning(
+                "composer_unknown_source_strategy_defaulting_to_parametric: "
+                "strategy=%s key=%s",
+                src,
+                key,
+            )
+        kind = _STRATEGY_TO_SOURCE_KIND.get(src, SourceKind.PARAMETRIC)
+        d["source_kind"] = kind.value
+
+        reconciled.append(d)
+
+    notes_payload: dict[str, Any] = {}
+    if synthesized_any:
+        notes_payload["incomplete_decisions"] = True
+
+    return reconciled, notes_payload
 
 
 def registry_strip_narrative(composed: dict[str, Any]) -> dict[str, Any]:

--- a/mcp-server/app/enrichment/types.py
+++ b/mcp-server/app/enrichment/types.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from enum import Enum
 from typing import Any, Literal
 from uuid import UUID
 
@@ -146,6 +147,26 @@ class ProposalAck(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class SourceKind(str, Enum):
+    """Provenance taxonomy for a single composed field (vision bullet 3 / #88).
+
+    Enables the coverage dashboard to count what fraction of canonical fields
+    come from parsing raw input vs. crawling vs. LLM world knowledge.
+
+    RAW_PARSE            — fact extracted directly from raw catalog input (parser_v1)
+    SCRAPE               — fact extracted from a crawled manufacturer page (scraper_v1)
+    PARAMETRIC           — LLM produced from world/parametric knowledge
+                           (specialist_v1, taxonomy_v1, soft_tagger_v1, or
+                           composer alone when no upstream contributed)
+    DETERMINISTIC_FALLBACK — rule-based / formula / pass-through; no LLM inference
+    """
+
+    RAW_PARSE = "raw_parse"
+    SCRAPE = "scrape"
+    PARAMETRIC = "parametric"
+    DETERMINISTIC_FALLBACK = "deterministic_fallback"
+
+
 class ComposerDecision(BaseModel):
     """One entry in ``composer_decisions``. Structured schema lets the
     inspector (#81) render cell lineage without re-parsing free-form JSON."""
@@ -153,5 +174,6 @@ class ComposerDecision(BaseModel):
     key: str
     chosen_value: Any = None
     source_strategy: str | None = None
+    source_kind: SourceKind = SourceKind.PARAMETRIC  # safe default; reconciler overrides per source_strategy
     reason: str | None = None
     dropped_alternatives: list[Any] = Field(default_factory=list)

--- a/mcp-server/tests/enrichment/test_composer.py
+++ b/mcp-server/tests/enrichment/test_composer.py
@@ -1,4 +1,4 @@
-"""composer_v1 — single writer of the canonical enriched row (issue #83)."""
+"""composer_v1 — single writer of the canonical enriched row (issues #83, #88)."""
 
 from __future__ import annotations
 
@@ -8,10 +8,14 @@ from uuid import uuid4
 import pytest
 
 from app.enrichment import registry
-from app.enrichment.agents.composer import ComposerAgent
+from app.enrichment.agents.composer import (
+    ComposerAgent,
+    _STRATEGY_TO_SOURCE_KIND,
+    _reconcile_composer_output,
+)
 from app.enrichment.agents.specialist import SpecialistAgent
 from app.enrichment.tools.llm_client import LLMResponse
-from app.enrichment.types import ProductInput
+from app.enrichment.types import ProductInput, SourceKind
 
 
 @pytest.fixture(autouse=True)
@@ -114,8 +118,12 @@ def test_composer_emits_composed_fields_and_decisions():
         "storage_gb": 512,
         "good_for_business": 0.9,
     }
-    assert attrs["composer_decisions"][0]["key"] == "ram_gb"
-    assert attrs["composer_decisions"][0]["source_strategy"] == "parser_v1"
+    # The reconciler (#88) ensures all 4 composed keys have decisions; the
+    # LLM only provided ram_gb so the other 3 are synthesized.
+    decision_keys = {d["key"] for d in attrs["composer_decisions"]}
+    assert decision_keys == {"product_type", "ram_gb", "storage_gb", "good_for_business"}
+    ram_decision = next(d for d in attrs["composer_decisions"] if d["key"] == "ram_gb")
+    assert ram_decision["source_strategy"] == "parser_v1"
     assert "composed_at" in attrs
 
 
@@ -245,7 +253,9 @@ def test_composer_coerces_malformed_llm_output():
 
 def test_composer_drops_decisions_that_lie_about_their_key():
     """Review fix #7: a decision whose chosen_value != composed_fields[key]
-    is the LLM lying about its own choice; drop it from the audit log."""
+    is the LLM lying about its own choice; drop it from the audit log.
+    The reconciler (#88) then synthesizes a replacement for the dropped key
+    so 1:1 is still satisfied."""
     llm = _FakeLLM(
         {
             "composed_fields": {"ram_gb": 16, "storage_gb": 512},
@@ -269,13 +279,23 @@ def test_composer_drops_decisions_that_lie_about_their_key():
     )
     result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
     decisions = result.output.attributes["composer_decisions"]
-    assert len(decisions) == 1
-    assert decisions[0]["key"] == "storage_gb"
+    # 1:1 is enforced: both keys are represented (ram_gb via synthesis).
+    assert {d["key"] for d in decisions} == {"ram_gb", "storage_gb"}
+    # The honest storage_gb decision is preserved as-is.
+    storage_d = next(d for d in decisions if d["key"] == "storage_gb")
+    assert storage_d["reason"] == "grounded"
+    # The lying ram_gb decision was dropped; the synthesized replacement
+    # carries the reconciler's reason.
+    ram_d = next(d for d in decisions if d["key"] == "ram_gb")
+    assert ram_d["reason"] == "decision_synthesized_from_composed_fields"
+    # incomplete_decisions flag is set because synthesis occurred.
+    assert result.output.attributes.get("incomplete_decisions") is True
 
 
 def test_composer_drops_decisions_with_unknown_source_strategy():
     """Review fix #7 + #8: a decision citing a source outside the known
-    strategy set can't be rendered as cell lineage — drop it."""
+    strategy set can't be rendered as cell lineage — the cross-check drops it.
+    The reconciler (#88) then synthesizes a replacement so 1:1 is satisfied."""
     llm = _FakeLLM(
         {
             "composed_fields": {"ram_gb": 16},
@@ -291,7 +311,12 @@ def test_composer_drops_decisions_with_unknown_source_strategy():
         }
     )
     result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
-    assert result.output.attributes["composer_decisions"] == []
+    decisions = result.output.attributes["composer_decisions"]
+    # The unknown-source decision was dropped; a synthesized replacement exists.
+    assert len(decisions) == 1
+    assert decisions[0]["key"] == "ram_gb"
+    assert decisions[0]["reason"] == "decision_synthesized_from_composed_fields"
+    assert result.output.attributes.get("incomplete_decisions") is True
 
 
 def test_composer_deterministic_fallback_when_llm_fails():
@@ -327,7 +352,10 @@ def test_composer_deterministic_fallback_when_llm_fails():
 def test_composer_registered_with_disjoint_keys():
     assert "composer_v1" in registry.all_known_keys()
     keys = registry.output_keys("composer_v1")
-    assert keys == frozenset({"composed_fields", "composer_decisions", "composed_at"})
+    # incomplete_decisions added in #88 to surface reconciler synthesis gaps.
+    assert keys == frozenset(
+        {"composed_fields", "composer_decisions", "composed_at", "incomplete_decisions"}
+    )
 
 
 def test_specialist_narrative_keys_registered_via_registry():
@@ -338,3 +366,182 @@ def test_specialist_narrative_keys_registered_via_registry():
     assert "specialist_buyer_questions" in narrative
     # Structured output is NOT narrative.
     assert "specialist_use_case_fit" not in narrative
+
+
+# ---------------------------------------------------------------------------
+# Issue #88 — 1:1 enforcement + source_kind provenance tests
+# All tests below use synthetic fixtures only; live mocklaptops validation is
+# deferred pending task #12 (composer uniformly empty on 200 products).
+# ---------------------------------------------------------------------------
+
+
+def test_composer_output_has_1_to_1_keys_happy_path():
+    """All composed_fields keys have matching decisions after reconciliation."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {"ram_gb": 16, "product_type": "laptop", "weight_kg": 1.12},
+            "composer_decisions": [
+                {
+                    "key": "ram_gb",
+                    "chosen_value": 16,
+                    "source_strategy": "parser_v1",
+                    "reason": "grounded in title",
+                    "dropped_alternatives": [],
+                },
+                {
+                    "key": "product_type",
+                    "chosen_value": "laptop",
+                    "source_strategy": "taxonomy_v1",
+                    "reason": "canonical classifier",
+                    "dropped_alternatives": [],
+                },
+                {
+                    "key": "weight_kg",
+                    "chosen_value": 1.12,
+                    "source_strategy": "scraper_v1",
+                    "reason": "manufacturer page",
+                    "dropped_alternatives": [],
+                },
+            ],
+        }
+    )
+    result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    attrs = result.output.attributes
+    composed_keys = set(attrs["composed_fields"].keys())
+    decision_keys = {d["key"] for d in attrs["composer_decisions"]}
+    assert composed_keys == decision_keys
+
+
+def test_composer_synthesizes_decision_for_orphan_composed_key():
+    """When LLM emits a composed key without a matching decision, the
+    reconciler synthesizes one marked source_kind=PARAMETRIC with the
+    canonical reason string, and sets incomplete_decisions=True."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {"cpu": "Intel i7", "ram_gb": 16},
+            "composer_decisions": [
+                # ram_gb has a decision; cpu does NOT
+                {
+                    "key": "ram_gb",
+                    "chosen_value": 16,
+                    "source_strategy": "parser_v1",
+                    "reason": "grounded",
+                    "dropped_alternatives": [],
+                }
+            ],
+        }
+    )
+    result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    attrs = result.output.attributes
+
+    # 1:1 is satisfied after reconciliation
+    composed_keys = set(attrs["composed_fields"].keys())
+    decision_keys = {d["key"] for d in attrs["composer_decisions"]}
+    assert composed_keys == decision_keys
+
+    # Synthesized decision for the orphan key
+    cpu_decision = next(d for d in attrs["composer_decisions"] if d["key"] == "cpu")
+    assert cpu_decision["reason"] == "decision_synthesized_from_composed_fields"
+    assert cpu_decision["source_kind"] == SourceKind.PARAMETRIC.value
+
+    # Flag is set so the inspector can surface the gap
+    assert attrs.get("incomplete_decisions") is True
+
+
+def test_source_kind_inference_from_source_strategy():
+    """For every entry in _STRATEGY_TO_SOURCE_KIND, the reconciler assigns
+    the correct SourceKind to an existing decision."""
+    for strategy, expected_kind in _STRATEGY_TO_SOURCE_KIND.items():
+        composed = {"some_key": "some_value"}
+        decisions = [
+            {
+                "key": "some_key",
+                "chosen_value": "some_value",
+                "source_strategy": strategy,
+                "reason": "test",
+                "dropped_alternatives": [],
+            }
+        ]
+        reconciled, _ = _reconcile_composer_output(composed, decisions)
+        assert len(reconciled) == 1
+        assert reconciled[0]["source_kind"] == expected_kind.value, (
+            f"strategy={strategy!r}: expected {expected_kind.value!r}, "
+            f"got {reconciled[0]['source_kind']!r}"
+        )
+
+
+def test_unknown_source_strategy_defaults_to_parametric(caplog):
+    """An unrecognised source_strategy falls back to PARAMETRIC and emits
+    a warning log so the gap is surfaceable in tracing."""
+    import logging
+
+    composed = {"some_key": "some_value"}
+    decisions = [
+        {
+            "key": "some_key",
+            "chosen_value": "some_value",
+            "source_strategy": "future_agent_v1",
+            "reason": "test",
+            "dropped_alternatives": [],
+        }
+    ]
+    with caplog.at_level(logging.WARNING, logger="app.enrichment.agents.composer"):
+        reconciled, _ = _reconcile_composer_output(composed, decisions)
+
+    assert reconciled[0]["source_kind"] == SourceKind.PARAMETRIC.value
+    # The warning message includes the unknown strategy name either in the
+    # formatted message or in the args tuple (depending on log handler).
+    warning_texts = " ".join(
+        record.getMessage() for record in caplog.records
+        if record.levelname == "WARNING"
+    )
+    assert "future_agent_v1" in warning_texts, (
+        f"Expected warning mentioning 'future_agent_v1', got: {warning_texts!r}"
+    )
+
+
+def test_reconcile_does_not_set_incomplete_decisions_when_all_present():
+    """When all composed keys have decisions, incomplete_decisions must NOT
+    be set (no false positives in the inspector)."""
+    composed = {"a": 1, "b": 2}
+    decisions = [
+        {"key": "a", "chosen_value": 1, "source_strategy": "parser_v1",
+         "reason": "r", "dropped_alternatives": []},
+        {"key": "b", "chosen_value": 2, "source_strategy": "taxonomy_v1",
+         "reason": "r", "dropped_alternatives": []},
+    ]
+    reconciled, notes = _reconcile_composer_output(composed, decisions)
+    assert "incomplete_decisions" not in notes
+    assert {d["key"] for d in reconciled} == {"a", "b"}
+
+
+def test_source_kind_set_on_decisions_via_full_agent_run():
+    """End-to-end: source_kind appears on every decision in the agent output."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {"ram_gb": 16, "product_type": "laptop"},
+            "composer_decisions": [
+                {
+                    "key": "ram_gb",
+                    "chosen_value": 16,
+                    "source_strategy": "parser_v1",
+                    "reason": "grounded",
+                    "dropped_alternatives": [],
+                },
+                {
+                    "key": "product_type",
+                    "chosen_value": "laptop",
+                    "source_strategy": "taxonomy_v1",
+                    "reason": "canonical",
+                    "dropped_alternatives": [],
+                },
+            ],
+        }
+    )
+    result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    decisions = result.output.attributes["composer_decisions"]
+    assert all("source_kind" in d for d in decisions)
+    ram_d = next(d for d in decisions if d["key"] == "ram_gb")
+    pt_d = next(d for d in decisions if d["key"] == "product_type")
+    assert ram_d["source_kind"] == SourceKind.RAW_PARSE.value
+    assert pt_d["source_kind"] == SourceKind.PARAMETRIC.value

--- a/mcp-server/tests/enrichment/test_runner.py
+++ b/mcp-server/tests/enrichment/test_runner.py
@@ -216,8 +216,8 @@ def test_run_reports_avg_keys_filled(patched_runtime):
     avg = result.summary.to_dict()["avg_keys_filled_per_product"]
     # Each successful agent contributes its OUTPUT_KEYS count;
     # taxonomy(3) + parser(3) + specialist(4) + scraper(6) + soft_tagger(2)
-    # + composer(3: composed_fields, composer_decisions, composed_at) = 21
-    assert avg == 21.0
+    # + composer(4: composed_fields, composer_decisions, composed_at, incomplete_decisions) = 22
+    assert avg == 22.0
 
 
 def test_orchestrated_run_skips_scraper_when_no_url(patched_runtime):


### PR DESCRIPTION
## Problem — issue #88

`composer_v1` frequently emits keys in `composed_fields` without matching entries in `composer_decisions`. Live evidence: `cpu`, `category`, `brand`, `color` ship without decisions on mocklaptops. This breaks the cell-lineage panel from #86 (falls back to \"no decisions entry\" copy) and removes auditable provenance for shipped cells.

## What this PR does

### 1:1 enforcement — `_reconcile_composer_output` (lenient-with-synthesis policy)

After the LLM returns (and after narrative strip + cross-check), a new reconciler pass enforces 1:1:

- For every key in `composed_fields` with **no matching decision**: synthesize a `ComposerDecision` with `reason='decision_synthesized_from_composed_fields'` and `source_kind=PARAMETRIC`.
- Set `attributes['incomplete_decisions'] = True` so the inspector can surface the gap without re-parsing all decisions.
- The row ships in full — synthesis is lenient, not blocking.

`COMPOSER_SYSTEM_PROMPT` gains an explicit policy 7 requiring 1:1 (belt-and-braces alongside the Python post-check).

### `SourceKind` provenance enum — vision bullet 3

New enum on `ComposerDecision.source_kind`:

| Value | Meaning |
|-------|---------|
| `raw_parse` | `parser_v1` — extracted from raw catalog text |
| `scrape` | `scraper_v1` — crawled manufacturer page |
| `parametric` | `specialist_v1`, `taxonomy_v1`, `soft_tagger_v1`, composer alone |
| `deterministic_fallback` | rule-based / pass-through |

`_STRATEGY_TO_SOURCE_KIND` drives reconciler inference. The reconciler **always** overrides `source_kind` from `source_strategy` (not from LLM output / pydantic default), so coverage-by-source becomes a simple group-by on the decisions table.

### Other changes

- `incomplete_decisions` added to `OUTPUT_KEYS` (base-class disjoint-key validation requires it).
- `_cross_check_decisions` known-sources set now derived from `_STRATEGY_TO_SOURCE_KIND` (adds `composer_v1`, `echoes_raw`).
- 4 existing tests updated to reflect reconciler behavior (lying/unknown decisions now result in synthesized replacements, not empty decision lists).

## `_STRATEGY_TO_SOURCE_KIND` mapping

```
parser_v1      → raw_parse          (LLM extraction from raw catalog text)
scraper_v1     → scrape             (crawled manufacturer page)
specialist_v1  → parametric         (LLM world knowledge, no direct evidence)
taxonomy_v1    → parametric         (LLM classifier)
soft_tagger_v1 → parametric         (LLM soft-tag inference)
composer_v1    → parametric         (composer acting alone)
echoes_raw     → raw_parse          (pass-through of raw_attributes value)
```

## Test plan

6 new tests, all synthetic-fixture only:

- `test_composer_output_has_1_to_1_keys_happy_path` — all decisions present; key sets match.
- `test_composer_synthesizes_decision_for_orphan_composed_key` — LLM emits `{cpu: "i7"}` without a decision; reconciler synthesizes one; `incomplete_decisions=True`.
- `test_source_kind_inference_from_source_strategy` — parametrised over all `_STRATEGY_TO_SOURCE_KIND` entries; asserts correct `SourceKind`.
- `test_unknown_source_strategy_defaults_to_parametric` — `future_agent_v1`; asserts `PARAMETRIC` and warning logged.
- `test_reconcile_does_not_set_incomplete_decisions_when_all_present` — no false positives.
- `test_source_kind_set_on_decisions_via_full_agent_run` — end-to-end; `source_kind` on all decisions.

**Live validation deferred.** The mocklaptops enrichment run currently returns uniformly empty composer output across all 200 products (composer is invoked but the LLM path produces empty `composed_fields`). Root cause is under investigation in task #12. Re-running live validation against a working fixture is not possible in this PR without blocking on an unrelated bug.

## Related

- #88 — the bug this closes in part
- #86 — inspector lineage panel; `incomplete_decisions` flag surfaces directly in that UI
- #83 — composer_v1 original PR (cross-check, narrative strip)
- Task #12 — live mocklaptops composer output empty (separate investigation)