### PR TITLE
fix(scraper): wire catalog.link into ProductInput / scraper._pick_url

### DIFF
--- a/mcp-server/app/enrichment/agents/web_scraper.py
+++ b/mcp-server/app/enrichment/agents/web_scraper.py
@@ -79,8 +79,16 @@ class WebScraperAgent(BaseEnrichmentAgent):
 
 
 def _pick_url(p: ProductInput) -> str | None:
+    # Prefer the top-level catalog column wired through ProductInput.link.
+    # Fall back to raw_attributes keys for backward compat with rows that
+    # carry the URL only in the JSONB blob.
     raw = p.raw_attributes or {}
-    candidate = raw.get("merchant_product_url") or raw.get("link") or raw.get("url")
+    candidate = (
+        p.link
+        or raw.get("merchant_product_url")
+        or raw.get("link")
+        or raw.get("url")
+    )
     if not isinstance(candidate, str):
         return None
     parsed = urlparse(candidate)

--- a/mcp-server/app/enrichment/tools/catalog_reader.py
+++ b/mcp-server/app/enrichment/tools/catalog_reader.py
@@ -27,6 +27,7 @@ def _to_input(p: Any) -> ProductInput:
         brand=p.brand,
         description=(p.attributes or {}).get("description") if p.attributes else None,
         price=p.price_value,
+        link=getattr(p, "link", None),
         raw_attributes=dict(p.attributes) if p.attributes else {},
     )
 

--- a/mcp-server/app/enrichment/types.py
+++ b/mcp-server/app/enrichment/types.py
@@ -32,6 +32,7 @@ class ProductInput(BaseModel):
     brand: str | None = None
     description: str | None = None
     price: Decimal | None = None
+    link: str | None = None
     raw_attributes: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/mcp-server/tests/enrichment/test_web_scraper.py
+++ b/mcp-server/tests/enrichment/test_web_scraper.py
@@ -94,3 +94,68 @@ def test_scraper_blocked_url_yields_empty_sources():
     )
     assert result.success is True
     assert result.output.attributes["scraped_sources"] == []
+
+
+# ---------------------------------------------------------------------------
+# URL wiring: catalog.link column → ProductInput.link → _pick_url
+# ---------------------------------------------------------------------------
+
+from app.enrichment.agents.web_scraper import _pick_url  # noqa: E402
+
+
+def test_pick_url_uses_product_link_field():
+    """Top-level catalog.link wired via ProductInput.link is the primary source."""
+    p = ProductInput(
+        product_id=uuid4(),
+        title="ThinkPad X1",
+        category="Electronics",
+        link="https://example-manufacturer.com/p123",
+    )
+    assert _pick_url(p) == "https://example-manufacturer.com/p123"
+
+
+def test_pick_url_prefers_product_link_over_raw_attributes():
+    """ProductInput.link takes precedence over raw_attributes keys."""
+    p = ProductInput(
+        product_id=uuid4(),
+        title="ThinkPad X1",
+        category="Electronics",
+        link="https://example-manufacturer.com/p123",
+        raw_attributes={"merchant_product_url": "https://example-manufacturer.com/other"},
+    )
+    assert _pick_url(p) == "https://example-manufacturer.com/p123"
+
+
+def test_pick_url_falls_back_to_raw_attributes_link():
+    """Backward compat: no top-level link but raw_attributes has 'link' key."""
+    p = ProductInput(
+        product_id=uuid4(),
+        title="ThinkPad X1",
+        category="Electronics",
+        raw_attributes={"link": "https://example-manufacturer.com/fallback"},
+    )
+    assert _pick_url(p) == "https://example-manufacturer.com/fallback"
+
+
+def test_pick_url_returns_none_when_no_url_anywhere():
+    p = ProductInput(product_id=uuid4(), title="ThinkPad X1", category="Electronics")
+    assert _pick_url(p) is None
+
+
+def test_scraper_end_to_end_uses_product_link_column():
+    """End-to-end: ProductInput with link= reaches scraper and fetches content."""
+    target_url = "https://example-manufacturer.com/spec/x"
+    http = _FakeHttp({target_url: _Resp(200, "<html>catalog-link-body</html>")})
+    agent = WebScraperAgent(scraper=ScraperClient(http_client=http))
+    product = ProductInput(
+        product_id=uuid4(),
+        title="ThinkPad X1",
+        category="Electronics",
+        link=target_url,
+        # raw_attributes intentionally empty — simulates mocklaptops with no JSONB link
+        raw_attributes={},
+    )
+    result = agent.run(product, context={"taxonomy": {"product_type": "laptop"}})
+    assert result.success is True
+    assert result.output.attributes["scraped_sources"]
+    assert "catalog-link-body" in result.output.attributes["scraped_specs"]["raw_text_excerpt"]


### PR DESCRIPTION
## Summary

- **Symptom (ENRICHMENT_FAILURE_AUDIT.md):** `scraper_v1` produced empty `scraped_specs`/`scraped_sources` for all 200 mocklaptops products. Root cause: `_pick_url()` reads URL candidates from `raw_attributes` JSONB, but mocklaptops rows have no `link` key there. The top-level `catalog.link` column (present in `_product_columns()`) was never threaded into `ProductInput`, so 200 valid URLs sat unused.
- **Fix (Option A):** Added `link: str | None = None` to `ProductInput`; `catalog_reader._to_input()` now passes `getattr(p, "link", None)` (safe for any model without the column); `_pick_url()` checks `p.link` first, then falls back to `raw_attributes` keys for backward compat.
- **Note:** This unblocks the scraper URL-resolution path but does not make scraper fully operational end-to-end — the `gpt-5-mini` model issue (Task 12) must be resolved separately.

## Files changed

| File | Change |
|---|---|
| `mcp-server/app/enrichment/types.py` | +1 line: `link: str | None = None` on `ProductInput` |
| `mcp-server/app/enrichment/tools/catalog_reader.py` | +1 line: `link=getattr(p, "link", None)` in `_to_input()` |
| `mcp-server/app/enrichment/agents/web_scraper.py` | `_pick_url()` checks `p.link` first, then raw_attributes fallbacks |
| `mcp-server/tests/enrichment/test_web_scraper.py` | +5 tests: top-level wiring, precedence, backward-compat, no-URL, end-to-end |

## Test plan

- `test_pick_url_uses_product_link_field` — primary path asserted directly
- `test_pick_url_prefers_product_link_over_raw_attributes` — precedence
- `test_pick_url_falls_back_to_raw_attributes_link` — backward compat preserved
- `test_pick_url_returns_none_when_no_url_anywhere` — no crash on missing URL
- `test_scraper_end_to_end_uses_product_link_column` — full agent invocation with `link=` set and empty `raw_attributes` (the mocklaptops scenario)
- All 19 existing + new scraper/runner tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)