### PR TITLE
fix(composer): raise max_completion_tokens to 16000 for gpt-5 reasoning floor

### DIFF
--- a/mcp-server/app/enrichment/agents/composer.py
+++ b/mcp-server/app/enrichment/agents/composer.py
@@ -92,11 +92,24 @@ from app.enrichment.types import ComposerDecision, ProductInput, StrategyOutput
 logger = logging.getLogger(__name__)
 
 
-# gpt-5-mini is a reasoning model. Composer synthesizes all upstream findings
-# + writes decisions — largest output of any agent (~1000+ tokens visible).
-# Budget covers reasoning floor + full composed_fields + decisions + margin.
-# See Task 12 / ENRICHMENT_MODEL_DIAGNOSIS.md.
-_MAX_COMPLETION_TOKENS = 6000
+# Composer uses gpt-5 (full tier, not gpt-5-mini). gpt-5's reasoning is
+# significantly more expensive in tokens than gpt-5-mini's: empirically ≥6000
+# reasoning tokens are consumed on hard products before any visible output is
+# emitted. Live evidence from a 10-product mocklaptops batch (refactor/
+# merchant-agent-v2 tip + PR #103): 7/10 composer calls hit output_tokens=6000
+# with empty content — entire budget consumed by invisible reasoning, zero JSON
+# emitted. The 3 successful calls used 5063/5522/5788 output_tokens, of which
+# ~2000 tokens was visible JSON (~7000 chars), implying ~3000-4000 reasoning.
+# Hard products (e.g. MacBook 128GB, Razer Blade, Framework 16) likely need
+# 6000+ reasoning tokens alone. Budget breakdown:
+#   - gpt-5 reasoning floor (hard products): ≥6000 tokens (empirical)
+#   - Visible JSON output (composed_fields + decisions): ~2000 tokens
+#   - Safety margin: ~8000 tokens
+# Other agents keep their lower budgets — they run on gpt-5-mini which has a
+# much lower reasoning cost and their existing 2000-4000 budgets still fit.
+# See Task 12 / ENRICHMENT_MODEL_DIAGNOSIS.md and PR #103 (raised 2500→6000),
+# PR #84 (gpt-5 tier setup).
+_MAX_COMPLETION_TOKENS = 16000
 
 
 # Context keys the runner populates for each upstream strategy.

--- a/mcp-server/tests/enrichment/test_composer.py
+++ b/mcp-server/tests/enrichment/test_composer.py
@@ -184,8 +184,10 @@ def test_composer_uses_json_mode_and_composer_model_default():
     ComposerAgent(llm=llm).run(_product(), _upstream_ctx())
     assert llm.calls[0]["json_mode"] is True
     assert llm.calls[0]["model"] == "gpt-5"
-    # Task 12: raised to 6000 to satisfy gpt-5-mini reasoning-floor requirement.
-    assert llm.calls[0]["max_tokens"] == 6000
+    # Raised to 16000 (PR #103 set 6000 for gpt-5-mini; composer uses gpt-5
+    # full tier whose reasoning floor alone is ≥6000 tokens on hard products —
+    # 7/10 calls on a mocklaptops batch hit the 6000 ceiling with empty output).
+    assert llm.calls[0]["max_tokens"] == 16000
 
 
 def test_composer_honors_context_model_override():


### PR DESCRIPTION
## Bug

7 of 10 composer calls in a live mocklaptops batch (refactor/merchant-agent-v2 tip + PR #103 applied) produced **empty output**. All 7 failures hit `output_tokens=6000` — the entire budget was consumed by gpt-5's invisible reasoning chain before any JSON was emitted.

| Call | output_tokens | visible content |
|------|--------------|-----------------|
| Fail ×7 | 6000 | empty |
| Success 1 | 5063 | ~2000 tokens JSON |
| Success 2 | 5522 | ~2000 tokens JSON |
| Success 3 | 5788 | ~2000 tokens JSON |

Hard products (Apple MacBook 128GB, Razer Blade, Framework 16) likely need ≥6000 reasoning tokens alone — the budget was exhausted before any output could be emitted.

## Root cause

PR #103 raised `_MAX_COMPLETION_TOKENS` from 2500 → 6000 to fix a reasoning-floor issue, but that was sized for gpt-5-mini. Composer actually uses **gpt-5** (full tier, per PR #84's tier setup via `ENRICHMENT_COMPOSER_MODEL` / `composer_model()`). gpt-5's reasoning is far more expensive in tokens than gpt-5-mini's.

## Fix

Raise `_MAX_COMPLETION_TOKENS` in `composer.py` from **6000 → 16000**.

Budget breakdown:
- gpt-5 reasoning floor for hard products: ≥6000 tokens (empirical)
- Visible JSON output (composed_fields + decisions): ~2000 tokens
- Safety margin: ~8000 tokens

## Why other agents are unaffected

All other agents (`taxonomy`, `parsed`, `specialist`, `assessor` utilities) run on **gpt-5-mini**, which has a much lower reasoning cost. Their existing 2000–4000 token budgets still fit. This change is composer-only.

## Cost impact

| | Before | After |
|--|--------|-------|
| Composer worst-case per call | ~\$0.06 | ~\$0.15 |
| Full 175-product re-run worst case | ~\$10 | ~\$25 |

The current 7/10 empty-output failure rate means the effective cost at 6000 is already high (retries required); 16000 eliminates retries for the hard products.

## What's NOT done

- No chunking of composer's input
- No selective field-by-field synthesis
- No change to which model composer uses
- No change to other agents' budgets

These are valid follow-on optimisations but out of scope for a budget fix.

## Tests

`mcp-server/tests/enrichment/` — 100 passed.