### PR TITLE
fix(enrichment/tracing): require Langfuse outside of tests (#93)

### DIFF
--- a/mcp-server/app/enrichment/tracing.py
+++ b/mcp-server/app/enrichment/tracing.py
@@ -394,12 +394,27 @@ class _CompositeTracer:
 # ---------------------------------------------------------------------------
 
 
+def _is_test_env() -> bool:
+    """True when we should permit a missing Langfuse config without raising.
+
+    Two escape hatches:
+    - ``PYTEST_CURRENT_TEST`` is set by pytest during test execution.
+    - ``ENRICHMENT_TRACE_DISABLED=1`` is an explicit opt-out for local work
+      (the operator is acknowledging they'll lose observability).
+    """
+    return bool(os.getenv("PYTEST_CURRENT_TEST")) or os.getenv("ENRICHMENT_TRACE_DISABLED") == "1"
+
+
 def build_tracer() -> Any:
     """Construct the tracer for this process.
 
     - Langfuse tracer when LANGFUSE_PUBLIC_KEY is set AND the SDK is installed.
     - JSONL tracer when ENRICHMENT_TRACE_JSONL=1 (can run alongside Langfuse).
-    - NoopTracer otherwise.
+    - NoopTracer only in tests or when ENRICHMENT_TRACE_DISABLED=1.
+
+    Outside of tests, a missing ``LANGFUSE_PUBLIC_KEY`` is a startup error
+    (issue #93). Silent degradation to noop meant we'd discover the
+    observability gap exactly when we needed the traces most.
     """
     tracers: list[Any] = []
 
@@ -413,9 +428,20 @@ def build_tracer() -> Any:
                 host=os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com"),
             )
             tracers.append(_LangfuseTracer(client))
-        except ImportError:
+        except ImportError as exc:
+            if not _is_test_env():
+                raise RuntimeError(
+                    "langfuse package not installed but LANGFUSE_PUBLIC_KEY is set. "
+                    "Install with `pip install langfuse` or unset the env var."
+                ) from exc
             logger.info("langfuse not installed — enrichment tracing disabled")
         except Exception as exc:  # noqa: BLE001 - never let tracing break enrichment
+            if not _is_test_env():
+                raise RuntimeError(
+                    f"langfuse client failed to initialize: {exc}. "
+                    "Check LANGFUSE_HOST / keys, or set ENRICHMENT_TRACE_DISABLED=1 "
+                    "to opt out (not recommended outside local dev)."
+                ) from exc
             logger.warning("langfuse init failed (%s) — falling back to no-op", exc)
 
     if os.getenv("ENRICHMENT_TRACE_JSONL") == "1":
@@ -423,6 +449,13 @@ def build_tracer() -> Any:
         tracers.append(_JsonlTracer(root))
 
     if not tracers:
+        if not _is_test_env():
+            raise RuntimeError(
+                "No tracer configured. Set LANGFUSE_PUBLIC_KEY (and LANGFUSE_SECRET_KEY "
+                "if the project requires it) to enable observability. "
+                "For local-only work you can set ENRICHMENT_TRACE_DISABLED=1, but note "
+                "that every agent call and LLM generation will go unrecorded."
+            )
         return _NoopTracer()
     if len(tracers) == 1:
         return tracers[0]

--- a/mcp-server/tests/enrichment/test_tracing_langfuse.py
+++ b/mcp-server/tests/enrichment/test_tracing_langfuse.py
@@ -143,3 +143,55 @@ def test_no_run_context_falls_back_to_client_level():
     client.trace.assert_not_called()
     client.span.assert_called_once()
     client.generation.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# #93 — Langfuse required outside of tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_tracer_raises_when_langfuse_unset_outside_tests(monkeypatch):
+    """Silent degradation to noop was the issue from #93: in prod we'd
+    discover the observability gap only when we needed traces. Now the
+    process refuses to start without an explicit tracer config."""
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("ENRICHMENT_TRACE_JSONL", raising=False)
+    monkeypatch.delenv("ENRICHMENT_TRACE_DISABLED", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    with pytest.raises(RuntimeError, match="LANGFUSE_PUBLIC_KEY"):
+        tracing.build_tracer()
+
+
+def test_build_tracer_allows_noop_when_explicitly_disabled(monkeypatch):
+    """Local dev escape hatch — operator explicitly opts out."""
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("ENRICHMENT_TRACE_JSONL", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("ENRICHMENT_TRACE_DISABLED", "1")
+
+    t = tracing.build_tracer()
+    assert t.enabled is False
+
+
+def test_build_tracer_allows_noop_inside_pytest(monkeypatch):
+    """Test env is the other escape hatch — PYTEST_CURRENT_TEST is set
+    automatically by pytest during test execution."""
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("ENRICHMENT_TRACE_JSONL", raising=False)
+    monkeypatch.delenv("ENRICHMENT_TRACE_DISABLED", raising=False)
+    # PYTEST_CURRENT_TEST is already set by the runner; don't clobber.
+
+    t = tracing.build_tracer()
+    assert t.enabled is False
+
+
+def test_build_tracer_allows_jsonl_only_outside_tests(monkeypatch):
+    """JSONL alone counts as 'a tracer is configured' — no Langfuse required."""
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("ENRICHMENT_TRACE_DISABLED", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("ENRICHMENT_TRACE_JSONL", "1")
+
+    t = tracing.build_tracer()
+    assert t.enabled is True


### PR DESCRIPTION
## Summary

- `build_tracer()` now raises `RuntimeError` if no tracer is configured in a non-test env. Silent degradation to noop was the exact failure mode interactive-decision-support-system/idss-backend#93 calls out — the observability gap only became visible when you needed the traces.
- Two explicit escape hatches: `PYTEST_CURRENT_TEST` (set automatically by pytest) and `ENRICHMENT_TRACE_DISABLED=1` (local-dev opt-out).
- Hardens the two pre-existing soft failures (langfuse-not-installed, langfuse-init-failed) into startup errors in non-test envs, with actionable messages.
- JSONL-only is still valid — `ENRICHMENT_TRACE_JSONL=1` with no Langfuse key satisfies the "a tracer is configured" check.

## Decisions for interactive-decision-support-system/idss-backend#93

This PR addresses **item 1** only. The other two decisions from the issue:

- **JSONL keep-or-delete** — coupled to interactive-decision-support-system/merchant-agent#11 (inspector direction). Keep for now as zero-dep replay fallback; delete when the inspector pivots to Langfuse's API.
- **us.cloud.langfuse.com acceptable** — yes for now. Traces carry LLM prompts/outputs containing product SKUs/descriptions/URLs, which are already public on the merchant's storefront. Revisit if prompts ever start including merchant-confidential material.

## Test plan

- [x] 4 new tests in `test_tracing_langfuse.py` cover all branches: raises without config, ENRICHMENT_TRACE_DISABLED opt-out, pytest auto-allow, JSONL-only.
- [x] Full enrichment suite green (130 passed, was 126).
- [ ] **Manual:** start the backend with `LANGFUSE_PUBLIC_KEY` unset and confirm it refuses to boot with an actionable message.

## Rollout note

Any env that was quietly running noop will now fail at startup. Check:
- CI — should be unaffected since `PYTEST_CURRENT_TEST` fires during tests.
- Local dev without Langfuse creds — set `ENRICHMENT_TRACE_DISABLED=1` in your local `.env` to opt out explicitly.
- Anything running `run_enrichment()` from a script — needs the Langfuse keys the same way the CLI already does.

Closes interactive-decision-support-system/idss-backend#93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)