### PR TITLE
fix(enrichment/agents): raise max_completion_tokens for gpt-5-mini reasoning floor

### DIFF
--- a/mcp-server/app/enrichment/agents/assessor.py
+++ b/mcp-server/app/enrichment/agents/assessor.py
@@ -25,6 +25,12 @@ from app.enrichment.types import AssessorOutput, ProductInput
 logger = logging.getLogger(__name__)
 
 
+# gpt-5-mini is a reasoning model; even simple list-of-labels output
+# requires ~500-1000 tokens of invisible CoT. Budget covers reasoning
+# + up to 12 product-type labels + margin. See Task 12 / ENRICHMENT_MODEL_DIAGNOSIS.md.
+_MAX_COMPLETION_TOKENS = 2000
+
+
 # Strategies the assessor can recommend. Kept here so the assessor can reason
 # about them without circular imports of the agent classes themselves.
 # composer_v1 always runs (single writer of the canonical row — #83); the
@@ -112,7 +118,7 @@ class Assessor:
                 user="Sample:\n" + json.dumps(sample, ensure_ascii=False),
                 model=model or utility_model(),
                 json_mode=True,
-                max_tokens=400,
+                max_tokens=_MAX_COMPLETION_TOKENS,
                 temperature=0.1,
             )
             data = resp.parsed_json or {}

--- a/mcp-server/app/enrichment/agents/composer.py
+++ b/mcp-server/app/enrichment/agents/composer.py
@@ -92,6 +92,13 @@ from app.enrichment.types import ComposerDecision, ProductInput, StrategyOutput
 logger = logging.getLogger(__name__)
 
 
+# gpt-5-mini is a reasoning model. Composer synthesizes all upstream findings
+# + writes decisions — largest output of any agent (~1000+ tokens visible).
+# Budget covers reasoning floor + full composed_fields + decisions + margin.
+# See Task 12 / ENRICHMENT_MODEL_DIAGNOSIS.md.
+_MAX_COMPLETION_TOKENS = 6000
+
+
 # Context keys the runner populates for each upstream strategy.
 # Keeping this list explicit (rather than scanning ctx) means the composer's
 # prompt has a stable shape — the LLM sees the same findings schema every
@@ -226,7 +233,7 @@ class ComposerAgent(BaseEnrichmentAgent):
                     or composer_model()
                 ),
                 json_mode=True,
-                max_tokens=2500,
+                max_tokens=_MAX_COMPLETION_TOKENS,
                 temperature=0.1,
             )
             context["_last_cost_usd"] = resp.cost_usd

--- a/mcp-server/app/enrichment/agents/parser.py
+++ b/mcp-server/app/enrichment/agents/parser.py
@@ -19,6 +19,13 @@ from app.enrichment.tools.llm_client import LLMClient, default_model
 from app.enrichment.types import ProductInput, StrategyOutput
 
 
+# gpt-5-mini is a reasoning model; ~500-1800 tokens go to invisible CoT
+# before any output. Multi-field extraction needs more headroom than
+# taxonomy. Budget covers reasoning + ~13 spec fields + margin.
+# See Task 12 / ENRICHMENT_MODEL_DIAGNOSIS.md.
+_MAX_COMPLETION_TOKENS = 3000
+
+
 _SYSTEM = (
     "You extract product specifications from unstructured text. Return JSON with keys:\n"
     "  parsed_specs        flat object of normalized specs you found "
@@ -52,7 +59,7 @@ class ParserAgent(BaseEnrichmentAgent):
             user=user,
             model=context.get("model") or default_model(),
             json_mode=True,
-            max_tokens=600,
+            max_tokens=_MAX_COMPLETION_TOKENS,
             temperature=0.0,
         )
         context["_last_cost_usd"] = resp.cost_usd

--- a/mcp-server/app/enrichment/agents/soft_tagger.py
+++ b/mcp-server/app/enrichment/agents/soft_tagger.py
@@ -21,6 +21,12 @@ from app.enrichment.tools.llm_client import LLMClient, default_model
 from app.enrichment.types import ProductInput, StrategyOutput
 
 
+# gpt-5-mini is a reasoning model; simple tag-confidence output still
+# requires ~500-1000 tokens of invisible CoT. Budget covers reasoning
+# + up to ~10 tag entries + margin. See Task 12 / ENRICHMENT_MODEL_DIAGNOSIS.md.
+_MAX_COMPLETION_TOKENS = 2000
+
+
 _SYSTEM = (
     "You generate soft 'good_for_*' tags for an e-commerce product. Return JSON with one key:\n"
     "  good_for_tags    object {tag_key: confidence 0.0-1.0}\n"
@@ -50,7 +56,7 @@ class SoftTaggerAgent(BaseEnrichmentAgent):
             user=user,
             model=context.get("model") or default_model(),
             json_mode=True,
-            max_tokens=400,
+            max_tokens=_MAX_COMPLETION_TOKENS,
             temperature=0.2,
         )
         context["_last_cost_usd"] = resp.cost_usd

--- a/mcp-server/app/enrichment/agents/specialist.py
+++ b/mcp-server/app/enrichment/agents/specialist.py
@@ -24,6 +24,13 @@ from app.enrichment.tools.llm_client import LLMClient, default_model
 from app.enrichment.types import ProductInput, StrategyOutput
 
 
+# gpt-5-mini is a reasoning model; heavier output (7 buyer questions,
+# use-case fit dict, capabilities list) demands more headroom than
+# parser. Budget covers reasoning + multi-field JSON + margin.
+# See Task 12 / ENRICHMENT_MODEL_DIAGNOSIS.md.
+_MAX_COMPLETION_TOKENS = 4000
+
+
 _PROMPT_DIR = Path(__file__).resolve().parent / "specialist_prompts"
 _DEFAULT_PROMPT_NAME = "_default.md"
 
@@ -91,7 +98,7 @@ class SpecialistAgent(BaseEnrichmentAgent):
             user=user,
             model=context.get("model") or default_model(),
             json_mode=True,
-            max_tokens=900,
+            max_tokens=_MAX_COMPLETION_TOKENS,
             temperature=0.2,
         )
         context["_last_cost_usd"] = resp.cost_usd

--- a/mcp-server/app/enrichment/agents/taxonomy.py
+++ b/mcp-server/app/enrichment/agents/taxonomy.py
@@ -17,6 +17,12 @@ from app.enrichment.tools.llm_client import LLMClient, default_model
 from app.enrichment.types import ProductInput, StrategyOutput
 
 
+# gpt-5-mini is a reasoning model; ~500-1500 tokens go to invisible CoT
+# before any output. Budget covers reasoning + visible output + margin.
+# See Task 12 / ENRICHMENT_MODEL_DIAGNOSIS.md.
+_MAX_COMPLETION_TOKENS = 2000
+
+
 _SYSTEM = (
     "You classify e-commerce products by product type. Return JSON with keys:\n"
     "  product_type     short noun (e.g. 'laptop', 'blender', 'headphones', 'smart-bulb', 'office-chair')\n"
@@ -45,7 +51,7 @@ class TaxonomyAgent(BaseEnrichmentAgent):
             user=user,
             model=context.get("model") or default_model(),
             json_mode=True,
-            max_tokens=200,
+            max_tokens=_MAX_COMPLETION_TOKENS,
             temperature=0.1,
         )
         context["_last_cost_usd"] = resp.cost_usd

--- a/mcp-server/tests/enrichment/test_composer.py
+++ b/mcp-server/tests/enrichment/test_composer.py
@@ -184,8 +184,8 @@ def test_composer_uses_json_mode_and_composer_model_default():
     ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
     assert llm.calls[0]["json_mode"] is True
     assert llm.calls[0]["model"] == "gpt-5"
-    # Review fix #6: composer budget bumped to handle dense findings.
-    assert llm.calls[0]["max_tokens"] == 2500
+    # Task 12: raised to 6000 to satisfy gpt-5-mini reasoning-floor requirement.
+    assert llm.calls[0]["max_tokens"] == 6000
 
 
 def test_composer_honors_context_model_override():


### PR DESCRIPTION
## Why

gpt-5-mini is a reasoning model — it counts hidden chain-of-thought (CoT) tokens against `max_completion_tokens`. The prior per-agent budgets (200–2500) were below its reasoning floor: all tokens get consumed by internal CoT, producing empty content the pipeline silently coerces to `{}`.

Proven in ENRICHMENT_MODEL_DIAGNOSIS.md (Task 12):
- budget=200 → `finish_reason='length'`, empty content
- budget=2000 → 128 CoT + 25 output tokens → correct JSON

## Changes

Per-agent budgets raised to cover reasoning floor + visible output + safety margin. Each budget is now extracted to a module-level `_MAX_COMPLETION_TOKENS` constant with a comment explaining the rationale.

| Agent | Before | After | Rationale |
|---|---|---|---|
| taxonomy_v1 | 200 | 2000 | Single field + confidence. ~1500 CoT + 50 output. |
| parser_v1 | 600 | 3000 | ~13 spec fields. ~1800 CoT + 300 output. |
| specialist_v1 | 900 | 4000 | 7 buyer questions + use-case fit. Heavier reasoning. |
| soft_tagger_v1 | 400 | 2000 | Tag confidences. Simple output but CoT floor applies. |
| assessor_v1 | 400 | 2000 | List of product-type labels. Catalog-level call. |
| composer_v1 | 2500 | 6000 | Synthesizes all upstream findings. Largest output by far. |

web_scraper_v1 (`scraper_v1`) has no LLM call — not changed. validator_v1 has no LLM call — not changed.

## Dependency on PR #95

This PR is **not sufficient alone**. PR #95 (`fix/llm-client-gpt5-compat`) must also merge first: it renames `max_tokens` → `max_completion_tokens` in `llm_client.py` and removes `temperature` (both required by gpt-5-mini's API). Without PR #95, the API rejects the call entirely. Without this PR, the call succeeds but returns empty content.

## Smoke test

Run `run_enrichment.py --merchant mocklaptops --limit 1 --mode fixed` against the base branch (which already uses gpt-4o-mini / non-reasoning) as a proxy. All 5 extraction strategies succeeded:
- taxonomy_v1: `product_type='laptop'`, confidence=0.95
- parser_v1: 7 specs extracted (`ram_gb`, `storage_gb`, `weight_lbs`, etc.)
- specialist_v1: 6 capabilities, 8 use cases, 7 buyer questions
- soft_tagger_v1: 8 tags (`good_for_gaming`, `good_for_school`, etc.)
- scraper_v1: no URL present → empty specs (expected)
- 18 keys filled, **$0.000724 total**, 17.7s latency

The smoke test with the worktree code (gpt-5-mini) fails on the `max_tokens` kwarg rejection — confirming the dependency on PR #95.

Unit tests: 100 passed. 1 test assertion updated (`test_composer_uses_json_mode_and_composer_model_default`) to match the new composer budget of 6000.

## Cost estimate (full 175-product re-run, worst-case envelope)

Rough math at gpt-5-mini pricing ($1.20/M output tokens), assuming every call hits its cap:

| Agent | Max output tokens | 175 products | Cost |
|---|---|---|---|
| taxonomy_v1 | 2000 | 350 000 | $0.42 |
| parser_v1 | 3000 | 525 000 | $0.63 |
| specialist_v1 | 4000 | 700 000 | $0.84 |
| soft_tagger_v1 | 2000 | 350 000 | $0.42 |
| assessor_v1 | 2000 | 1× catalog call | ~$0.00 |
| composer_v1 | 6000 | 1 050 000 | $1.26 |

**Worst-case total: ~$3.57 output tokens alone.** Reasoning (CoT) tokens are also billed at the same rate and can be 5–10× the visible output — so the practical worst-case envelope is **$5–15 per full re-run**. Most calls will be well under the cap; this is not expected spend, it is the ceiling.

## Out of scope

- `llm_client.py` kwarg rename (PR #95)
- composer 1:1 provenance (PR #97)
- Full 175-product re-run (user's decision post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
