### PR TITLE
feat(enrichment/runner): --offset flag + plan for nested Langfuse tracing

### DIFF
--- a/mcp-server/app/enrichment/orchestration/runner.py
+++ b/mcp-server/app/enrichment/orchestration/runner.py
@@ -160,6 +160,7 @@ def run_enrichment(
     mode: Mode = "fixed",
     merchant_id: str = "default",
     limit: int = 10,
+    offset: int = 0,
     strategies_filter: list[str] | None = None,
     dry_run: bool = False,
     audit: bool = False,
@@ -186,6 +187,7 @@ def run_enrichment(
             mode=mode,
             merchant_id=merchant_id,
             limit=limit,
+            offset=offset,
             strategies_filter=strategies_filter,
             dry_run=dry_run,
             audit=audit,
@@ -200,6 +202,7 @@ def _run_inner(
     mode: Mode,
     merchant_id: str,
     limit: int,
+    offset: int,
     strategies_filter: list[str] | None,
     dry_run: bool,
     audit: bool,
@@ -211,6 +214,7 @@ def _run_inner(
         db,
         product_model=catalog.product_model,
         limit=limit,
+        offset=offset,
     )
     per_product_dump: dict[str, list[dict[str, Any]]] = defaultdict(list)
     if not products:

--- a/mcp-server/app/enrichment/tools/catalog_reader.py
+++ b/mcp-server/app/enrichment/tools/catalog_reader.py
@@ -61,5 +61,8 @@ def load_products(
     *,
     product_model: Any,
     limit: int | None = None,
+    offset: int = 0,
 ) -> list[ProductInput]:
-    return list(iter_products(db, product_model=product_model, limit=limit))
+    return list(
+        iter_products(db, product_model=product_model, limit=limit, offset=offset)
+    )

--- a/scripts/run_enrichment.py
+++ b/scripts/run_enrichment.py
@@ -36,6 +36,12 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--mode", choices=["fixed", "orchestrated"], default="fixed")
     p.add_argument("--limit", type=int, default=10, help="Max products to process.")
     p.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Skip the first N products (ordered by product_id). Useful for batching.",
+    )
+    p.add_argument(
         "--merchant",
         default=_V1_MERCHANT_ID,
         help=f"Merchant slug to enrich (default {_V1_MERCHANT_ID!r}). "
@@ -95,6 +101,7 @@ def main() -> int:
             mode=args.mode,
             merchant_id=args.merchant,
             limit=args.limit,
+            offset=args.offset,
             strategies_filter=strategies_filter,
             dry_run=args.dry_run,
             audit=args.audit,


### PR DESCRIPTION
## Summary

Two things in one PR. Part 1 is shippable code. Part 2 is a plan for a follow-up PR.

### Part 1 (shippable): `--offset` flag on the enrichment runner

Adds `offset: int = 0` through `load_products`, `run_enrichment`, and the `scripts/run_enrichment.py` CLI so large catalogs can be batched:

```bash
./scripts/run_enrichment.py --merchant mocklaptops --offset 0   --limit 50
./scripts/run_enrichment.py --merchant mocklaptops --offset 50  --limit 50
./scripts/run_enrichment.py --merchant mocklaptops --offset 100 --limit 50
./scripts/run_enrichment.py --merchant mocklaptops --offset 150 --limit 50
```

Backwards compatible: every existing caller passes 0 via the default. Used today to work around interactive-decision-support-system/merchant-agent#13 (parallel runner stalls at >~100 products); exercised to completion on 200 mocklaptops products across 4 consecutive batches with no failures.

**Diff:** 15 additive lines, 3 files. All 120 existing enrichment tests pass.

### Part 2 (tracked as interactive-decision-support-system/idss-backend#111, not implemented in this PR): nested Langfuse tracing

Today every enrichment span becomes a flat root-level `generation()` in Langfuse (see `tracing.py:163`). This loses the parent/child structure and also silently drops the `run:<id>` / `merchant:<id>` / `kg_strategy:<s>` tags because `tags` is a trace-level field in the Langfuse v2 SDK, not a generation-level field. We confirmed this against a live Langfuse project — traces arrive with `tags=[]`.

**Target structure:**

```
Trace: enrichment_run:<merchant_id>:<run_id[:8]>
  tags=[run:<full_id>, merchant:<id>, kg_strategy:<s>]
├── Span: assessor:discover_product_types
│   └── Generation: llm:gpt-5-nano
├── Span: product:<product_id_1>
│   ├── Span: taxonomy_v1
│   │   └── Generation: llm:gpt-5-nano
│   ├── Span: parser_v1
│   │   └── Generation: llm:gpt-5-mini
│   ├── Span: specialist_v1
│   ├── Span: scraper_v1
│   ├── Span: soft_tagger_v1
│   └── Span: composer_v1
│       └── Generation: llm:gpt-5
├── Span: product:<product_id_2>
│   └── ...
└── ...
```

**Why:** one trace per run with all ~600 observations nested lets you (a) filter Langfuse by `run:<id>` tag, (b) click a single product and see every strategy that touched it plus the LLM call inside each, (c) compare two runs as two traces rather than 1,200 disconnected generations, (d) use Langfuse's built-in cost-by-tag dashboards.

**Implementation sketch:**

1. `tracing.py` — add `trace_context` and `current_span_context` contextvars. `_LangfuseTracer` reads `current_trace` on first span call, lazily materializes a `self._client.trace(name=..., tags=...)`, then every subsequent span calls `trace.span(...)` or `trace.generation(...)` so Langfuse links them.
2. `runner.py:run_enrichment` — open the trace context inside `run_context`, so the trace name + tags are known at trace-creation time.
3. `runner.py:_work` — wrap the per-product strategy loop in a `span("product:<id>")` so strategy spans become its children.
4. `base.py:StrategyBase.run` — already calls `tracer.span(...)`; will auto-inherit the current product-span as parent once contextvars are threaded.
5. `_LangfuseSpan` — the existing class already supports `.update()` / `.end()`; no API change for callers.
6. `_JsonlTracer` — no-op change; JSONL already nests logically via `span_id`. Add `parent_span_id` to the record so offline inspection matches the Langfuse tree.
7. Tests — extend `tests/enrichment/test_tracing.py` with (a) tag propagation assertion against a fake Langfuse client, (b) parent/child span-id linkage assertion.

**LOC estimate:** ~150 lines net, including tests. Pure tracer/runner internal plumbing — no API changes for agents or callers.

**Validation plan:** one 50-product run with the nested tracer enabled, click through the Langfuse UI to confirm: one trace per run, clicking a product shows 6 child strategies, each strategy expands to its `llm:*` generation. Then re-run all four 50-product batches to confirm no regression in DB output (avg_keys_filled, per-strategy success count).

## Context

- Offset flag was the workaround for interactive-decision-support-system/merchant-agent#13 (parallel runner stalls at 175 products). Batching with `--offset 0/50/100/150` completed all 200 mocklaptops products on the new pipeline across 4 runs with zero failures.
- Current tracing gap: confirmed against a live Langfuse project — `cloud.langfuse.com` shows generations with `tags=[]` even though the JSONL tracer records `[run:..., merchant:..., kg_strategy:...]` correctly. That is the blocker for cross-run filtering in the Langfuse UI and the main driver for the refactor.

## Test plan

### Part 1 (implemented)
- [x] All 120 enrichment tests pass (`cd mcp-server && pytest tests/enrichment`)
- [x] Manual: 4 × 50-product batches on mocklaptops complete without failure, 200/200 products enriched, 1200 strategy invocations all succeed
- [ ] Reviewer: read through the 3-file diff

### Part 2 (tracked as interactive-decision-support-system/idss-backend#111, no code here)
- [ ] Follow-up PR closes interactive-decision-support-system/idss-backend#111 by implementing the structure above, landing `parent_span_id` and trace-level tags
- [ ] Single-run Langfuse UI sanity check (visual confirmation of the tree structure)
