### PR TITLE
feat(inspector): Coverage tab (vision bullet 3) — per-merchant cell breakdown by source_kind

### DIFF
--- a/mcp-server/app/enrichment/agents/composer.py
+++ b/mcp-server/app/enrichment/agents/composer.py
@@ -1,4 +1,4 @@
-"""composer_v1 — single writer of the canonical enriched row (issue #83).
+"""composer_v1 — single writer of the canonical enriched row (issues #83, #88).
 
 Today's enrichment pipeline lets every strategy (taxonomy, parser, specialist,
 scraper, soft_tagger) write its own (product_id, strategy, attributes) row;
@@ -13,8 +13,8 @@ The composer is the structural fix: it is the **only** agent allowed to
 emit canonical catalog fields. Every other strategy still writes its own
 row — but downstream readers prefer composer output when present.
 
-v1 scope (this commit)
-----------------------
+v1 scope
+--------
   - Reads every upstream strategy's output from the runner's ``context``
     dict (populated in orchestration/runner.py: ``ctx[_short(strategy)] =
     output.attributes``).
@@ -48,6 +48,37 @@ v1 scope (this commit)
         composer_decisions    list[ComposerDecision] — audit log for the
                               cell-lineage UX in #81
         composed_at           ISO timestamp
+
+1:1 enforcement policy (issue #88)
+------------------------------------
+Every key in ``composed_fields`` MUST have a matching entry in
+``composer_decisions``. The composer instructs the LLM to comply, but compliance
+is not guaranteed. After the LLM returns, ``_reconcile_composer_output`` enforces
+this **leniently with synthesis**: any composed key that has no decision gets a
+synthesized ``ComposerDecision`` marked ``source_kind=PARAMETRIC`` and
+``reason='decision_synthesized_from_composed_fields'``. The row ships in full;
+``attributes['incomplete_decisions'] = True`` flags the gap for the inspector.
+
+source_kind provenance taxonomy (vision bullet 3 / #88)
+--------------------------------------------------------
+``ComposerDecision.source_kind`` (a ``SourceKind`` enum) classifies each
+composed field by how its value was obtained:
+
+  RAW_PARSE            — parser_v1 extracted it from raw catalog text
+  SCRAPE               — scraper_v1 crawled the manufacturer page
+  PARAMETRIC           — LLM world knowledge (specialist_v1, taxonomy_v1,
+                         soft_tagger_v1, composer alone, or echoes from raw)
+  DETERMINISTIC_FALLBACK — rule-based pass-through (no LLM inference)
+
+The reconciler infers ``source_kind`` from ``source_strategy`` via
+``_STRATEGY_TO_SOURCE_KIND``. If ``source_strategy`` is unknown, the field
+defaults to ``PARAMETRIC`` and a warning is logged so the gap is visible.
+
+Live validation caveat
+-----------------------
+The live mocklaptops enrichment run currently returns uniformly empty composer
+output (task #12 investigates root cause). All validation for this PR is
+therefore synthetic-fixture-only — see ``tests/enrichment/test_composer.py``.
 
 # _TODO(closed_loop) — #85 attach points
 # ---------------------------------------
@@ -87,7 +118,7 @@ from pydantic import ValidationError
 from app.enrichment import registry
 from app.enrichment.base import BaseEnrichmentAgent
 from app.enrichment.tools.llm_client import LLMClient, composer_model
-from app.enrichment.types import ComposerDecision, ProductInput, StrategyOutput
+from app.enrichment.types import ComposerDecision, ProductInput, SourceKind, StrategyOutput
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +145,31 @@ _SHORT_TO_STRATEGY: dict[str, str] = {
     "specialist": "specialist_v1",
     "scraped": "scraper_v1",
     "soft_tagger": "soft_tagger_v1",
+}
+
+
+# Maps each known source_strategy to its SourceKind provenance bucket.
+# Used by _reconcile_composer_output to populate source_kind on each
+# ComposerDecision without requiring the LLM to do so (it often omits it).
+# Unknown source_strategy values fall back to PARAMETRIC with a warning.
+#
+# Mapping rationale:
+#   parser_v1      — LLM extraction from raw text → RAW_PARSE
+#   scraper_v1     — crawled manufacturer page → SCRAPE
+#   specialist_v1  — LLM world knowledge, no direct evidence → PARAMETRIC
+#   taxonomy_v1    — LLM classifier, no raw evidence → PARAMETRIC
+#   soft_tagger_v1 — LLM soft-tag inference → PARAMETRIC
+#   composer_v1    — composer acting alone (no upstream contributed) → PARAMETRIC
+#   echoes_raw     — literal pass-through reason from echo discipline → RAW_PARSE
+#                    (the value came from raw_attributes, which is raw catalog input)
+_STRATEGY_TO_SOURCE_KIND: dict[str, SourceKind] = {
+    "parser_v1": SourceKind.RAW_PARSE,
+    "scraper_v1": SourceKind.SCRAPE,
+    "specialist_v1": SourceKind.PARAMETRIC,
+    "taxonomy_v1": SourceKind.PARAMETRIC,
+    "soft_tagger_v1": SourceKind.PARAMETRIC,
+    "composer_v1": SourceKind.PARAMETRIC,
+    "echoes_raw": SourceKind.RAW_PARSE,
 }
 
 
@@ -166,6 +222,12 @@ _SYSTEM = (
     "  6. Only reference strategies listed in the 'available_findings' "
     "section of the user prompt. If a strategy didn't run, do not invent "
     "a source_strategy for it.\n"
+    "  7. 1:1 requirement. For every key you emit in `composed_fields`, "
+    "you MUST emit a matching entry in `composer_decisions` with `key` "
+    "equal to that field name. Do not ship a composed value without a "
+    "decision — the Python post-check will synthesize missing decisions "
+    "and flag the gap, but a missing decision breaks cell lineage in the "
+    "inspector.\n"
     "\n"
     + _PRECEDENCE_NOTE
     + "\n\n"
@@ -182,7 +244,13 @@ _SYSTEM = (
 @registry.register
 class ComposerAgent(BaseEnrichmentAgent):
     STRATEGY = "composer_v1"
-    OUTPUT_KEYS = frozenset({"composed_fields", "composer_decisions", "composed_at"})
+    OUTPUT_KEYS = frozenset({
+        "composed_fields", "composer_decisions", "composed_at",
+        # incomplete_decisions is set to True when the reconciler had to
+        # synthesize decisions for keys the LLM omitted from composer_decisions.
+        # Presence flags the gap for the inspector (#88).
+        "incomplete_decisions",
+    })
     DEFAULT_MODEL = "gpt-5"
 
     def __init__(self, llm: LLMClient | None = None) -> None:
@@ -241,6 +309,7 @@ class ComposerAgent(BaseEnrichmentAgent):
             composed, decisions = _deterministic_fallback(findings)
             composed = registry_strip_narrative(composed)
             composed, decisions = _cross_check_decisions(composed, decisions)
+            decisions, notes_payload = _reconcile_composer_output(composed, decisions)
             return StrategyOutput(
                 product_id=product.product_id,
                 strategy=self.STRATEGY,
@@ -249,6 +318,7 @@ class ComposerAgent(BaseEnrichmentAgent):
                     "composed_fields": composed,
                     "composer_decisions": decisions,
                     "composed_at": now_iso,
+                    **notes_payload,
                 },
                 notes="deterministic_fallback",
             )
@@ -259,6 +329,10 @@ class ComposerAgent(BaseEnrichmentAgent):
         composed = registry_strip_narrative(composed)
         composed, decisions = _cross_check_decisions(composed, decisions)
 
+        # 1:1 enforcement (issue #88): synthesize missing decisions and infer
+        # source_kind for all existing decisions.
+        decisions, notes_payload = _reconcile_composer_output(composed, decisions)
+
         return StrategyOutput(
             product_id=product.product_id,
             strategy=self.STRATEGY,
@@ -267,6 +341,7 @@ class ComposerAgent(BaseEnrichmentAgent):
                 "composed_fields": composed,
                 "composer_decisions": decisions,
                 "composed_at": now_iso,
+                **notes_payload,
             },
         )
 
@@ -366,7 +441,7 @@ def _cross_check_decisions(
     catches the LLM lying about its own decisions, per #83 review item 7.
     Decisions with ``source_strategy`` outside the known upstream set are
     also dropped (can't lineage-render an unknown source)."""
-    known_sources = frozenset(_SHORT_TO_STRATEGY.values()) | {None}
+    known_sources = frozenset(_STRATEGY_TO_SOURCE_KIND.keys()) | {None}
     kept: list[dict[str, Any]] = []
     for d in decisions:
         key = d.get("key")
@@ -384,6 +459,73 @@ def _cross_check_decisions(
             continue
         kept.append(d)
     return composed, kept
+
+
+def _reconcile_composer_output(
+    composed_fields: dict[str, Any],
+    composer_decisions: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Enforce 1:1 between composed_fields keys and composer_decisions entries.
+
+    Policy: lenient with synthesis. For any composed key without a decision,
+    synthesize a ComposerDecision marked source_kind=PARAMETRIC and
+    reason='decision_synthesized_from_composed_fields'. The output ships in
+    full but the gap is visible in the trace and surfaceable in the inspector.
+
+    Also ensures source_kind is populated on every existing decision:
+    inferred from source_strategy via _STRATEGY_TO_SOURCE_KIND. If the
+    source_strategy is not in the mapping, defaults to PARAMETRIC and emits
+    a warning.
+
+    Returns (reconciled_decisions, notes_payload). notes_payload contains
+    'incomplete_decisions': True if any synthesis happened.
+    """
+    # Index existing decisions by key for O(1) lookup.
+    decision_by_key: dict[str, dict[str, Any]] = {
+        d["key"]: d for d in composer_decisions if isinstance(d.get("key"), str)
+    }
+
+    reconciled: list[dict[str, Any]] = []
+    synthesized_any = False
+
+    for key, value in composed_fields.items():
+        if key in decision_by_key:
+            d = dict(decision_by_key[key])
+        else:
+            # Orphan composed key — synthesize a decision.
+            logger.warning(
+                "composer_missing_decision_synthesized",
+                extra={"key": key},
+            )
+            d = {
+                "key": key,
+                "chosen_value": value,
+                "source_strategy": None,
+                "reason": "decision_synthesized_from_composed_fields",
+                "dropped_alternatives": [],
+            }
+            synthesized_any = True
+
+        # Always infer source_kind from source_strategy so the authoritative
+        # mapping drives provenance (not the LLM's or pydantic's default).
+        src = d.get("source_strategy")
+        if src is not None and src not in _STRATEGY_TO_SOURCE_KIND:
+            logger.warning(
+                "composer_unknown_source_strategy_defaulting_to_parametric: "
+                "strategy=%s key=%s",
+                src,
+                key,
+            )
+        kind = _STRATEGY_TO_SOURCE_KIND.get(src, SourceKind.PARAMETRIC)
+        d["source_kind"] = kind.value
+
+        reconciled.append(d)
+
+    notes_payload: dict[str, Any] = {}
+    if synthesized_any:
+        notes_payload["incomplete_decisions"] = True
+
+    return reconciled, notes_payload
 
 
 def registry_strip_narrative(composed: dict[str, Any]) -> dict[str, Any]:

--- a/mcp-server/app/enrichment/types.py
+++ b/mcp-server/app/enrichment/types.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from enum import Enum
 from typing import Any, Literal
 from uuid import UUID
 
@@ -146,6 +147,26 @@ class ProposalAck(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class SourceKind(str, Enum):
+    """Provenance taxonomy for a single composed field (vision bullet 3 / #88).
+
+    Enables the coverage dashboard to count what fraction of canonical fields
+    come from parsing raw input vs. crawling vs. LLM world knowledge.
+
+    RAW_PARSE            — fact extracted directly from raw catalog input (parser_v1)
+    SCRAPE               — fact extracted from a crawled manufacturer page (scraper_v1)
+    PARAMETRIC           — LLM produced from world/parametric knowledge
+                           (specialist_v1, taxonomy_v1, soft_tagger_v1, or
+                           composer alone when no upstream contributed)
+    DETERMINISTIC_FALLBACK — rule-based / formula / pass-through; no LLM inference
+    """
+
+    RAW_PARSE = "raw_parse"
+    SCRAPE = "scrape"
+    PARAMETRIC = "parametric"
+    DETERMINISTIC_FALLBACK = "deterministic_fallback"
+
+
 class ComposerDecision(BaseModel):
     """One entry in ``composer_decisions``. Structured schema lets the
     inspector (#81) render cell lineage without re-parsing free-form JSON."""
@@ -153,5 +174,6 @@ class ComposerDecision(BaseModel):
     key: str
     chosen_value: Any = None
     source_strategy: str | None = None
+    source_kind: SourceKind = SourceKind.PARAMETRIC  # safe default; reconciler overrides per source_strategy
     reason: str | None = None
     dropped_alternatives: list[Any] = Field(default_factory=list)

--- a/mcp-server/tests/enrichment/test_composer.py
+++ b/mcp-server/tests/enrichment/test_composer.py
@@ -1,4 +1,4 @@
-"""composer_v1 — single writer of the canonical enriched row (issue #83)."""
+"""composer_v1 — single writer of the canonical enriched row (issues #83, #88)."""
 
 from __future__ import annotations
 
@@ -8,10 +8,14 @@ from uuid import uuid4
 import pytest
 
 from app.enrichment import registry
-from app.enrichment.agents.composer import ComposerAgent
+from app.enrichment.agents.composer import (
+    ComposerAgent,
+    _STRATEGY_TO_SOURCE_KIND,
+    _reconcile_composer_output,
+)
 from app.enrichment.agents.specialist import SpecialistAgent
 from app.enrichment.tools.llm_client import LLMResponse
-from app.enrichment.types import ProductInput
+from app.enrichment.types import ProductInput, SourceKind
 
 
 @pytest.fixture(autouse=True)
@@ -114,8 +118,12 @@ def test_composer_emits_composed_fields_and_decisions():
         "storage_gb": 512,
         "good_for_business": 0.9,
     }
-    assert attrs["composer_decisions"][0]["key"] == "ram_gb"
-    assert attrs["composer_decisions"][0]["source_strategy"] == "parser_v1"
+    # The reconciler (#88) ensures all 4 composed keys have decisions; the
+    # LLM only provided ram_gb so the other 3 are synthesized.
+    decision_keys = {d["key"] for d in attrs["composer_decisions"]}
+    assert decision_keys == {"product_type", "ram_gb", "storage_gb", "good_for_business"}
+    ram_decision = next(d for d in attrs["composer_decisions"] if d["key"] == "ram_gb")
+    assert ram_decision["source_strategy"] == "parser_v1"
     assert "composed_at" in attrs
 
 
@@ -245,7 +253,9 @@ def test_composer_coerces_malformed_llm_output():
 
 def test_composer_drops_decisions_that_lie_about_their_key():
     """Review fix #7: a decision whose chosen_value != composed_fields[key]
-    is the LLM lying about its own choice; drop it from the audit log."""
+    is the LLM lying about its own choice; drop it from the audit log.
+    The reconciler (#88) then synthesizes a replacement for the dropped key
+    so 1:1 is still satisfied."""
     llm = _FakeLLM(
         {
             "composed_fields": {"ram_gb": 16, "storage_gb": 512},
@@ -269,13 +279,23 @@ def test_composer_drops_decisions_that_lie_about_their_key():
     )
     result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
     decisions = result.output.attributes["composer_decisions"]
-    assert len(decisions) == 1
-    assert decisions[0]["key"] == "storage_gb"
+    # 1:1 is enforced: both keys are represented (ram_gb via synthesis).
+    assert {d["key"] for d in decisions} == {"ram_gb", "storage_gb"}
+    # The honest storage_gb decision is preserved as-is.
+    storage_d = next(d for d in decisions if d["key"] == "storage_gb")
+    assert storage_d["reason"] == "grounded"
+    # The lying ram_gb decision was dropped; the synthesized replacement
+    # carries the reconciler's reason.
+    ram_d = next(d for d in decisions if d["key"] == "ram_gb")
+    assert ram_d["reason"] == "decision_synthesized_from_composed_fields"
+    # incomplete_decisions flag is set because synthesis occurred.
+    assert result.output.attributes.get("incomplete_decisions") is True
 
 
 def test_composer_drops_decisions_with_unknown_source_strategy():
     """Review fix #7 + #8: a decision citing a source outside the known
-    strategy set can't be rendered as cell lineage — drop it."""
+    strategy set can't be rendered as cell lineage — the cross-check drops it.
+    The reconciler (#88) then synthesizes a replacement so 1:1 is satisfied."""
     llm = _FakeLLM(
         {
             "composed_fields": {"ram_gb": 16},
@@ -291,7 +311,12 @@ def test_composer_drops_decisions_with_unknown_source_strategy():
         }
     )
     result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
-    assert result.output.attributes["composer_decisions"] == []
+    decisions = result.output.attributes["composer_decisions"]
+    # The unknown-source decision was dropped; a synthesized replacement exists.
+    assert len(decisions) == 1
+    assert decisions[0]["key"] == "ram_gb"
+    assert decisions[0]["reason"] == "decision_synthesized_from_composed_fields"
+    assert result.output.attributes.get("incomplete_decisions") is True
 
 
 def test_composer_deterministic_fallback_when_llm_fails():
@@ -327,7 +352,10 @@ def test_composer_deterministic_fallback_when_llm_fails():
 def test_composer_registered_with_disjoint_keys():
     assert "composer_v1" in registry.all_known_keys()
     keys = registry.output_keys("composer_v1")
-    assert keys == frozenset({"composed_fields", "composer_decisions", "composed_at"})
+    # incomplete_decisions added in #88 to surface reconciler synthesis gaps.
+    assert keys == frozenset(
+        {"composed_fields", "composer_decisions", "composed_at", "incomplete_decisions"}
+    )
 
 
 def test_specialist_narrative_keys_registered_via_registry():
@@ -338,3 +366,182 @@ def test_specialist_narrative_keys_registered_via_registry():
     assert "specialist_buyer_questions" in narrative
     # Structured output is NOT narrative.
     assert "specialist_use_case_fit" not in narrative
+
+
+# ---------------------------------------------------------------------------
+# Issue #88 — 1:1 enforcement + source_kind provenance tests
+# All tests below use synthetic fixtures only; live mocklaptops validation is
+# deferred pending task #12 (composer uniformly empty on 200 products).
+# ---------------------------------------------------------------------------
+
+
+def test_composer_output_has_1_to_1_keys_happy_path():
+    """All composed_fields keys have matching decisions after reconciliation."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {"ram_gb": 16, "product_type": "laptop", "weight_kg": 1.12},
+            "composer_decisions": [
+                {
+                    "key": "ram_gb",
+                    "chosen_value": 16,
+                    "source_strategy": "parser_v1",
+                    "reason": "grounded in title",
+                    "dropped_alternatives": [],
+                },
+                {
+                    "key": "product_type",
+                    "chosen_value": "laptop",
+                    "source_strategy": "taxonomy_v1",
+                    "reason": "canonical classifier",
+                    "dropped_alternatives": [],
+                },
+                {
+                    "key": "weight_kg",
+                    "chosen_value": 1.12,
+                    "source_strategy": "scraper_v1",
+                    "reason": "manufacturer page",
+                    "dropped_alternatives": [],
+                },
+            ],
+        }
+    )
+    result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    attrs = result.output.attributes
+    composed_keys = set(attrs["composed_fields"].keys())
+    decision_keys = {d["key"] for d in attrs["composer_decisions"]}
+    assert composed_keys == decision_keys
+
+
+def test_composer_synthesizes_decision_for_orphan_composed_key():
+    """When LLM emits a composed key without a matching decision, the
+    reconciler synthesizes one marked source_kind=PARAMETRIC with the
+    canonical reason string, and sets incomplete_decisions=True."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {"cpu": "Intel i7", "ram_gb": 16},
+            "composer_decisions": [
+                # ram_gb has a decision; cpu does NOT
+                {
+                    "key": "ram_gb",
+                    "chosen_value": 16,
+                    "source_strategy": "parser_v1",
+                    "reason": "grounded",
+                    "dropped_alternatives": [],
+                }
+            ],
+        }
+    )
+    result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    attrs = result.output.attributes
+
+    # 1:1 is satisfied after reconciliation
+    composed_keys = set(attrs["composed_fields"].keys())
+    decision_keys = {d["key"] for d in attrs["composer_decisions"]}
+    assert composed_keys == decision_keys
+
+    # Synthesized decision for the orphan key
+    cpu_decision = next(d for d in attrs["composer_decisions"] if d["key"] == "cpu")
+    assert cpu_decision["reason"] == "decision_synthesized_from_composed_fields"
+    assert cpu_decision["source_kind"] == SourceKind.PARAMETRIC.value
+
+    # Flag is set so the inspector can surface the gap
+    assert attrs.get("incomplete_decisions") is True
+
+
+def test_source_kind_inference_from_source_strategy():
+    """For every entry in _STRATEGY_TO_SOURCE_KIND, the reconciler assigns
+    the correct SourceKind to an existing decision."""
+    for strategy, expected_kind in _STRATEGY_TO_SOURCE_KIND.items():
+        composed = {"some_key": "some_value"}
+        decisions = [
+            {
+                "key": "some_key",
+                "chosen_value": "some_value",
+                "source_strategy": strategy,
+                "reason": "test",
+                "dropped_alternatives": [],
+            }
+        ]
+        reconciled, _ = _reconcile_composer_output(composed, decisions)
+        assert len(reconciled) == 1
+        assert reconciled[0]["source_kind"] == expected_kind.value, (
+            f"strategy={strategy!r}: expected {expected_kind.value!r}, "
+            f"got {reconciled[0]['source_kind']!r}"
+        )
+
+
+def test_unknown_source_strategy_defaults_to_parametric(caplog):
+    """An unrecognised source_strategy falls back to PARAMETRIC and emits
+    a warning log so the gap is surfaceable in tracing."""
+    import logging
+
+    composed = {"some_key": "some_value"}
+    decisions = [
+        {
+            "key": "some_key",
+            "chosen_value": "some_value",
+            "source_strategy": "future_agent_v1",
+            "reason": "test",
+            "dropped_alternatives": [],
+        }
+    ]
+    with caplog.at_level(logging.WARNING, logger="app.enrichment.agents.composer"):
+        reconciled, _ = _reconcile_composer_output(composed, decisions)
+
+    assert reconciled[0]["source_kind"] == SourceKind.PARAMETRIC.value
+    # The warning message includes the unknown strategy name either in the
+    # formatted message or in the args tuple (depending on log handler).
+    warning_texts = " ".join(
+        record.getMessage() for record in caplog.records
+        if record.levelname == "WARNING"
+    )
+    assert "future_agent_v1" in warning_texts, (
+        f"Expected warning mentioning 'future_agent_v1', got: {warning_texts!r}"
+    )
+
+
+def test_reconcile_does_not_set_incomplete_decisions_when_all_present():
+    """When all composed keys have decisions, incomplete_decisions must NOT
+    be set (no false positives in the inspector)."""
+    composed = {"a": 1, "b": 2}
+    decisions = [
+        {"key": "a", "chosen_value": 1, "source_strategy": "parser_v1",
+         "reason": "r", "dropped_alternatives": []},
+        {"key": "b", "chosen_value": 2, "source_strategy": "taxonomy_v1",
+         "reason": "r", "dropped_alternatives": []},
+    ]
+    reconciled, notes = _reconcile_composer_output(composed, decisions)
+    assert "incomplete_decisions" not in notes
+    assert {d["key"] for d in reconciled} == {"a", "b"}
+
+
+def test_source_kind_set_on_decisions_via_full_agent_run():
+    """End-to-end: source_kind appears on every decision in the agent output."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {"ram_gb": 16, "product_type": "laptop"},
+            "composer_decisions": [
+                {
+                    "key": "ram_gb",
+                    "chosen_value": 16,
+                    "source_strategy": "parser_v1",
+                    "reason": "grounded",
+                    "dropped_alternatives": [],
+                },
+                {
+                    "key": "product_type",
+                    "chosen_value": "laptop",
+                    "source_strategy": "taxonomy_v1",
+                    "reason": "canonical",
+                    "dropped_alternatives": [],
+                },
+            ],
+        }
+    )
+    result = ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
+    decisions = result.output.attributes["composer_decisions"]
+    assert all("source_kind" in d for d in decisions)
+    ram_d = next(d for d in decisions if d["key"] == "ram_gb")
+    pt_d = next(d for d in decisions if d["key"] == "product_type")
+    assert ram_d["source_kind"] == SourceKind.RAW_PARSE.value
+    assert pt_d["source_kind"] == SourceKind.PARAMETRIC.value

--- a/mcp-server/tests/enrichment/test_runner.py
+++ b/mcp-server/tests/enrichment/test_runner.py
@@ -216,8 +216,8 @@ def test_run_reports_avg_keys_filled(patched_runtime):
     avg = result.summary.to_dict()["avg_keys_filled_per_product"]
     # Each successful agent contributes its OUTPUT_KEYS count;
     # taxonomy(3) + parser(3) + specialist(4) + scraper(6) + soft_tagger(2)
-    # + composer(3: composed_fields, composer_decisions, composed_at) = 21
-    assert avg == 21.0
+    # + composer(4: composed_fields, composer_decisions, composed_at, incomplete_decisions) = 22
+    assert avg == 22.0
 
 
 def test_orchestrated_run_skips_scraper_when_no_url(patched_runtime):

--- a/mcp-server/tests/test_enrichment_inspector.py
+++ b/mcp-server/tests/test_enrichment_inspector.py
@@ -480,3 +480,197 @@ def test_composer_notes_preserves_explicit_empty_string(inspector_module):
         "updates": [{"output": {"notes": None}, "metadata": {}}],
     }
     assert inspector_module._composer_notes(span_none) is None
+
+
+# ---------------------------------------------------------------------------
+# compute_coverage_breakdown (PR #98 — Coverage tab)
+# ---------------------------------------------------------------------------
+#
+# The helper is a pure DB function (no Streamlit).  We fake the engine with
+# a simple mock rather than pulling in SQLite so we don't depend on the
+# real schema.  The Engine.connect() context-manager returns a connection
+# whose execute().mappings().all() returns our fixture rows.
+# ---------------------------------------------------------------------------
+
+
+class _FakeRow:
+    """Minimal mapping-like object returned by the fake cursor."""
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def __getitem__(self, key: str):
+        return self._data[key]
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[dict]):
+        self._rows = rows
+
+    def mappings(self):
+        return self
+
+    def all(self):
+        return [_FakeRow(r) for r in self._rows]
+
+
+class _FakeConn:
+    def __init__(self, rows: list[dict]):
+        self._rows = rows
+
+    def execute(self, *_args, **_kwargs):
+        return _FakeCursor(self._rows)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass
+
+
+class _FakeEngine:
+    def __init__(self, rows: list[dict]):
+        self._rows = rows
+
+    def connect(self):
+        return _FakeConn(self._rows)
+
+
+def _make_attrs(
+    composed_fields: dict,
+    decisions: list[dict] | None = None,
+    incomplete: bool = False,
+) -> dict:
+    """Helper: build the ``attributes`` JSONB dict that the enriched table stores."""
+    return {
+        "composed_fields": composed_fields,
+        "composer_decisions": decisions or [],
+        "incomplete_decisions": incomplete,
+    }
+
+
+def test_coverage_breakdown_empty_merchant(inspector_module):
+    """No rows → all-zero breakdown; no crash."""
+    engine = _FakeEngine([])
+    bd = inspector_module.compute_coverage_breakdown(engine, "default")
+    assert bd.total_products == 0
+    assert bd.total_cells == 0
+    assert bd.by_source_kind == {}
+    assert bd.by_attribute == {}
+    assert bd.missing_per_attribute == {}
+    assert bd.incomplete_decisions_count == 0
+
+
+def test_coverage_breakdown_single_product_mixed_source_kinds(inspector_module):
+    """Single product with 3 composed fields, one per source_kind bucket."""
+    decisions = [
+        {"key": "ram_gb", "chosen_value": 16,
+         "source_strategy": "parser_v1", "source_kind": "raw_parse",
+         "reason": "parsed", "dropped_alternatives": []},
+        {"key": "description", "chosen_value": "fast laptop",
+         "source_strategy": "specialist_v1", "source_kind": "parametric",
+         "reason": "generated", "dropped_alternatives": []},
+        {"key": "url", "chosen_value": "http://x.com",
+         "source_strategy": "scraper_v1", "source_kind": "scrape",
+         "reason": "scraped", "dropped_alternatives": []},
+    ]
+    attrs = _make_attrs(
+        composed_fields={"ram_gb": 16, "description": "fast laptop", "url": "http://x.com"},
+        decisions=decisions,
+    )
+    engine = _FakeEngine([{"attributes": attrs}])
+    bd = inspector_module.compute_coverage_breakdown(engine, "default")
+
+    assert bd.total_products == 1
+    assert bd.total_cells == 3
+    assert bd.by_source_kind.get("raw_parse") == 1
+    assert bd.by_source_kind.get("parametric") == 1
+    assert bd.by_source_kind.get("scrape") == 1
+    assert "unknown" not in bd.by_source_kind or bd.by_source_kind["unknown"] == 0
+    # Per-attribute counts.
+    assert bd.by_attribute["ram_gb"]["raw_parse"] == 1
+    assert bd.by_attribute["description"]["parametric"] == 1
+    assert bd.by_attribute["url"]["scrape"] == 1
+    # Nothing missing.
+    assert all(v == 0 for v in bd.missing_per_attribute.values())
+    assert bd.incomplete_decisions_count == 0
+
+
+def test_coverage_breakdown_incomplete_decisions_flag(inspector_module):
+    """A row with ``incomplete_decisions=True`` bumps the counter."""
+    attrs = _make_attrs(
+        composed_fields={"title": "Laptop"},
+        decisions=[
+            {"key": "title", "chosen_value": "Laptop",
+             "source_strategy": "specialist_v1", "source_kind": "parametric",
+             "reason": "synthesised", "dropped_alternatives": []}
+        ],
+        incomplete=True,
+    )
+    engine = _FakeEngine([{"attributes": attrs}])
+    bd = inspector_module.compute_coverage_breakdown(engine, "default")
+    assert bd.incomplete_decisions_count == 1
+
+
+def test_coverage_breakdown_missing_attribute(inspector_module):
+    """Two products; attribute only present in one → missing_per_attribute bumped."""
+    attrs_a = _make_attrs(
+        composed_fields={"ram_gb": 16, "storage_gb": 512},
+        decisions=[
+            {"key": "ram_gb", "chosen_value": 16,
+             "source_strategy": "parser_v1", "source_kind": "raw_parse",
+             "reason": "parsed", "dropped_alternatives": []},
+            {"key": "storage_gb", "chosen_value": 512,
+             "source_strategy": "parser_v1", "source_kind": "raw_parse",
+             "reason": "parsed", "dropped_alternatives": []},
+        ],
+    )
+    # Second product has ram_gb but not storage_gb.
+    attrs_b = _make_attrs(
+        composed_fields={"ram_gb": 8},
+        decisions=[
+            {"key": "ram_gb", "chosen_value": 8,
+             "source_strategy": "parser_v1", "source_kind": "raw_parse",
+             "reason": "parsed", "dropped_alternatives": []},
+        ],
+    )
+    engine = _FakeEngine([
+        {"attributes": attrs_a},
+        {"attributes": attrs_b},
+    ])
+    bd = inspector_module.compute_coverage_breakdown(engine, "default")
+    assert bd.total_products == 2
+    assert bd.total_cells == 3  # 2 from product A, 1 from product B
+    # storage_gb is missing on product B.
+    assert bd.missing_per_attribute.get("storage_gb") == 1
+    # ram_gb is present on both → 0 missing.
+    assert bd.missing_per_attribute.get("ram_gb") == 0
+
+
+def test_coverage_breakdown_missing_source_kind_defaults_to_unknown(inspector_module):
+    """A decision without a ``source_kind`` field (pre-PR-#97 trace) is
+    counted under ``"unknown"`` rather than crashing."""
+    attrs = _make_attrs(
+        composed_fields={"title": "Old laptop"},
+        decisions=[
+            # No source_kind key at all.
+            {"key": "title", "chosen_value": "Old laptop",
+             "source_strategy": "specialist_v1",
+             "reason": "legacy", "dropped_alternatives": []},
+        ],
+    )
+    engine = _FakeEngine([{"attributes": attrs}])
+    bd = inspector_module.compute_coverage_breakdown(engine, "default")
+    assert bd.by_source_kind.get("unknown") == 1
+
+
+def test_coverage_breakdown_zero_composed_fields(inspector_module):
+    """Product with ``composed_fields={}`` (current zero-signal state)
+    counts toward total_products but adds 0 cells."""
+    attrs = _make_attrs(composed_fields={}, decisions=[])
+    engine = _FakeEngine([{"attributes": attrs}])
+    bd = inspector_module.compute_coverage_breakdown(engine, "default")
+    assert bd.total_products == 1
+    assert bd.total_cells == 0
+    assert bd.by_source_kind == {}
+    assert bd.incomplete_decisions_count == 0

--- a/scripts/enrichment_inspector.py
+++ b/scripts/enrichment_inspector.py
@@ -36,6 +36,7 @@ import os
 import re
 import sys
 import urllib.parse
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -159,6 +160,188 @@ def list_merchants(engine: Engine) -> list[dict[str, Any]]:
             "— falling back to DB._"
         )
     return list_merchants_from_db(engine)
+
+
+# ---------------------------------------------------------------------------
+# Coverage breakdown (vision bullet 3 — per-cell source_kind provenance)
+# ---------------------------------------------------------------------------
+
+# Canonical source_kind values from PR #97's SourceKind enum, plus "unknown"
+# for decisions written before that PR or with missing source_kind fields.
+_CANONICAL_SOURCE_KINDS: tuple[str, ...] = (
+    "raw_parse",
+    "scrape",
+    "parametric",
+    "deterministic_fallback",
+    "unknown",
+)
+
+# Path to feature-discovery coverage.json outputs (PR #91, optional).
+_FEATURE_DISCOVERY_DIR = _REPO_ROOT / "runs" / "feature_discovery"
+
+
+@dataclass
+class CoverageBreakdown:
+    """Per-merchant cell-count breakdown by source_kind.
+
+    Built by ``compute_coverage_breakdown`` from
+    ``merchants.products_enriched_<merchant_id>`` rows with
+    ``strategy='composer_v1'``.
+
+    Fields
+    ------
+    total_products : int
+        Number of rows queried (may be 0 for a fresh / failed merchant).
+    total_cells : int
+        Sum of ``len(composed_fields)`` across all products.
+    by_source_kind : dict[str, int]
+        Cell count per source_kind bucket.  Keys come from
+        ``_CANONICAL_SOURCE_KINDS`` plus any other value present in the data.
+    by_attribute : dict[str, dict[str, int]]
+        ``{attr_name: {source_kind: count}}`` across all products.
+    missing_per_attribute : dict[str, int]
+        Count of products where the attribute is absent from
+        ``composed_fields``.
+    incomplete_decisions_count : int
+        Number of products whose ``attributes['incomplete_decisions']`` is True
+        (set by the PR #97 reconciler when it had to synthesise decisions).
+    """
+
+    total_products: int = 0
+    total_cells: int = 0
+    by_source_kind: dict[str, int] = field(default_factory=dict)
+    by_attribute: dict[str, dict[str, int]] = field(default_factory=dict)
+    missing_per_attribute: dict[str, int] = field(default_factory=dict)
+    incomplete_decisions_count: int = 0
+
+
+def compute_coverage_breakdown(engine: Engine, merchant_id: str) -> CoverageBreakdown:
+    """Query ``merchants.products_enriched_<merchant_id>`` (strategy=
+    ``composer_v1``) and return a ``CoverageBreakdown``.
+
+    Pure function — no Streamlit calls.  Safe to call from tests with a
+    mocked/in-memory engine.
+
+    Edge cases handled:
+    * No rows → all-zero breakdown.
+    * Row with ``composed_fields={}`` (current zero-signal state on
+      mocklaptops) → counts toward total_products but adds 0 cells.
+    * Decision missing ``source_kind`` (pre-PR-#97 traces) → bucketed as
+      ``"unknown"``.
+    * Composed key with no matching decision → counted under the source_kind
+      of the synthesised sentinel (``"parametric"`` per the reconciler) but
+      we default to ``"unknown"`` for maximum honesty.
+    * ValueError from ``merchant_enriched_table`` (bad slug) → empty breakdown.
+    """
+    try:
+        enr = merchant_enriched_table(merchant_id)
+    except ValueError:
+        return CoverageBreakdown()
+
+    sql = text(
+        f"SELECT attributes FROM {enr} WHERE strategy = 'composer_v1'"
+    )
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(sql).mappings().all()
+    except (ProgrammingError, DatabaseError):
+        return CoverageBreakdown()
+
+    bd = CoverageBreakdown()
+    # First pass: collect composed_fields data to build the attribute universe.
+    parsed_rows: list[dict[str, Any]] = []
+    attr_universe: set[str] = set()
+
+    for r in rows:
+        attrs: dict[str, Any] = r["attributes"] or {}
+        if not isinstance(attrs, dict):
+            continue
+        composed: dict[str, Any] = attrs.get("composed_fields") or {}
+        if not isinstance(composed, dict):
+            composed = {}
+        decisions: list[Any] = attrs.get("composer_decisions") or []
+        if not isinstance(decisions, list):
+            decisions = []
+        incomplete: bool = bool(attrs.get("incomplete_decisions", False))
+
+        parsed_rows.append(
+            {
+                "composed": composed,
+                "decisions": decisions,
+                "incomplete": incomplete,
+            }
+        )
+        attr_universe.update(composed.keys())
+
+    # Ensure by_attribute and missing_per_attribute cover the full universe.
+    for attr in attr_universe:
+        bd.by_attribute.setdefault(attr, {})
+        bd.missing_per_attribute.setdefault(attr, 0)
+
+    bd.total_products = len(parsed_rows)
+
+    for pr in parsed_rows:
+        composed = pr["composed"]
+        decisions: list[Any] = pr["decisions"]
+        incomplete: bool = pr["incomplete"]
+
+        if incomplete:
+            bd.incomplete_decisions_count += 1
+
+        # Build a key → source_kind lookup from this product's decisions.
+        decision_by_key: dict[str, str] = {}
+        for d in decisions:
+            if not isinstance(d, dict):
+                continue
+            k = d.get("key")
+            if not isinstance(k, str) or not k:
+                continue
+            sk = d.get("source_kind")
+            if sk is None:
+                sk = "unknown"
+            elif isinstance(sk, str) and sk:
+                pass  # use as-is
+            else:
+                sk = "unknown"
+            decision_by_key[k] = sk
+
+        # Tally cells and missing counts against the full attribute universe.
+        for attr in attr_universe:
+            if attr in composed:
+                bd.total_cells += 1
+                sk = decision_by_key.get(attr, "unknown")
+                bd.by_source_kind[sk] = bd.by_source_kind.get(sk, 0) + 1
+                bd.by_attribute[attr][sk] = bd.by_attribute[attr].get(sk, 0) + 1
+            else:
+                bd.missing_per_attribute[attr] = (
+                    bd.missing_per_attribute.get(attr, 0) + 1
+                )
+
+    return bd
+
+
+def _latest_feature_discovery_coverage(product_type: str | None = None) -> dict[str, Any] | None:
+    """Return the most-recently-modified coverage.json from
+    ``runs/feature_discovery/<product_type>/<latest>/coverage.json``.
+
+    Returns ``None`` silently if PR #91 hasn't landed yet (directory absent)
+    or no files exist.  ``product_type=None`` scans all subdirectories."""
+    if not _FEATURE_DISCOVERY_DIR.exists():
+        return None
+    try:
+        candidates: list[Path] = []
+        if product_type:
+            base = _FEATURE_DISCOVERY_DIR / product_type
+            candidates = list(base.rglob("coverage.json")) if base.is_dir() else []
+        else:
+            candidates = list(_FEATURE_DISCOVERY_DIR.rglob("coverage.json"))
+        if not candidates:
+            return None
+        latest = max(candidates, key=lambda p: p.stat().st_mtime)
+        with open(latest, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -1840,6 +2023,123 @@ def render_reasoning_trace(run: dict[str, Any]) -> None:
                 st.json(_jsonable(sp))
 
 
+def render_coverage(engine: Engine, merchant_id: str) -> None:
+    """Coverage tab — per-merchant cell breakdown by source_kind.
+
+    Surfaces vision bullet 3: "% populated from parsing the raw source /
+    % from crawling / % from parametric knowledge."  Powered by PR #97's
+    ``source_kind`` field on ``ComposerDecision``.
+    """
+    st.markdown(f"### Coverage breakdown for `{merchant_id}`")
+    st.caption(
+        "Per-cell provenance across ``composer_v1`` decisions — counts how many "
+        "canonical fields were produced by each ``source_kind`` bucket."
+    )
+
+    with st.spinner("Querying enriched table..."):
+        cov = compute_coverage_breakdown(engine, merchant_id)
+
+    # -- Zero-signal banner (current state on mocklaptops, see audit / Task 12)
+    if cov.total_cells == 0:
+        st.warning(
+            "Composer is producing 0 cells across all products on this merchant. "
+            "Coverage breakdown is structurally correct but reflects the upstream "
+            "zero-signal issue (see ENRICHMENT_FAILURE_AUDIT.md / Task 12). "
+            "Re-run after the model investigation lands."
+        )
+
+    # -- Top metrics row -------------------------------------------------------
+    m1, m2, m3, m4 = st.columns(4)
+    m1.metric("Products", cov.total_products)
+    m2.metric("Cells populated", cov.total_cells)
+    avg_cells = (
+        round(cov.total_cells / cov.total_products, 1)
+        if cov.total_products
+        else 0.0
+    )
+    m3.metric("Avg cells / product", avg_cells)
+    m4.metric("Rows with incomplete_decisions", cov.incomplete_decisions_count)
+
+    st.divider()
+
+    # -- Source-kind bar chart -------------------------------------------------
+    st.markdown("#### Per-cell provenance distribution")
+    st.caption("Counts how many composer cells came from each source_kind bucket.")
+
+    if cov.by_source_kind:
+        sk_df = pd.DataFrame(
+            [{"source_kind": k, "cells": v}
+             for k, v in sorted(cov.by_source_kind.items(), key=lambda x: -x[1])],
+        ).set_index("source_kind")
+        st.bar_chart(sk_df, use_container_width=True)
+    else:
+        st.info("No source_kind data yet — run enrichment to populate this chart.")
+
+    st.divider()
+
+    # -- Per-attribute breakdown table ----------------------------------------
+    st.markdown("#### Per-attribute coverage (sorted by gap: worst first)")
+    st.caption(
+        "Rows = attribute names.  Columns = source_kind bucket counts, "
+        "``missing`` = products where this attribute was absent, "
+        "``total_populated`` = filled cells, ``pct_populated`` = fill rate."
+    )
+
+    if cov.by_attribute:
+        all_sk = sorted(
+            {sk for sks in cov.by_attribute.values() for sk in sks}
+            | (set(cov.by_source_kind.keys()) if cov.by_source_kind else set())
+        )
+        attr_rows: list[dict[str, Any]] = []
+        for attr in sorted(cov.by_attribute.keys()):
+            row: dict[str, Any] = {"attribute": attr}
+            total_pop = 0
+            for sk in all_sk:
+                cnt = cov.by_attribute[attr].get(sk, 0)
+                row[sk] = cnt
+                total_pop += cnt
+            missing_cnt = cov.missing_per_attribute.get(attr, 0)
+            row["missing"] = missing_cnt
+            row["total_populated"] = total_pop
+            denom = total_pop + missing_cnt
+            row["pct_populated"] = round(total_pop / denom * 100, 1) if denom else 0.0
+            attr_rows.append(row)
+
+        attr_df = pd.DataFrame(attr_rows).sort_values(
+            "pct_populated", ascending=True
+        )
+        st.dataframe(attr_df, hide_index=True, use_container_width=True)
+
+        st.download_button(
+            "Download as CSV",
+            data=attr_df.to_csv(index=False),
+            file_name=f"{merchant_id}_coverage.csv",
+            mime="text/csv",
+        )
+    else:
+        st.info("No composed attributes found — the attribute table will appear once enrichment runs.")
+
+    st.divider()
+
+    # -- Optional: feature-discovery overlay (PR #91) -------------------------
+    fd_cov = _latest_feature_discovery_coverage()
+    if fd_cov is not None:
+        covered = fd_cov.get("covered", 0)
+        missing_fd = fd_cov.get("missing", 0)
+        underused = fd_cov.get("underused", 0)
+        denom_fd = covered + missing_fd + underused
+        pct_fd = round(covered / denom_fd * 100, 1) if denom_fd else 0.0
+        st.markdown("#### Feature-discovery overlay (PR #91)")
+        st.metric(
+            "% of user-queried features the catalog covers",
+            f"{pct_fd}%",
+            help=(
+                f"covered={covered}, missing={missing_fd}, underused={underused} "
+                "(from latest runs/feature_discovery coverage.json)"
+            ),
+        )
+
+
 def _jsonable(obj: Any) -> Any:
     try:
         json.dumps(obj, default=str)
@@ -1930,6 +2230,7 @@ def main() -> None:
             "Raw → Enriched → KG",
             "Enriched table",
             "KG coverage",
+            "Coverage",
             "Per-product drill-down",
             "Reasoning trace",
         ]
@@ -1943,8 +2244,10 @@ def main() -> None:
     with tabs[3]:
         render_kg_coverage(run)
     with tabs[4]:
-        render_per_product(run, engine, picked_id)
+        render_coverage(engine, picked_id)
     with tabs[5]:
+        render_per_product(run, engine, picked_id)
+    with tabs[6]:
         render_reasoning_trace(run)
 
 


### PR DESCRIPTION
## Summary

Surfaces vision bullet 3 ("Add metrics on coverage to dashboard — % populated from parsing the raw source / % from crawling / % from parametric knowledge") as a new **Coverage** tab in the enrichment inspector.

Stacked on PR #97 (`fix/composer-1-1-provenance`) — `SourceKind` enum added there is the data prerequisite. Merge #97 first; this PR rebases cleanly.

## What's in this PR

- **`CoverageBreakdown` dataclass** — structured summary of per-merchant composer output: `total_products`, `total_cells`, `by_source_kind`, `by_attribute`, `missing_per_attribute`, `incomplete_decisions_count`.
- **`compute_coverage_breakdown(engine, merchant_id)`** — pure function (no Streamlit), queries `merchants.products_enriched_<merchant_id>` for `strategy='composer_v1'` rows and tallies cell provenance from `composer_decisions[*].source_kind`.
- **Coverage tab** added to `st.tabs(...)`: top metrics row (products, cells, avg cells/product, incomplete_decisions count), source-kind bar chart, per-attribute breakdown table sorted worst-coverage first, CSV download, and an honest zero-signal banner when `total_cells == 0`.
- **Feature-discovery overlay** (PR #91) — silently skipped if `runs/feature_discovery/` doesn't exist; renders a "% of user-queried features catalog covers" metric if a `coverage.json` is found.
- **6 new unit tests** in `mcp-server/tests/test_enrichment_inspector.py` covering: empty merchant, single product with mixed source kinds, `incomplete_decisions` flag, missing attribute, pre-PR-#97 decision without `source_kind` (bucketed as `"unknown"`), and the zero-cells edge case.

## Current state on mocklaptops

The composer is producing 0 cells across 200 products (0 keys per product — see `ENRICHMENT_FAILURE_AUDIT.md` + Task 12 model investigation). The Coverage tab will therefore show `total_cells=0` and the zero-signal banner. **This is expected and intended** — the UI scaffold and data plumbing are correct; the root cause is upstream in the LLM call chain. The tab will populate once the model investigation resolves.

## Test results

```
23 passed in 3.61s (17 pre-existing + 6 new)
```

## Deferred

- Plotly-based donut chart (prettier than `st.bar_chart`) — would need `plotly` added to deps; punted to avoid dependency creep.
- Time-series view (coverage delta across consecutive runs).
- Breakdown by product type (needs product_type column on enriched table).

## Stack

`refactor/merchant-agent-v2` ← `fix/composer-1-1-provenance` (#97) ← `feat/inspector-coverage-tab` (this PR)