### PR TITLE
spike(orchestration): composer feedback-loop routing scaffold (vision bullet 1, #85)

### DIFF
--- a/mcp-server/app/enrichment/orchestration/feedback_loop.py
+++ b/mcp-server/app/enrichment/orchestration/feedback_loop.py
@@ -1,0 +1,162 @@
+"""
+SPIKE — composer feedback loop routing scaffold.
+
+Vision-bullet-1: introduce more looping in the enrichment pipeline.
+Issue #85 capability gap 1: no closed-loop refinement.
+
+Today's flow (one-shot):
+    specialist → asks 7 buyer questions → composer drops unanswered ones
+
+Target flow (closed loop):
+    specialist → asks 7 buyer questions
+                            │
+                            ▼
+                    composer encounters unanswered Q
+                            │
+                            ▼
+              ┌──────── route_question ─────────┐
+              ▼                ▼                ▼
+        scraper.try_url   web_search    kg_lookup
+              │                │                │
+              └──────────► evidence ◄───────────┘
+                            │
+                            ▼
+                    composer re-attempts
+
+This module defines the routing interface ONLY. Live wiring into composer is
+deferred — see PR description for what's NOT done.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional, Protocol, runtime_checkable
+
+
+class QuestionKind(str, Enum):
+    SPEC_FACT = "spec_fact"         # numeric or categorical product attribute (refresh_rate, ram_gb)
+    BRAND_FACT = "brand_fact"       # who-makes-this, when-released — likely web search
+    USAGE_OPINION = "usage_opinion" # subjective, "good for X" — likely review aggregation
+    AVAILABILITY = "availability"   # in-stock, where-to-buy
+    UNKNOWN = "unknown"
+
+
+class EvidenceSource(str, Enum):
+    SCRAPER = "scraper"
+    WEB_SEARCH = "web_search"
+    KG_LOOKUP = "kg_lookup"
+    REVIEW_AGGREGATOR = "review_aggregator"
+
+
+@dataclass
+class UnansweredQuestion:
+    """One specialist-grounded question composer couldn't answer from raw."""
+
+    key: str                           # canonical attribute name (e.g. "refresh_rate")
+    text: str                          # human-readable question
+    kind: QuestionKind
+    product_id: str
+    product_url: str | None = None     # if known (raw catalog has it)
+    raw_context: dict[str, Any] = field(default_factory=dict)  # raw_attributes slice relevant to this Q
+
+
+@dataclass
+class Evidence:
+    """A claim with linked source — vision bullet 2 ('require linked source')."""
+
+    key: str
+    value: Any
+    source: EvidenceSource
+    source_url: str | None = None
+    confidence: float = 0.5
+    raw_extract: str | None = None     # the snippet evidence came from
+
+
+@runtime_checkable
+class EvidenceProvider(Protocol):
+    """Each downstream tool implements this interface.
+
+    Note: the codebase's agents use BaseEnrichmentAgent (ABC). Protocol is used
+    here deliberately — providers (scraper, web_search, kg_lookup) are not
+    enrichment agents and shouldn't inherit the agent lifecycle. Duck-typing
+    suits this lightweight dispatch surface.
+    """
+
+    def can_answer(self, question: UnansweredQuestion) -> bool:
+        """Return True if this provider is able to attempt this question."""
+        ...
+
+    def fetch(self, question: UnansweredQuestion) -> Optional[Evidence]:
+        """Attempt to answer the question. Return None if unsuccessful."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Stub providers — NOT WIRED — document the interface; implementations elsewhere
+# ---------------------------------------------------------------------------
+
+class _ScraperProvider:
+    """Calls scraper_v1 with a target URL + the specific question. Stub for spike."""
+
+    def can_answer(self, question: UnansweredQuestion) -> bool:
+        return (
+            question.product_url is not None
+            and question.kind in {QuestionKind.SPEC_FACT, QuestionKind.AVAILABILITY}
+        )
+
+    def fetch(self, question: UnansweredQuestion) -> Optional[Evidence]:
+        return None  # spike-only; real impl delegates to scraper_v1
+
+
+class _WebSearchProvider:
+    """Calls a web search API for facts the catalog page doesn't carry. Stub."""
+
+    def can_answer(self, question: UnansweredQuestion) -> bool:
+        return question.kind in {QuestionKind.BRAND_FACT, QuestionKind.SPEC_FACT}
+
+    def fetch(self, question: UnansweredQuestion) -> Optional[Evidence]:
+        return None  # spike-only; no external dep added
+
+
+class _KgLookupProvider:
+    """Looks up similar products in the KG to infer missing fields by neighborhood. Stub."""
+
+    def can_answer(self, question: UnansweredQuestion) -> bool:
+        return question.kind == QuestionKind.SPEC_FACT
+
+    def fetch(self, question: UnansweredQuestion) -> Optional[Evidence]:
+        return None  # spike-only; real impl queries kg_service.py
+
+
+# Default ordering: scraper first (cheapest + most accurate when URL exists),
+# then web_search, then kg_lookup.
+_DEFAULT_PROVIDERS: list[EvidenceProvider] = [
+    _ScraperProvider(),
+    _WebSearchProvider(),
+    _KgLookupProvider(),
+]
+
+
+def route_question(
+    question: UnansweredQuestion,
+    providers: list[EvidenceProvider] | None = None,
+) -> Optional[Evidence]:
+    """Decide which provider should answer the question and fetch evidence.
+
+    Returns None if no provider can answer or all capable providers return None.
+
+    Dispatch is rule-based today (``EvidenceProvider.can_answer``); a future
+    agentic version would let an LLM choose, with retrospective learning from
+    past successes per ``(product_type, question.kind)``.
+
+    Fall-through semantics: if the first capable provider returns None (e.g.
+    fetch failed), the next capable provider is tried.
+    """
+    active = providers if providers is not None else _DEFAULT_PROVIDERS
+    for provider in active:
+        if provider.can_answer(question):
+            evidence = provider.fetch(question)
+            if evidence is not None:
+                return evidence
+    return None

--- a/mcp-server/tests/enrichment/test_feedback_loop.py
+++ b/mcp-server/tests/enrichment/test_feedback_loop.py
@@ -1,0 +1,156 @@
+"""Tests for the composer feedback-loop routing scaffold (spike).
+
+Covers routing decisions: provider selection, fall-through, None path, and
+Evidence dataclass shape.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.enrichment.orchestration.feedback_loop import (
+    Evidence,
+    EvidenceProvider,
+    EvidenceSource,
+    QuestionKind,
+    UnansweredQuestion,
+    route_question,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _spec_question(*, url: str | None = None) -> UnansweredQuestion:
+    return UnansweredQuestion(
+        key="refresh_rate",
+        text="What is the refresh rate?",
+        kind=QuestionKind.SPEC_FACT,
+        product_id="prod-001",
+        product_url=url,
+    )
+
+
+def _make_evidence(key: str = "refresh_rate", source: EvidenceSource = EvidenceSource.SCRAPER) -> Evidence:
+    return Evidence(
+        key=key,
+        value="144Hz",
+        source=source,
+        source_url="https://example.com/laptop",
+        confidence=0.9,
+        raw_extract="144Hz refresh rate",
+    )
+
+
+def _fake_provider(*, can: bool, evidence: Evidence | None) -> EvidenceProvider:
+    """Hand-rolled fake — avoids MagicMock spec mismatch on Protocol."""
+    class _Fake:
+        def can_answer(self, question: UnansweredQuestion) -> bool:
+            return can
+        def fetch(self, question: UnansweredQuestion) -> Optional[Evidence]:
+            return evidence
+    return _Fake()  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_route_question_picks_scraper_when_url_present_and_spec_fact():
+    """URL present + SPEC_FACT → scraper provider is first and wins."""
+    expected = _make_evidence(source=EvidenceSource.SCRAPER)
+    scraper = _fake_provider(can=True, evidence=expected)
+    web = _fake_provider(can=False, evidence=None)
+    kg = _fake_provider(can=False, evidence=None)
+
+    result = route_question(_spec_question(url="https://example.com/laptop"), providers=[scraper, web, kg])
+
+    assert result is expected
+    assert result.source == EvidenceSource.SCRAPER
+
+
+def test_route_question_falls_through_to_web_search_when_no_url():
+    """No URL → scraper can_answer=False; web_search picks it up."""
+    web_evidence = _make_evidence(source=EvidenceSource.WEB_SEARCH)
+    scraper = _fake_provider(can=False, evidence=None)
+    web = _fake_provider(can=True, evidence=web_evidence)
+    kg = _fake_provider(can=False, evidence=None)
+
+    result = route_question(_spec_question(url=None), providers=[scraper, web, kg])
+
+    assert result is web_evidence
+    assert result.source == EvidenceSource.WEB_SEARCH
+
+
+def test_route_question_returns_none_when_no_provider_can_answer():
+    """UNKNOWN kind with no URL → no provider claims it → None."""
+    question = UnansweredQuestion(
+        key="some_unknown",
+        text="Is this good for gaming?",
+        kind=QuestionKind.UNKNOWN,
+        product_id="prod-002",
+        product_url=None,
+    )
+    providers = [
+        _fake_provider(can=False, evidence=None),
+        _fake_provider(can=False, evidence=None),
+    ]
+
+    result = route_question(question, providers=providers)
+
+    assert result is None
+
+
+def test_route_question_respects_provider_order():
+    """When multiple providers can_answer, try first; fall through if it returns None."""
+    # First provider can answer but returns None (fetch fails)
+    first = _fake_provider(can=True, evidence=None)
+    # Second provider can answer and returns evidence
+    second_evidence = _make_evidence(source=EvidenceSource.KG_LOOKUP)
+    second = _fake_provider(can=True, evidence=second_evidence)
+    # Third should never be reached
+    third = _fake_provider(can=True, evidence=_make_evidence())
+
+    result = route_question(_spec_question(url="https://example.com"), providers=[first, second, third])
+
+    assert result is second_evidence
+    assert result.source == EvidenceSource.KG_LOOKUP
+
+
+def test_evidence_carries_source_and_url():
+    """Smoke test: Evidence dataclass fields round-trip correctly."""
+    ev = Evidence(
+        key="ram_gb",
+        value=16,
+        source=EvidenceSource.WEB_SEARCH,
+        source_url="https://example.com/spec",
+        confidence=0.85,
+        raw_extract="16 GB RAM",
+    )
+
+    assert ev.key == "ram_gb"
+    assert ev.value == 16
+    assert ev.source == EvidenceSource.WEB_SEARCH
+    assert ev.source_url == "https://example.com/spec"
+    assert ev.confidence == 0.85
+    assert ev.raw_extract == "16 GB RAM"
+
+
+def test_route_question_uses_default_providers_when_none_given():
+    """Calling without explicit providers uses _DEFAULT_PROVIDERS (all stubs → None)."""
+    # All default providers have stub fetch() → None, so result is None
+    question = _spec_question(url="https://example.com/laptop")
+    result = route_question(question)
+    assert result is None
+
+
+def test_unanswered_question_raw_context_defaults_to_empty():
+    """raw_context should default to empty dict, not a shared mutable."""
+    q1 = UnansweredQuestion(key="x", text="x?", kind=QuestionKind.SPEC_FACT, product_id="p1")
+    q2 = UnansweredQuestion(key="y", text="y?", kind=QuestionKind.BRAND_FACT, product_id="p2")
+    q1.raw_context["a"] = 1
+    assert q2.raw_context == {}


### PR DESCRIPTION
> **SPIKE — not production-ready.** This PR introduces a routing scaffold only. No runtime wiring. No external dependencies added. Safe to merge or discard independently.

## Problem

The enrichment pipeline is one-shot today: specialist asks ~7 grounded buyer questions per product; when the raw catalog doesn't answer them, composer correctly drops the unanswered ones (no hallucination). A real agentic loop would *route* unanswered questions to the right downstream tool rather than silently dropping them.

The signal already exists: `composer_decisions` records what was dropped (partially tracked via PR interactive-decision-support-system/idss-backend#97's reconciler). What's missing is the routing layer.

## Today vs. target flow

```
Today (one-shot):
    specialist → asks 7 buyer questions → composer drops unanswered ones

Target (closed loop):
    specialist → asks 7 buyer questions
                            │
                            ▼
                    composer encounters unanswered Q
                            │
                            ▼
              ┌──────── route_question ─────────┐
              ▼                ▼                ▼
        scraper.try_url   web_search    kg_lookup
              │                │                │
              └──────────► evidence ◄───────────┘
                            │
                            ▼
                    composer re-attempts
```

## What's done

- `UnansweredQuestion` / `Evidence` dataclasses — typed container for a dropped question and a retrieved claim with linked source
- `EvidenceProvider` Protocol — the interface each downstream tool must satisfy (`can_answer`, `fetch`)
- 3 stub providers: `_ScraperProvider`, `_WebSearchProvider`, `_KgLookupProvider` — document routing rules, stubs only
- `route_question` dispatcher — rule-based fall-through: first capable provider wins; falls through if `fetch` returns None
- 7 tests covering all dispatch cases (scraper wins, falls through to web_search, returns None, respects order, Evidence shape, default providers, mutable-default safety)

## What's NOT done (deferred)

- Live wiring inside `composer.py` — `route_question` is not called anywhere in runtime
- Real implementations of the 3 providers (`scraper_v1` exists; `web_search` and `kg_lookup` are stubs returning `None`)
- LLM-driven routing — today's dispatch is rule-based via `can_answer`; the Protocol makes an LLM-router a drop-in replacement
- Retrospective learning per `(product_type, question.kind)`
- Cost / latency budgets per provider

Suggested child issues under interactive-decision-support-system/merchant-agent#6:
1. Wire `route_question` into `composer.py` on dropped decisions
2. Implement `_WebSearchProvider.fetch` (real web search call)
3. Implement `_KgLookupProvider.fetch` (neighborhood inference via `kg_service.py`)

## Files added

| File | LOC |
|------|-----|
| `mcp-server/app/enrichment/orchestration/feedback_loop.py` | 162 |
| `mcp-server/tests/enrichment/test_feedback_loop.py` | 156 |

## Test results

```
7 passed (new) / 107 passed total (enrichment suite) / 0 failures
```

## Refs

- Vision bullet 1: introduce more looping in the enrichment pipeline
- Issue interactive-decision-support-system/merchant-agent#6 capability gap 1: no closed-loop refinement
- Issue interactive-decision-support-system/merchant-agent#9: linked evidence / source tracking (`Evidence.source_url`)
- PR interactive-decision-support-system/idss-backend#97: reconciler that surfaces the `composer_decisions` signal this routing layer consumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)