### PR TITLE
fix(enrichment/runner): flush per-product + OpenAI timeout (#108)

### DIFF
--- a/mcp-server/app/enrichment/orchestration/runner.py
+++ b/mcp-server/app/enrichment/orchestration/runner.py
@@ -339,21 +339,25 @@ def _run_inner(
             summary.keys_filled_per_product.append(r["keys_filled"])
             summary.products_processed += 1
 
-    # write outputs (one batched commit)
-    all_outputs: list[StrategyOutput] = [
-        out for outs in successful_outputs_by_pid.values() for out in outs
-    ]
-    if audit:
-        all_outputs.extend(
-            validator_mod.make_audit_output(product_id=pid, verdicts=verdicts)
-            for pid, verdicts in verdicts_by_pid.items()
-        )
-    db_writer.upsert_many(
-        db,
-        all_outputs,
-        enriched_model=catalog.enriched_model,
-        dry_run=dry_run,
-    )
+            # Flush this product's rows as soon as its future completes (#108).
+            # Previously the entire run's outputs were held in memory and written
+            # in one upsert_many after the drain finished — if any future hung,
+            # every completed product's work was discarded. Flushing per-product
+            # makes partial progress durable; each flush commits independently.
+            product_outputs: list[StrategyOutput] = list(r["successful"])
+            if audit:
+                product_outputs.append(
+                    validator_mod.make_audit_output(
+                        product_id=pid, verdicts=r["verdicts"]
+                    )
+                )
+            if product_outputs:
+                db_writer.upsert_many(
+                    db,
+                    product_outputs,
+                    enriched_model=catalog.enriched_model,
+                    dry_run=dry_run,
+                )
 
     # 7) catalog schema + propose extensions
     schema = _build_catalog_schema(merchant_id, successful_outputs_by_pid, products)

--- a/mcp-server/app/enrichment/tools/llm_client.py
+++ b/mcp-server/app/enrichment/tools/llm_client.py
@@ -123,7 +123,12 @@ class LLMClient:
         try:
             from openai import OpenAI
 
-            self._client = OpenAI(api_key=api_key)
+            # Without an explicit timeout the OpenAI SDK uses httpx.Timeout(None, connect=5.0):
+            # a stuck request never raises, so a single hung worker blocks the entire
+            # ThreadPoolExecutor drain (#108). Any positive value is enough to convert
+            # the hang into an exception that the retry envelope at complete() handles.
+            timeout_s = float(os.getenv("ENRICHMENT_OPENAI_TIMEOUT_S", "180"))
+            self._client = OpenAI(api_key=api_key, timeout=timeout_s)
         except ImportError:
             logger.warning("openai package not installed — LLMClient is no-op")
             self._client = None

--- a/mcp-server/tests/enrichment/test_runner.py
+++ b/mcp-server/tests/enrichment/test_runner.py
@@ -345,3 +345,44 @@ def test_worker_spans_land_in_run_id_jsonl_not_no_run(
         assert expected_tag in span.get("tags", []), (
             f"span {span.get('name')} is missing tag '{expected_tag}': {span.get('tags')}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: incremental upsert inside the as_completed drain (#108)
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_flush_per_product_not_once_at_end(monkeypatch):
+    """Each completed product's rows must hit the DB while other futures are
+    still running — not in a single post-drain batch. Otherwise a single hung
+    worker blocks persistence for every successful peer (#108 stall).
+    """
+    from app.enrichment.tools import llm_client as llm_module
+    from app.enrichment.tools import catalog_reader
+
+    products = _products(3)
+    monkeypatch.setattr(catalog_reader, "load_products", lambda *a, **kw: products)
+    monkeypatch.setattr(runner, "load_products", lambda *a, **kw: products)
+    scripted = _ScriptedLLM()
+    monkeypatch.setattr(
+        llm_module.LLMClient, "complete", lambda self, **kw: scripted.complete(**kw)
+    )
+
+    calls: list[int] = []
+    monkeypatch.setattr(
+        db_writer,
+        "upsert_many",
+        lambda db, outs, *, enriched_model, dry_run=False: calls.append(
+            len(list(outs))
+        )
+        or 0,
+    )
+
+    runner.run_enrichment(db=None, mode="fixed", limit=3, dry_run=False)
+
+    assert len(calls) == 3, (
+        f"expected upsert_many called once per product (3), got {len(calls)} "
+        f"with sizes {calls} — regression to single-batched-commit pattern"
+    )
+    # Every flush should carry at least one row (the 6 successful strategies per product).
+    assert all(n > 0 for n in calls), f"empty flush detected: {calls}"


### PR DESCRIPTION
## Summary

Two fixes for the parallel-runner stall tracked in interactive-decision-support-system/merchant-agent#13. Draft while we wait for a real repro at ≥175 products to confirm the hang no longer deadlocks the drain.

### Fix 1 — incremental upsert inside the `as_completed` drain

`runner.py:_run_inner` used to collect every product's outputs in memory and call `db_writer.upsert_many` once after the loop finished. If any single future never completed, the drain blocked forever and every completed peer's work was discarded (#108 symptom: 123/175 composers done, 22 min idle, 0 DB rows).

Now each product's rows flush the moment its future completes. Each flush commits independently, so partial progress is durable even if a later worker stalls, crashes, or the process is killed.

**Trade-off:** ~50 small upsert calls per 50-product batch instead of 1 × 300-row batch. Postgres commits are sub-millisecond; the measured overhead on mocklaptops batches was indistinguishable from noise.

### Fix 2 — explicit OpenAI client timeout

`LLMClient.__init__` instantiated `OpenAI(api_key=...)` with no `timeout=` kwarg. The SDK defaults to `httpx.Timeout(None, connect=5.0)` — total-request timeout of None means a stuck HTTP call never raises and the worker hangs indefinitely. This is the suspected root cause of the stall: one unlucky OpenAI request hangs, its future never completes, `as_completed` blocks forever.

Added:
```python
timeout_s = float(os.getenv("ENRICHMENT_OPENAI_TIMEOUT_S", "180"))
self._client = OpenAI(api_key=api_key, timeout=timeout_s)
```

The existing `complete()` retry envelope (`max_retries=3`) already catches and retries on timeout exceptions, so the worst-case failure mode is now: product times out → 3 retries at 180s → strategy marked failed → other products continue.

### New regression test

`test_outputs_flush_per_product_not_once_at_end` mocks `upsert_many` and asserts it gets called **once per product**, not once total. Locks in the incremental-flush contract so a future refactor can't silently revert to the batched-end pattern.

## Why draft

Fix 2 is a best-guess root cause, not a confirmed one. To confirm, we'd need to:

- Run ≥175 products without `--offset` batching and observe no stall
- Ideally with a py-spy/thread dump under a seeded hung request to see the timeout fire

I'd rather you eyeball the code first and make sure the incremental-flush refactor didn't break anything before we burn another $15 on a 200-product confirmation run. Flip out of draft once reviewed.

## Test plan

- [x] All 121 enrichment tests pass (120 existing + new regression test)
- [x] Manual: local smoke run at `--limit 3` succeeds and writes 3 products × 6 strategies
- [ ] Reviewer: read through the 3-file diff (runner, llm_client, test)
- [ ] Full-scale confirmation: one unbatched `--limit 200` run against mocklaptops completes without stalling (requires merging so we pick up the fixes)

## Out of scope

- The `--offset` flag from interactive-decision-support-system/idss-backend#110 is independent and stays useful even after this fix (batched runs are a legitimate operational pattern for very large catalogs).
- Nested Langfuse tracing / trace-level tags are tracked in interactive-decision-support-system/idss-backend#111.

Closes interactive-decision-support-system/merchant-agent#13 once the full-scale confirmation run passes.
