### PR TITLE
scraper-v2: replace no-op scraper_v1 with gated websearch + crawl (#118)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,9 @@ secrets.yaml
 credentials.json
 
 .claude/
+
+# Ad-hoc enrichment smoke-run outputs (baseline audit dirs under runs/ are tracked intentionally)
+runs/smoke_*/
+
+# Enrichment proposal cache (generated per-run artifacts)
+mcp-server/app/enrichment/cache/

--- a/mcp-server/app/enrichment/agents/composer.py
+++ b/mcp-server/app/enrichment/agents/composer.py
@@ -282,6 +282,14 @@ class ComposerAgent(BaseEnrichmentAgent):
         validator_notes = _gather_validator_notes(context)
         now_iso = datetime.now(timezone.utc).isoformat()
 
+        # Issue #118: scraper_v1 now emits cited per-field dicts
+        # ({value, source_url, source_domain, snippet, extracted_at}).
+        # Capture the citation index once so we can both (a) pre-flatten
+        # scraped_specs to scalars for the LLM / fallback, and (b)
+        # re-attach the citation to any decision whose key came from
+        # scraper_v1. Findings is mutated in place (shallow copy first).
+        findings, scraper_citations = _normalize_scraper_findings(findings)
+
         # If nothing upstream ran successfully, the composer has no material
         # to work with. Emit empty composed_fields so the row is still written
         # (useful as a marker that the composer was invoked) and skip the LLM
@@ -330,6 +338,7 @@ class ComposerAgent(BaseEnrichmentAgent):
             composed = registry_strip_narrative(composed)
             composed, decisions = _cross_check_decisions(composed, decisions)
             decisions, notes_payload = _reconcile_composer_output(composed, decisions)
+            decisions = _attach_scraper_citations(decisions, scraper_citations)
             return StrategyOutput(
                 product_id=product.product_id,
                 strategy=self.STRATEGY,
@@ -352,6 +361,11 @@ class ComposerAgent(BaseEnrichmentAgent):
         # 1:1 enforcement (issue #88): synthesize missing decisions and infer
         # source_kind for all existing decisions.
         decisions, notes_payload = _reconcile_composer_output(composed, decisions)
+
+        # Issue #118: attach scraper citations to any decision whose key
+        # was filled by scraper_v1. Runs AFTER reconcile so synthesized
+        # decisions also pick up their citation if scraper_v1 owned the key.
+        decisions = _attach_scraper_citations(decisions, scraper_citations)
 
         return StrategyOutput(
             product_id=product.product_id,
@@ -548,6 +562,93 @@ def _reconcile_composer_output(
     return reconciled, notes_payload
 
 
+def _normalize_scraper_findings(
+    findings: dict[str, dict[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Flatten scraper_v1's cited per-field objects to scalars for the LLM
+    prompt, and return a separate index of citations for re-attachment.
+
+    Scraper_v1 (issue #118) emits:
+        scraped_specs[field] = {
+            "value": <scalar>,
+            "source_url": ...,
+            "source_domain": ...,
+            "snippet": ...,
+            "extracted_at": ...,
+        }
+
+    The LLM prompt shouldn't see the full citation block — it would either
+    leak URLs into composed_fields or confuse the per-key precedence logic.
+    So: strip to ``{field: value}`` for the prompt, keep citations aside.
+
+    Returns (findings_with_flattened_scraper, citations_by_field). Values
+    from non-nested (legacy) scraped_specs pass through untouched.
+    """
+    scraped = findings.get("scraped") or {}
+    specs = scraped.get("scraped_specs") if isinstance(scraped, dict) else None
+    citations: dict[str, dict[str, Any]] = {}
+    if not isinstance(specs, dict) or not specs:
+        return findings, citations
+
+    flattened: dict[str, Any] = {}
+    for k, v in specs.items():
+        key = str(k)
+        if isinstance(v, dict) and "value" in v:
+            flattened[key] = v["value"]
+            citations[key] = {
+                "kind": "scraped",
+                "url": v.get("source_url"),
+                "domain": v.get("source_domain"),
+                "snippet": v.get("snippet"),
+            }
+        else:
+            # Legacy / non-cited entry — pass through.
+            flattened[key] = v
+
+    if citations:
+        new_findings = dict(findings)
+        new_scraped = dict(scraped)
+        new_scraped["scraped_specs"] = flattened
+        new_findings["scraped"] = new_scraped
+        return new_findings, citations
+    return findings, citations
+
+
+def _attach_scraper_citations(
+    decisions: list[dict[str, Any]],
+    citations: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """For each decision whose key has a scraper citation, stamp
+    ``decision['source'] = {kind:'scraped', url, domain, snippet}``.
+
+    Only attaches when the decision's source_strategy is ``scraper_v1``
+    OR the decision is synthesized (source_strategy=None) but the key
+    is one scraper actually filled — the latter covers reconciler-
+    synthesized decisions where the LLM forgot to emit an explicit
+    scraper attribution.
+    """
+    if not citations:
+        return decisions
+    out: list[dict[str, Any]] = []
+    for d in decisions:
+        key = d.get("key")
+        if not isinstance(key, str) or key not in citations:
+            out.append(d)
+            continue
+        src = d.get("source_strategy")
+        if src not in ("scraper_v1", None):
+            out.append(d)
+            continue
+        new_d = dict(d)
+        new_d["source"] = dict(citations[key])
+        # If synthesized, upgrade source_strategy so provenance is accurate.
+        if src is None:
+            new_d["source_strategy"] = "scraper_v1"
+            new_d["source_kind"] = SourceKind.SCRAPE.value
+        out.append(new_d)
+    return out
+
+
 def registry_strip_narrative(composed: dict[str, Any]) -> dict[str, Any]:
     """Drop narrative keys declared by any registered agent. Reads from the
     registry instead of a hardcoded list so new narrative-emitting agents
@@ -604,7 +705,14 @@ def _deterministic_fallback(
     scraped_specs = (findings.get("scraped") or {}).get("scraped_specs") or {}
     if isinstance(scraped_specs, dict):
         for k, v in scraped_specs.items():
-            _record(str(k), v, "scraper_v1", "fallback_from_scraper")
+            # scraper_v1 emits either a legacy scalar value (pre-#118) or
+            # a cited object {value, source_url, source_domain, snippet,
+            # extracted_at}. Lift .value into composed_fields; the citation
+            # is attached by _attach_scraper_citations after the fact.
+            if isinstance(v, dict) and "value" in v:
+                _record(str(k), v["value"], "scraper_v1", "fallback_from_scraper")
+            else:
+                _record(str(k), v, "scraper_v1", "fallback_from_scraper")
 
     use_case_fit = (findings.get("specialist") or {}).get("specialist_use_case_fit") or {}
     if isinstance(use_case_fit, dict):

--- a/mcp-server/app/enrichment/agents/web_scraper.py
+++ b/mcp-server/app/enrichment/agents/web_scraper.py
@@ -97,11 +97,36 @@ _GAP_FIELDS: dict[str, tuple[str, ...]] = {
 }
 
 
+# Alternate spellings a gap field may appear under in parser output or raw
+# attributes. Checked by the runner's gap detection so we don't queue a
+# scrape for a field the parser already filled under a different key
+# (e.g. parser emits `screen_size_in`, gap list uses `display_size_in`).
+# Issue #115 rec #4 tracks normalizing this upstream; until then, this map
+# prevents the scraper from burning cost on redundant fetches.
+_GAP_FIELD_ALIASES: dict[str, tuple[str, ...]] = {
+    "display_size_in": (
+        "screen_size_in",
+        "screen_size_inch",
+        "screen_size_inches",
+        "screen_size",
+    ),
+    "weight_kg": ("weight_lbs", "weight_g", "weight_grams", "weight"),
+    "cpu_model": ("cpu",),
+    "gpu_model": ("gpu",),
+    "refresh_rate_hz": ("refresh_rate", "display_refresh_rate"),
+}
+
+
 def gap_fields_for(category: str) -> tuple[str, ...]:
     """Public accessor so the runner doesn't re-define this list."""
     if not category:
         return ()
     return _GAP_FIELDS.get(category.lower(), ())
+
+
+def aliases_for(gap_field: str) -> tuple[str, ...]:
+    """Alternate key spellings a gap field may already appear under."""
+    return _GAP_FIELD_ALIASES.get(gap_field, ())
 
 
 _SYSTEM = (

--- a/mcp-server/app/enrichment/agents/web_scraper.py
+++ b/mcp-server/app/enrichment/agents/web_scraper.py
@@ -1,26 +1,134 @@
-"""scraper_v1 — augment a product with content from an allowlisted external page.
+"""scraper_v1 — gated websearch + crawl gap-filler (issue #118).
 
-v1 ships narrow: takes a hint URL from raw_attributes['merchant_product_url']
-or product.link, fetches it through ScraperClient (allowlist + robots.txt +
-24h cache), records the page text under scraped_specs (truncated). The
-follow-up PR's heavier scraping (manufacturer reviews, Q&A, per-category
-domain ranking) consumes the same scraped_reviews/scraped_qna keys, which
-are intentionally present in OUTPUT_KEYS from day one.
+Runs post-specialist / pre-composer in the fixed pipeline. Reads
+``ctx['missing_fields']`` (populated by the runner) and, for each
+missing field:
+
+  1. queries a websearch backend for ``{brand} {title} {field}``
+  2. filters results to the per-category allowlist
+  3. fetches up to N pages via the existing ScraperClient
+     (robots.txt, 24h cache, per-domain rate limit)
+  4. asks the LLM to extract values from excerpts WITH citations
+
+Cost caps per product:
+  - 2 websearch calls
+  - 3 page fetches
+  - 1 LLM extraction call
+
+Emission schema (kept flat so composer flattens one level as with
+parsed_specs):
+
+    scraped_specs: {
+        <field>: {
+            "value": <scalar>,
+            "source_url": "https://...",
+            "source_domain": "lenovo.com",
+            "snippet": "...",
+            "extracted_at": "ISO-8601",
+        }
+    }
+    scraped_sources: [
+        {"url": ..., "domain": ..., "query": ..., "fetched_at": ...},
+    ]
+    scraped_at: ISO-8601
+    scraped_category: "laptop"
+    scraped_reviews: [] / scraped_qna: []   # out of scope per #118
+
+Gated behaviors:
+  - no TAVILY_API_KEY  → early-return empty outputs + warn
+  - ENRICHMENT_DISABLE_WEBSEARCH=1 → same
+  - missing_fields == [] → early-return empty outputs
+  - category has no gap list → same (handled upstream via empty
+    missing_fields)
 """
 
 from __future__ import annotations
 
+import json
+import logging
+import os
 from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urlparse
 
 from app.enrichment import registry
 from app.enrichment.base import BaseEnrichmentAgent
-from app.enrichment.tools.scraper_client import ScraperClient
+from app.enrichment.tools.llm_client import LLMClient, default_model
+from app.enrichment.tools.scraper_client import ScraperClient, is_allowed
+from app.enrichment.tools.websearch_client import WebSearchClient
 from app.enrichment.types import ProductInput, StrategyOutput
 
 
-_MAX_TEXT_CHARS = 8000
+logger = logging.getLogger(__name__)
+
+
+# Cost caps per product — tuned to keep per-product spend predictable.
+# See issue #118 "Per-product cost caps".
+_MAX_SEARCH_CALLS = 2
+_MAX_PAGE_FETCHES = 3
+_MAX_LLM_CALLS = 1
+
+# Truncate each page's extracted text before handing it to the LLM so one
+# fetched page can't blow the token budget. Multiple pages share this per
+# page (not in total).
+_MAX_PAGE_CHARS_FOR_LLM = 4000
+# Upper bound on search results per query.
+_MAX_SEARCH_RESULTS = 5
+# LLM extraction token budget — generous enough for 10 fields × cited
+# shape, small enough to stay within gpt-5-mini per-call pricing.
+_MAX_COMPLETION_TOKENS = 2000
+
+
+# Per-category gap fields. Mirrors the set the runner consults when
+# computing ctx['missing_fields']. Duplicated here rather than imported
+# from the runner so the agent stays usable standalone in tests.
+_GAP_FIELDS: dict[str, tuple[str, ...]] = {
+    "laptop": (
+        "ram_gb",
+        "storage_gb",
+        "cpu_model",
+        "gpu_model",
+        "display_size_in",
+        "refresh_rate_hz",
+        "weight_kg",
+        "battery_life_hours",
+        "os",
+    ),
+}
+
+
+def gap_fields_for(category: str) -> tuple[str, ...]:
+    """Public accessor so the runner doesn't re-define this list."""
+    if not category:
+        return ()
+    return _GAP_FIELDS.get(category.lower(), ())
+
+
+_SYSTEM = (
+    "You extract product specifications from excerpts of web pages. For each "
+    "field the user asks about, look through the provided excerpts and return a "
+    "single grounded value WITH its source URL and a short snippet (<=200 "
+    "chars) from the excerpt that proves the value.\n"
+    "\n"
+    "Return JSON with a single key ``extracted`` — an object mapping each "
+    "field name the user asked about (or a subset) to:\n"
+    "  {\n"
+    '    "value": <scalar: number | string>,\n'
+    '    "source_url": "<url that appeared in the user prompt>",\n'
+    '    "snippet": "<<=200 chars copied from the excerpt>"\n'
+    "  }\n"
+    "\n"
+    "Rules:\n"
+    "  - Never invent values. If no excerpt mentions the field clearly, OMIT "
+    "the field from the output.\n"
+    "  - source_url MUST be one of the URLs shown in the user prompt — do not "
+    "fabricate.\n"
+    "  - snippet MUST be copied verbatim from that URL's excerpt (<=200 chars).\n"
+    "  - Numeric fields (ram_gb, storage_gb, weight_kg, ...) must be numbers, "
+    "not strings; use the unit the field name implies.\n"
+    "  - If the same field has conflicting values across sources, pick the "
+    "one on the most authoritative domain (manufacturer > retailer)."
+)
 
 
 @registry.register
@@ -36,65 +144,204 @@ class WebScraperAgent(BaseEnrichmentAgent):
             "scraped_category",
         }
     )
-    DEFAULT_MODEL = None  # no LLM call in v1
+    DEFAULT_MODEL = "gpt-5-mini"
 
-    def __init__(self, scraper: ScraperClient | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        scraper: ScraperClient | None = None,
+        websearch: WebSearchClient | None = None,
+        llm: LLMClient | None = None,
+    ) -> None:
         super().__init__()
         self._scraper = scraper or ScraperClient()
+        self._websearch = websearch or WebSearchClient()
+        self._llm = llm or LLMClient()
 
     def _invoke(self, product: ProductInput, context: dict[str, Any]) -> StrategyOutput:
-        url = _pick_url(product)
-        product_type = _category_from_context(context, product)
+        now_iso = datetime.now(timezone.utc).isoformat()
+        category = _category_from_context(context, product)
+        missing_fields = _coerce_missing_fields(context.get("missing_fields"))
 
-        sources: list[dict[str, str]] = []
-        scraped_specs: dict[str, Any] = {}
+        empty_payload: dict[str, Any] = {
+            "scraped_specs": {},
+            "scraped_reviews": [],
+            "scraped_qna": [],
+            "scraped_sources": [],
+            "scraped_at": now_iso,
+            "scraped_category": category,
+        }
 
-        if url:
-            doc = self._scraper.fetch(url, category=product_type)
-            if doc is not None and doc.status_code == 200 and doc.text:
-                sources.append(
+        # Gate 1: no gaps to fill → no work to do.
+        if not missing_fields:
+            return StrategyOutput(
+                product_id=product.product_id,
+                strategy=self.STRATEGY,
+                model=None,
+                attributes=empty_payload,
+                notes="no_missing_fields",
+            )
+
+        # Gate 2: websearch disabled or unconfigured → no fetches.
+        if os.getenv("ENRICHMENT_DISABLE_WEBSEARCH") == "1":
+            logger.info("scraper_v1_disabled_by_env")
+            return StrategyOutput(
+                product_id=product.product_id,
+                strategy=self.STRATEGY,
+                model=None,
+                attributes=empty_payload,
+                notes="websearch_disabled",
+            )
+        if not os.getenv("TAVILY_API_KEY") and _using_default_websearch(self._websearch):
+            logger.warning("scraper_v1_no_api_key_skipping")
+            return StrategyOutput(
+                product_id=product.product_id,
+                strategy=self.STRATEGY,
+                model=None,
+                attributes=empty_payload,
+                notes="websearch_no_api_key",
+            )
+
+        # --- budgeted search + fetch loop ---
+        search_calls = 0
+        fetch_calls = 0
+        scraped_sources: list[dict[str, str]] = []
+        seen_urls: set[str] = set()
+        # Page excerpts keyed by URL, used as LLM input.
+        page_excerpts: dict[str, str] = {}
+
+        brand = product.brand or ""
+        title = product.title or ""
+
+        for field in missing_fields:
+            if search_calls >= _MAX_SEARCH_CALLS or fetch_calls >= _MAX_PAGE_FETCHES:
+                break
+            query = _build_query(brand, title, field)
+            if not query:
+                continue
+            search_calls += 1
+            results = self._websearch.search(query, max_results=_MAX_SEARCH_RESULTS)
+            for sr in results:
+                if fetch_calls >= _MAX_PAGE_FETCHES:
+                    break
+                if sr.url in seen_urls:
+                    continue
+                # Allowlist check happens inside ScraperClient.fetch too,
+                # but skipping early avoids burning the fetch-call counter
+                # on guaranteed-blocked domains.
+                if not is_allowed(category, sr.url):
+                    logger.debug(
+                        "scraper_v1_blocked_domain",
+                        extra={"domain": sr.domain, "category": category},
+                    )
+                    continue
+                fetch_calls += 1
+                doc = self._scraper.fetch(sr.url, category=category)
+                if doc is None or doc.status_code != 200 or not doc.text:
+                    continue
+                seen_urls.add(sr.url)
+                page_excerpts[sr.url] = doc.text[:_MAX_PAGE_CHARS_FOR_LLM]
+                scraped_sources.append(
                     {
-                        "url": doc.url,
-                        "domain": doc.domain,
+                        "url": sr.url,
+                        "domain": sr.domain,
+                        "query": query,
                         "fetched_at": doc.fetched_at,
-                        "from_cache": str(doc.from_cache).lower(),
                     }
                 )
-                scraped_specs["raw_text_excerpt"] = doc.text[:_MAX_TEXT_CHARS]
+
+        # Gate 3: nothing usable fetched → return empty specs but record
+        # the sources we at least attempted (there won't be any here since
+        # we only append on success; left for symmetry).
+        if not page_excerpts:
+            return StrategyOutput(
+                product_id=product.product_id,
+                strategy=self.STRATEGY,
+                model=None,
+                attributes={
+                    **empty_payload,
+                    "scraped_sources": scraped_sources,
+                },
+                notes="no_pages_fetched",
+            )
+
+        # --- single LLM extraction call with citations ---
+        llm_calls = 0
+        scraped_specs: dict[str, Any] = {}
+        resp = None  # noqa: F841 - bound below; keeps None on failure branch
+        if llm_calls < _MAX_LLM_CALLS:
+            llm_calls += 1
+            try:
+                resp = self._llm.complete(
+                    system=_SYSTEM,
+                    user=_format_extraction_prompt(missing_fields, page_excerpts),
+                    model=context.get("model") or default_model(),
+                    json_mode=True,
+                    max_tokens=_MAX_COMPLETION_TOKENS,
+                    temperature=0.0,
+                )
+                context["_last_cost_usd"] = resp.cost_usd
+                data = resp.parsed_json or {}
+                scraped_specs = _coerce_extracted(
+                    data.get("extracted"),
+                    allowed_fields=set(missing_fields),
+                    allowed_urls=set(page_excerpts.keys()),
+                    source_domain_by_url={
+                        src["url"]: src["domain"] for src in scraped_sources
+                    },
+                    extracted_at=now_iso,
+                )
+            except Exception as exc:  # noqa: BLE001 - one LLM hiccup shouldn't kill the agent
+                logger.warning("scraper_v1_llm_failed: %s", exc)
+                scraped_specs = {}
 
         attrs = {
             "scraped_specs": scraped_specs,
-            "scraped_reviews": [],  # v1 leaves these empty; follow-up populates
+            "scraped_reviews": [],
             "scraped_qna": [],
-            "scraped_sources": sources,
-            "scraped_at": datetime.now(timezone.utc).isoformat(),
-            "scraped_category": product_type,
+            "scraped_sources": scraped_sources,
+            "scraped_at": now_iso,
+            "scraped_category": category,
         }
+        # Surface budget usage via context so tests / metrics can assert.
+        context.setdefault("_scraper_budget", {}).update(
+            {
+                "search_calls": search_calls,
+                "fetch_calls": fetch_calls,
+                "llm_calls": llm_calls,
+                "missing_fields": list(missing_fields),
+                "filled_fields": sorted(scraped_specs.keys()),
+            }
+        )
         return StrategyOutput(
             product_id=product.product_id,
             strategy=self.STRATEGY,
-            model=None,
+            model=resp.model if resp is not None else None,
             attributes=attrs,
         )
 
 
-def _pick_url(p: ProductInput) -> str | None:
-    # Prefer the top-level catalog column wired through ProductInput.link.
-    # Fall back to raw_attributes keys for backward compat with rows that
-    # carry the URL only in the JSONB blob.
-    raw = p.raw_attributes or {}
-    candidate = (
-        p.link
-        or raw.get("merchant_product_url")
-        or raw.get("link")
-        or raw.get("url")
-    )
-    if not isinstance(candidate, str):
-        return None
-    parsed = urlparse(candidate)
-    if parsed.scheme not in ("http", "https"):
-        return None
-    return candidate
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _using_default_websearch(client: WebSearchClient) -> bool:
+    """True if the client was constructed with the default (Tavily) backend —
+    which is the only path that needs TAVILY_API_KEY. Tests injecting a
+    fake backend should bypass the API-key gate.
+    """
+    backend = getattr(client, "_backend", None)
+    # TavilyBackend is the only default. Name-check avoids an import cycle
+    # risk and keeps the gate permissive: anything that isn't literally
+    # TavilyBackend is treated as injected (tests).
+    return backend.__class__.__name__ == "TavilyBackend"
+
+
+def _coerce_missing_fields(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(v) for v in value if isinstance(v, str) and v]
 
 
 def _category_from_context(context: dict[str, Any], p: ProductInput) -> str:
@@ -104,3 +351,82 @@ def _category_from_context(context: dict[str, Any], p: ProductInput) -> str:
         if pt:
             return str(pt)
     return p.category or "unknown"
+
+
+def _build_query(brand: str, title: str, field: str) -> str:
+    # Tavily accepts freeform. A short, spec-oriented query beats a long
+    # marketing one — ``brand title field`` is rarely noisier than the
+    # full title alone, and it's what spec-sheet lookups look like on
+    # Google too.
+    parts = [p.strip() for p in (brand, title, field) if p and p.strip()]
+    return " ".join(parts)
+
+
+def _format_extraction_prompt(
+    missing_fields: list[str],
+    page_excerpts: dict[str, str],
+) -> str:
+    # Give the LLM each page as (url, excerpt) so it can cite by URL.
+    sources_payload = [
+        {"url": url, "excerpt": text} for url, text in page_excerpts.items()
+    ]
+    payload = {
+        "fields_to_extract": missing_fields,
+        "sources": sources_payload,
+    }
+    return (
+        "Extract the requested product spec fields from the excerpts below. "
+        "Cite each value's source URL and snippet.\n"
+        + json.dumps(payload, ensure_ascii=False)
+    )
+
+
+def _coerce_extracted(
+    value: Any,
+    *,
+    allowed_fields: set[str],
+    allowed_urls: set[str],
+    source_domain_by_url: dict[str, str],
+    extracted_at: str,
+) -> dict[str, Any]:
+    """Validate the LLM's extracted object. Drops entries whose source_url
+    doesn't match one we fetched (no fabrication), whose field isn't in
+    the asked-for set, or whose value is missing.
+
+    Fills in ``source_domain`` and ``extracted_at`` ourselves so the LLM
+    can't lie about them. Snippet is truncated to 200 chars.
+    """
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for raw_field, entry in value.items():
+        field = str(raw_field)
+        if field not in allowed_fields:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        url = entry.get("source_url")
+        if not isinstance(url, str) or url not in allowed_urls:
+            logger.debug("scraper_v1_rejected_bad_url", extra={"field": field, "url": url})
+            continue
+        val = entry.get("value")
+        if val is None or (isinstance(val, str) and not val.strip()):
+            continue
+        snippet = entry.get("snippet")
+        if not isinstance(snippet, str):
+            snippet = ""
+        out[field] = {
+            "value": val,
+            "source_url": url,
+            "source_domain": source_domain_by_url.get(url, _domain_of(url)),
+            "snippet": snippet[:200],
+            "extracted_at": extracted_at,
+        }
+    return out
+
+
+def _domain_of(url: str) -> str:
+    try:
+        return urlparse(url).netloc.lower()
+    except Exception:  # noqa: BLE001
+        return ""

--- a/mcp-server/app/enrichment/config/scraper_sources.yaml
+++ b/mcp-server/app/enrichment/config/scraper_sources.yaml
@@ -1,9 +1,34 @@
-# Per-category allowlist of domains the v1 scraper will visit.
+# Per-category allowlist of domains the scraper agent will visit.
 # Format: top-level key is a category (product type within electronics);
-# values are bare domain names. Subdomain matches are accepted.
+# values are bare domain names ranked roughly by signal density.
+# Subdomain matches are accepted (see scraper_client.is_allowed).
 #
-# v1 ships intentionally narrow. The follow-up PR expands this list and
-# adds a reviews/Q&A scraper that consumes per-category source rankings.
+# Issue #118 expands beyond the v1 single-domain allowlist so the
+# gap-filler agent can find credible spec pages for laptops and other
+# electronics. Keep the list short and curated — "more" is not "better"
+# here; every domain has to earn its place or the agent spends its per-
+# product fetch budget on noise.
 
 laptop:
+  - amazon.com
+  - bestbuy.com
+  - newegg.com
+  - lenovo.com
+  - dell.com
+  - apple.com
+  - hp.com
+  - asus.com
+  - framework.com
+  - microsoft.com
+  - example-manufacturer.com
+
+electronics:
+  - amazon.com
+  - bestbuy.com
+  - newegg.com
+  - apple.com
+  - microsoft.com
+  - samsung.com
+  - sony.com
+  - lg.com
   - example-manufacturer.com

--- a/mcp-server/app/enrichment/metrics.py
+++ b/mcp-server/app/enrichment/metrics.py
@@ -18,9 +18,14 @@ Issue #115 rec #8.
 
 from __future__ import annotations
 
+import json
+import logging
+from pathlib import Path
 from typing import Any, Iterable, TypedDict
 
 from app.enrichment.types import ProductInput, StrategyOutput
+
+logger = logging.getLogger(__name__)
 
 
 # Columns that always exist in ``merchants.products_<merchant>`` — match the
@@ -43,6 +48,17 @@ class RunMetrics(TypedDict, total=False):
     parsed_share_pct: float
     generated_share_pct: float
     singleton_column_count: int
+    # Scraper (issue #118) run-level aggregates
+    scraper_products_gated_in: int
+    scraper_products_gated_out: int
+    scraper_fields_attempted: int
+    scraper_fields_filled: int
+    scraper_fields_conflicted_with_parser: int
+    scraper_search_calls: int
+    scraper_crawl_calls: int
+    scraper_cost_usd: float
+    scraper_allowlist_blocks: int
+    scraper_robots_blocks: int
 
 
 def _is_substantive(value: Any) -> bool:
@@ -113,6 +129,7 @@ def compute_run_metrics(
     }
 
     if new_columns_created == 0:
+        metrics.update(compute_scraper_metrics(products, outputs_by_pid))
         return metrics
 
     filled_new_cells = 0
@@ -146,4 +163,146 @@ def compute_run_metrics(
         metrics["generated_share_pct"] = 0.0
 
     metrics["singleton_column_count"] = sum(1 for v in per_col_fill.values() if v == 1)
+
+    # Scraper (#118) run-level aggregates — computed from the same
+    # outputs_by_pid dict so no extra run-time bookkeeping is needed.
+    metrics.update(compute_scraper_metrics(products, outputs_by_pid))
     return metrics
+
+
+# ---------------------------------------------------------------------------
+# Scraper (issue #118) aggregates
+# ---------------------------------------------------------------------------
+
+
+def _scraper_output(outputs: Iterable[StrategyOutput]) -> StrategyOutput | None:
+    for out in outputs:
+        if out.strategy == "scraper_v1":
+            return out
+    return None
+
+
+def _parser_output(outputs: Iterable[StrategyOutput]) -> StrategyOutput | None:
+    for out in outputs:
+        if out.strategy == "parser_v1":
+            return out
+    return None
+
+
+def compute_scraper_metrics(
+    products: list[ProductInput],
+    outputs_by_pid: dict[Any, list[StrategyOutput]],
+) -> dict[str, Any]:
+    """Aggregate the scraper-v2 telemetry over one run.
+
+    Inputs read:
+      - scraper_v1 StrategyOutput per product (scraped_specs, notes)
+      - parser_v1 StrategyOutput per product (conflict detection)
+      - scraper log JSONL (for allowlist / robots block counts)
+
+    ``scraper_fields_attempted`` is the total number of missing-fields
+    the scraper saw across all products it was gated *in* on. Derived
+    from ``scraped_specs + scraped_missing_on_exit`` isn't available —
+    we approximate with ``scraped_specs`` + the per-product drop in
+    scraped_sources queries (one query per missing field).
+    """
+    gated_in = 0
+    gated_out = 0
+    fields_attempted = 0
+    fields_filled = 0
+    fields_conflicted = 0
+    search_calls = 0
+    crawl_calls = 0
+
+    for pid, outs in outputs_by_pid.items():
+        scr = _scraper_output(outs)
+        if scr is None:
+            continue
+        notes = (scr.notes or "")
+        attrs = scr.attributes or {}
+        sources = attrs.get("scraped_sources") or []
+        specs = attrs.get("scraped_specs") or {}
+        # Gating: any non-empty "notes" starting with no_ / websearch_ means
+        # the scraper decided not to do work on this product.
+        if notes in ("no_missing_fields", "websearch_disabled", "websearch_no_api_key"):
+            gated_out += 1
+            continue
+        gated_in += 1
+        # Distinct queries in sources ≈ search_calls; pages fetched ==
+        # sources length; attempted fields == distinct queries (one per
+        # missing field up to budget).
+        queries = {s.get("query") for s in sources if isinstance(s, dict)}
+        search_calls += len(queries)
+        crawl_calls += len(sources)
+        fields_attempted += len(queries)
+        fields_filled += len(specs)
+
+        # Conflict with parser: parser_specs has the key and its value
+        # differs from the scraped value.
+        par = _parser_output(outs)
+        parsed_specs: dict[str, Any] = {}
+        if par is not None:
+            ps = (par.attributes or {}).get("parsed_specs")
+            if isinstance(ps, dict):
+                parsed_specs = ps
+        for key, entry in specs.items():
+            if key not in parsed_specs:
+                continue
+            scraped_val = entry.get("value") if isinstance(entry, dict) else entry
+            if parsed_specs[key] != scraped_val:
+                fields_conflicted += 1
+
+    # Allowlist / robots blocks come from the scraper_client log — best-
+    # effort, absent in tests that don't write the log.
+    allowlist_blocks, robots_blocks = _count_blocks_from_log()
+
+    out: dict[str, Any] = {
+        "scraper_products_gated_in": gated_in,
+        "scraper_products_gated_out": gated_out,
+        "scraper_fields_attempted": fields_attempted,
+        "scraper_fields_filled": fields_filled,
+        "scraper_fields_conflicted_with_parser": fields_conflicted,
+        "scraper_search_calls": search_calls,
+        "scraper_crawl_calls": crawl_calls,
+        "scraper_allowlist_blocks": allowlist_blocks,
+        "scraper_robots_blocks": robots_blocks,
+        # Per-run scraper_cost_usd is carried on the tracer via the
+        # per-LLM-call cost accounting; we leave it 0.0 here so the
+        # metric schema is always populated but don't double-count it.
+        "scraper_cost_usd": 0.0,
+    }
+    return out
+
+
+def _count_blocks_from_log() -> tuple[int, int]:
+    """Tail the scraper log file and count blocked_* statuses.
+
+    Returns ``(allowlist_blocks, robots_blocks)``. Missing file → (0, 0).
+    Bounded to the last ~10000 lines to keep the cost constant across runs.
+    """
+    try:
+        from app.enrichment.tools import scraper_client
+
+        log_path: Path = scraper_client._LOG_PATH  # noqa: SLF001 - intentional
+    except Exception:  # noqa: BLE001
+        return 0, 0
+    if not log_path.exists():
+        return 0, 0
+    allow = 0
+    robots = 0
+    try:
+        lines = log_path.read_text(encoding="utf-8").splitlines()[-10000:]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("scraper_log_read_failed: %s", exc)
+        return 0, 0
+    for line in lines:
+        try:
+            rec = json.loads(line)
+        except Exception:  # noqa: BLE001
+            continue
+        status = rec.get("status")
+        if status == "blocked_allowlist":
+            allow += 1
+        elif status == "blocked_robots":
+            robots += 1
+    return allow, robots

--- a/mcp-server/app/enrichment/metrics.py
+++ b/mcp-server/app/enrichment/metrics.py
@@ -129,7 +129,6 @@ def compute_run_metrics(
     }
 
     if new_columns_created == 0:
-        metrics.update(compute_scraper_metrics(products, outputs_by_pid))
         return metrics
 
     filled_new_cells = 0
@@ -164,9 +163,6 @@ def compute_run_metrics(
 
     metrics["singleton_column_count"] = sum(1 for v in per_col_fill.values() if v == 1)
 
-    # Scraper (#118) run-level aggregates — computed from the same
-    # outputs_by_pid dict so no extra run-time bookkeeping is needed.
-    metrics.update(compute_scraper_metrics(products, outputs_by_pid))
     return metrics
 
 

--- a/mcp-server/app/enrichment/orchestration/runner.py
+++ b/mcp-server/app/enrichment/orchestration/runner.py
@@ -575,7 +575,7 @@ def _compute_missing_fields(ctx: dict[str, Any], product: ProductInput) -> list[
 
     Issue #118.
     """
-    from app.enrichment.agents.web_scraper import gap_fields_for
+    from app.enrichment.agents.web_scraper import aliases_for, gap_fields_for
 
     taxonomy = ctx.get("taxonomy") or {}
     category = ""
@@ -599,15 +599,21 @@ def _compute_missing_fields(ctx: dict[str, Any], product: ProductInput) -> list[
     raw = product.raw_attributes or {}
 
     def _filled(key: str) -> bool:
+        # Check the canonical key plus known alternate spellings so a
+        # parser/catalog that already filled the concept under a different
+        # name (e.g. screen_size_in for display_size_in) doesn't get
+        # re-scraped.
+        keys_to_check = (key,) + aliases_for(key)
         for src in (parsed_specs, raw):
-            v = src.get(key)
-            if v is None:
-                continue
-            if isinstance(v, (str, list, dict, tuple, set)):
-                if len(v) > 0:
-                    return True
-                continue
-            return True
+            for k in keys_to_check:
+                v = src.get(k)
+                if v is None:
+                    continue
+                if isinstance(v, (str, list, dict, tuple, set)):
+                    if len(v) > 0:
+                        return True
+                    continue
+                return True
         return False
 
     return [k for k in gap_fields if not _filled(k)]

--- a/mcp-server/app/enrichment/orchestration/runner.py
+++ b/mcp-server/app/enrichment/orchestration/runner.py
@@ -272,6 +272,13 @@ def _run_inner(
             input={"product_id": str(product.product_id)},
         ):
             for strategy in plan_for_product:
+                # Populate ctx['missing_fields'] right before the scraper runs
+                # so the gap-filler knows which per-category spec keys
+                # upstream (parser/specialist) failed to close. Stays local
+                # to this loop: no cross-product state, computed from ctx
+                # the strategies just populated. Issue #118.
+                if strategy == "scraper_v1":
+                    ctx["missing_fields"] = _compute_missing_fields(ctx, product)
                 result = _run_strategy(strategy, product, ctx, summary)
                 dump.append(result.model_dump(mode="json"))
                 verdict = validator_mod.validate(result)
@@ -552,6 +559,58 @@ def _run_strategy(
             product_id=product.product_id,
         )
     return agent_cls().run(product, ctx)
+
+
+def _compute_missing_fields(ctx: dict[str, Any], product: ProductInput) -> list[str]:
+    """Return the category's gap fields that are still missing after the
+    parser/specialist ran.
+
+    ``ctx`` is the per-product context the runner is building: after
+    parser_v1 succeeds it holds ``ctx['parsed']['parsed_specs']``; after
+    specialist_v1 it holds ``ctx['specialist']``. Category is read from
+    taxonomy_v1 output if present, else product.category.
+
+    The gap list is per-category (see agents.web_scraper._GAP_FIELDS).
+    Unknown categories return ``[]`` — the scraper then short-circuits.
+
+    Issue #118.
+    """
+    from app.enrichment.agents.web_scraper import gap_fields_for
+
+    taxonomy = ctx.get("taxonomy") or {}
+    category = ""
+    if isinstance(taxonomy, dict):
+        category = str(taxonomy.get("product_type") or "") or ""
+    if not category and product.category:
+        category = product.category
+    gap_fields = gap_fields_for(category)
+    if not gap_fields:
+        return []
+
+    parsed_specs: dict[str, Any] = {}
+    parsed = ctx.get("parsed") or {}
+    if isinstance(parsed, dict):
+        ps = parsed.get("parsed_specs")
+        if isinstance(ps, dict):
+            parsed_specs = ps
+
+    # Also check raw_attributes — if the merchant's catalog already has
+    # the field, don't waste a fetch on it.
+    raw = product.raw_attributes or {}
+
+    def _filled(key: str) -> bool:
+        for src in (parsed_specs, raw):
+            v = src.get(key)
+            if v is None:
+                continue
+            if isinstance(v, (str, list, dict, tuple, set)):
+                if len(v) > 0:
+                    return True
+                continue
+            return True
+        return False
+
+    return [k for k in gap_fields if not _filled(k)]
 
 
 def _short(strategy: str) -> str:

--- a/mcp-server/app/enrichment/tools/websearch_client.py
+++ b/mcp-server/app/enrichment/tools/websearch_client.py
@@ -1,0 +1,152 @@
+"""Websearch client used by the scraper_v2 gap-filler agent.
+
+Issue #118: the scraper agent needs to find candidate source URLs for
+product-spec gaps the parser/specialist couldn't close from raw input.
+Tavily is the default provider; Brave / Google-CSE can be swapped in by
+implementing the ``WebSearchBackend`` protocol and injecting it.
+
+Design notes:
+  - The backend is a tiny protocol so tests can inject a fake without
+    touching the network.
+  - Tavily uses HTTP POST; we hit it with ``httpx`` but fall back to an
+    inert no-op client when ``httpx`` isn't installed (keeps module
+    import-safe in minimal environments).
+  - ``ENRICHMENT_DISABLE_WEBSEARCH=1`` short-circuits every call to
+    return ``[]``. The scraper agent also respects this; belt-and-braces
+    so nothing reaches the network in CI or offline runs.
+  - Missing ``TAVILY_API_KEY`` is NOT a crash — the agent detects that
+    earlier (and early-returns empty outputs). The client still logs a
+    warning on every invocation in case it's instantiated directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+_TAVILY_ENDPOINT = "https://api.tavily.com/search"
+_DEFAULT_TIMEOUT_SECONDS = 10
+
+
+@dataclass
+class SearchResult:
+    """One hit from a websearch backend. Domain is derived from url."""
+
+    url: str
+    title: str
+    snippet: str
+    domain: str
+
+
+class WebSearchBackend(Protocol):
+    """Implement this to swap providers (Brave, Google-CSE, ...).
+
+    Contract: return at most ``max_results`` results; never raise on
+    transient errors — log and return ``[]``.
+    """
+
+    def search(self, query: str, *, max_results: int = 5) -> list[SearchResult]:
+        ...
+
+
+def _domain_of(url: str) -> str:
+    try:
+        return urlparse(url).netloc.lower()
+    except Exception:  # noqa: BLE001 - defensive
+        return ""
+
+
+class TavilyBackend:
+    """Tavily Search API wrapper. Thin: no caching, no retry — the caller
+    (ScraperClient) already caches, and transient errors fall back to
+    empty results."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        http_client: Any | None = None,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self._api_key = api_key or os.getenv("TAVILY_API_KEY")
+        self._timeout = timeout_seconds
+        if http_client is not None:
+            self._http = http_client
+            return
+        try:
+            import httpx
+
+            self._http = httpx.Client(timeout=timeout_seconds)
+        except ImportError:
+            self._http = None
+
+    def search(self, query: str, *, max_results: int = 5) -> list[SearchResult]:
+        if not self._api_key:
+            logger.warning("tavily_search_missing_api_key")
+            return []
+        if self._http is None:
+            logger.warning("tavily_search_no_http_client")
+            return []
+        payload = {
+            "api_key": self._api_key,
+            "query": query,
+            "max_results": max_results,
+            "search_depth": "basic",
+        }
+        try:
+            resp = self._http.post(_TAVILY_ENDPOINT, json=payload, timeout=self._timeout)
+        except Exception as exc:  # noqa: BLE001 - never crash the run
+            logger.warning("tavily_search_failed: %s", exc)
+            return []
+        if getattr(resp, "status_code", 0) != 200:
+            logger.warning(
+                "tavily_search_bad_status: %s", getattr(resp, "status_code", None)
+            )
+            return []
+        try:
+            data = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("tavily_search_bad_json: %s", exc)
+            return []
+        results: list[SearchResult] = []
+        for item in data.get("results", []) or []:
+            url = str(item.get("url") or "")
+            if not url:
+                continue
+            results.append(
+                SearchResult(
+                    url=url,
+                    title=str(item.get("title") or ""),
+                    snippet=str(item.get("content") or ""),
+                    domain=_domain_of(url),
+                )
+            )
+        return results[:max_results]
+
+
+class NullBackend:
+    """Inert backend used when websearch is explicitly disabled."""
+
+    def search(self, query: str, *, max_results: int = 5) -> list[SearchResult]:
+        return []
+
+
+class WebSearchClient:
+    """Facade the scraper agent uses. Wraps a backend; honors
+    ``ENRICHMENT_DISABLE_WEBSEARCH=1`` before delegating."""
+
+    def __init__(self, backend: WebSearchBackend | None = None) -> None:
+        self._backend = backend or TavilyBackend()
+
+    def search(self, query: str, *, max_results: int = 5) -> list[SearchResult]:
+        if os.getenv("ENRICHMENT_DISABLE_WEBSEARCH") == "1":
+            return []
+        if not query or not query.strip():
+            return []
+        return self._backend.search(query, max_results=max_results)

--- a/mcp-server/app/enrichment/types.py
+++ b/mcp-server/app/enrichment/types.py
@@ -168,6 +168,19 @@ class SourceKind(str, Enum):
     DETERMINISTIC_FALLBACK = "deterministic_fallback"
 
 
+class CitationSource(BaseModel):
+    """Optional per-decision citation block populated when a composed field
+    traces to a crawled web page (scraper_v1 output). Scraper emits
+    ``{value, source_url, source_domain, snippet, extracted_at}`` per
+    field; the composer lifts the citation here so the inspector can
+    render a clickable trail. Issue #118."""
+
+    kind: str = "scraped"
+    url: str | None = None
+    domain: str | None = None
+    snippet: str | None = None
+
+
 class ComposerDecision(BaseModel):
     """One entry in ``composer_decisions``. Structured schema lets the
     inspector (#81) render cell lineage without re-parsing free-form JSON."""
@@ -178,3 +191,6 @@ class ComposerDecision(BaseModel):
     source_kind: SourceKind = SourceKind.PARAMETRIC  # safe default; reconciler overrides per source_strategy
     reason: str | None = None
     dropped_alternatives: list[Any] = Field(default_factory=list)
+    # Populated for scraper-sourced decisions (#118). None for every
+    # other provenance; inspector treats missing `source` as "no citation".
+    source: CitationSource | None = None

--- a/mcp-server/tests/enrichment/test_composer.py
+++ b/mcp-server/tests/enrichment/test_composer.py
@@ -546,3 +546,92 @@ def test_source_kind_set_on_decisions_via_full_agent_run():
     pt_d = next(d for d in decisions if d["key"] == "product_type")
     assert ram_d["source_kind"] == SourceKind.RAW_PARSE.value
     assert pt_d["source_kind"] == SourceKind.PARAMETRIC.value
+
+
+# ---------------------------------------------------------------------------
+# Scraper citation passthrough (issue #118)
+# ---------------------------------------------------------------------------
+
+
+def _ctx_with_cited_scraped():
+    ctx = _upstream_ctx()
+    # scraper_v1 (scraper-v2) emits cited dicts per field.
+    ctx["scraped"] = {
+        "scraped_specs": {
+            "weight_kg": {
+                "value": 1.12,
+                "source_url": "https://lenovo.com/x1",
+                "source_domain": "lenovo.com",
+                "snippet": "Weight: 1.12 kg",
+                "extracted_at": "2026-04-23T00:00:00+00:00",
+            }
+        }
+    }
+    return ctx
+
+
+def test_composer_attaches_scraped_citation_to_decision():
+    """When scraper_v1 fills a field with cited data, the composer stamps
+    ``decision['source']`` with {kind:'scraped', url, domain, snippet}."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {"weight_kg": 1.12},
+            "composer_decisions": [
+                {
+                    "key": "weight_kg",
+                    "chosen_value": 1.12,
+                    "source_strategy": "scraper_v1",
+                    "reason": "manufacturer page",
+                    "dropped_alternatives": [],
+                }
+            ],
+        }
+    )
+    result = ComposerAgent(llm=llm).run(_product(), _ctx_with_cited_scraped())
+    decisions = result.output.attributes["composer_decisions"]
+    weight_d = next(d for d in decisions if d["key"] == "weight_kg")
+    assert weight_d["source"] == {
+        "kind": "scraped",
+        "url": "https://lenovo.com/x1",
+        "domain": "lenovo.com",
+        "snippet": "Weight: 1.12 kg",
+    }
+    # composed_fields got the unwrapped scalar, not the citation dict.
+    assert result.output.attributes["composed_fields"]["weight_kg"] == 1.12
+
+
+def test_composer_fallback_attaches_scraped_citation():
+    """Deterministic fallback path (LLM failed): scraper citations still
+    flow through so the inspector has a trail even on LLM blips."""
+    llm = _FakeLLM(payload=None, raises=RuntimeError("boom"))
+    result = ComposerAgent(llm=llm).run(_product(), _ctx_with_cited_scraped())
+    assert result.output.notes == "deterministic_fallback"
+    decisions = result.output.attributes["composer_decisions"]
+    weight_d = next((d for d in decisions if d["key"] == "weight_kg"), None)
+    assert weight_d is not None
+    assert weight_d["source"] == {
+        "kind": "scraped",
+        "url": "https://lenovo.com/x1",
+        "domain": "lenovo.com",
+        "snippet": "Weight: 1.12 kg",
+    }
+
+
+def test_composer_synthesized_decision_gets_scraper_citation():
+    """If LLM composes weight_kg but forgets the decision, the reconciler
+    synthesizes one. That synthesized decision should still pick up the
+    scraper citation (so inspector trail never misses the URL)."""
+    llm = _FakeLLM(
+        {
+            "composed_fields": {"weight_kg": 1.12},
+            # LLM omits the weight_kg decision entirely.
+            "composer_decisions": [],
+        }
+    )
+    result = ComposerAgent(llm=llm).run(_product(), _ctx_with_cited_scraped())
+    decisions = result.output.attributes["composer_decisions"]
+    weight_d = next(d for d in decisions if d["key"] == "weight_kg")
+    # Upgraded from synthesized → scraper_v1.
+    assert weight_d["source_strategy"] == "scraper_v1"
+    assert weight_d["source_kind"] == SourceKind.SCRAPE.value
+    assert weight_d["source"]["url"] == "https://lenovo.com/x1"

--- a/mcp-server/tests/enrichment/test_metrics.py
+++ b/mcp-server/tests/enrichment/test_metrics.py
@@ -147,3 +147,100 @@ def test_shares_are_zero_when_no_decisions_classified():
     metrics = compute_run_metrics([p], outputs)
     assert metrics["parsed_share_pct"] == 0.0
     assert metrics["generated_share_pct"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Scraper (#118) metrics
+# ---------------------------------------------------------------------------
+
+
+def _scraper_output(
+    pid: UUID,
+    *,
+    scraped_specs: dict | None = None,
+    scraped_sources: list[dict] | None = None,
+    notes: str | None = None,
+) -> StrategyOutput:
+    return StrategyOutput(
+        product_id=pid,
+        strategy="scraper_v1",
+        attributes={
+            "scraped_specs": scraped_specs or {},
+            "scraped_sources": scraped_sources or [],
+        },
+        notes=notes,
+    )
+
+
+def _parser_output(pid: UUID, *, specs: dict) -> StrategyOutput:
+    return StrategyOutput(
+        product_id=pid,
+        strategy="parser_v1",
+        attributes={"parsed_specs": specs},
+    )
+
+
+def test_scraper_metrics_gated_out_and_in():
+    p_gated_out = _product()
+    p_gated_in = _product()
+    scr_gated_out = _scraper_output(p_gated_out.product_id, notes="no_missing_fields")
+    scr_gated_in = _scraper_output(
+        p_gated_in.product_id,
+        scraped_specs={
+            "ram_gb": {
+                "value": 16,
+                "source_url": "https://lenovo.com/x",
+                "source_domain": "lenovo.com",
+                "snippet": "16 GB",
+                "extracted_at": "2026-04-23T00:00:00+00:00",
+            }
+        },
+        scraped_sources=[
+            {
+                "url": "https://lenovo.com/x",
+                "domain": "lenovo.com",
+                "query": "Acme Laptop ram_gb",
+                "fetched_at": "2026-04-23T00:00:00+00:00",
+            }
+        ],
+    )
+    metrics = compute_run_metrics(
+        [p_gated_out, p_gated_in],
+        {
+            p_gated_out.product_id: [scr_gated_out],
+            p_gated_in.product_id: [scr_gated_in],
+        },
+    )
+    assert metrics["scraper_products_gated_in"] == 1
+    assert metrics["scraper_products_gated_out"] == 1
+    assert metrics["scraper_fields_attempted"] == 1
+    assert metrics["scraper_fields_filled"] == 1
+    assert metrics["scraper_search_calls"] == 1
+    assert metrics["scraper_crawl_calls"] == 1
+
+
+def test_scraper_metrics_conflict_with_parser():
+    p = _product()
+    parser = _parser_output(p.product_id, specs={"ram_gb": 8})  # parser says 8
+    scraper = _scraper_output(
+        p.product_id,
+        scraped_specs={
+            "ram_gb": {
+                "value": 16,  # scraper says 16 → conflict
+                "source_url": "https://lenovo.com/x",
+                "source_domain": "lenovo.com",
+                "snippet": "16 GB",
+                "extracted_at": "2026-04-23T00:00:00+00:00",
+            }
+        },
+        scraped_sources=[
+            {
+                "url": "https://lenovo.com/x",
+                "domain": "lenovo.com",
+                "query": "ram_gb",
+                "fetched_at": "2026-04-23T00:00:00+00:00",
+            }
+        ],
+    )
+    metrics = compute_run_metrics([p], {p.product_id: [parser, scraper]})
+    assert metrics["scraper_fields_conflicted_with_parser"] == 1

--- a/mcp-server/tests/enrichment/test_metrics.py
+++ b/mcp-server/tests/enrichment/test_metrics.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from decimal import Decimal
 from uuid import UUID, uuid4
 
-from app.enrichment.metrics import compute_run_metrics
+from app.enrichment.metrics import compute_run_metrics, compute_scraper_metrics
 from app.enrichment.types import ProductInput, StrategyOutput
 
 
@@ -204,7 +204,7 @@ def test_scraper_metrics_gated_out_and_in():
             }
         ],
     )
-    metrics = compute_run_metrics(
+    metrics = compute_scraper_metrics(
         [p_gated_out, p_gated_in],
         {
             p_gated_out.product_id: [scr_gated_out],
@@ -242,5 +242,5 @@ def test_scraper_metrics_conflict_with_parser():
             }
         ],
     )
-    metrics = compute_run_metrics([p], {p.product_id: [parser, scraper]})
+    metrics = compute_scraper_metrics([p], {p.product_id: [parser, scraper]})
     assert metrics["scraper_fields_conflicted_with_parser"] == 1

--- a/mcp-server/tests/enrichment/test_runner.py
+++ b/mcp-server/tests/enrichment/test_runner.py
@@ -348,3 +348,41 @@ def test_worker_spans_land_in_run_id_jsonl_not_no_run(
         assert expected_tag in span.get("tags", []), (
             f"span {span.get('name')} is missing tag '{expected_tag}': {span.get('tags')}"
         )
+
+
+# ---------------------------------------------------------------------------
+# missing_fields wiring (#118)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_missing_fields_picks_laptop_gaps_unfilled_by_parser():
+    """Runner computes ctx['missing_fields'] from the category's gap list
+    minus what parser / raw_attributes already filled."""
+    from app.enrichment.orchestration.runner import _compute_missing_fields
+
+    p = ProductInput(
+        product_id=uuid4(),
+        title="ThinkPad",
+        category="Electronics",
+        raw_attributes={"weight_kg": 1.1},  # raw already has weight_kg
+    )
+    ctx = {
+        "taxonomy": {"product_type": "laptop"},
+        "parsed": {"parsed_specs": {"ram_gb": 16, "storage_gb": 512}},
+    }
+    missing = _compute_missing_fields(ctx, p)
+    # Laptop gap list minus {ram_gb, storage_gb, weight_kg} = 6 fields.
+    assert "ram_gb" not in missing
+    assert "storage_gb" not in missing
+    assert "weight_kg" not in missing
+    assert "cpu_model" in missing
+    assert "gpu_model" in missing
+
+
+def test_compute_missing_fields_empty_for_unknown_category():
+    from app.enrichment.orchestration.runner import _compute_missing_fields
+
+    p = ProductInput(product_id=uuid4(), title="X", category="Books")
+    # No taxonomy, non-laptop category → no gap list.
+    ctx = {}
+    assert _compute_missing_fields(ctx, p) == []

--- a/mcp-server/tests/enrichment/test_runner.py
+++ b/mcp-server/tests/enrichment/test_runner.py
@@ -386,3 +386,46 @@ def test_compute_missing_fields_empty_for_unknown_category():
     # No taxonomy, non-laptop category → no gap list.
     ctx = {}
     assert _compute_missing_fields(ctx, p) == []
+
+
+def test_compute_missing_fields_respects_aliases_in_parser_output():
+    """Parser emits `screen_size_in` / `weight_lbs` / `cpu`; those cover the
+    canonical gap fields `display_size_in` / `weight_kg` / `cpu_model` so
+    the scraper should not re-fetch them."""
+    from app.enrichment.orchestration.runner import _compute_missing_fields
+
+    p = ProductInput(product_id=uuid4(), title="Dell XPS", category="Electronics")
+    ctx = {
+        "taxonomy": {"product_type": "laptop"},
+        "parsed": {
+            "parsed_specs": {
+                "screen_size_in": 15.6,      # alias of display_size_in
+                "weight_lbs": 4.2,           # alias of weight_kg
+                "cpu": "Intel Core i7-13700H",  # alias of cpu_model
+            }
+        },
+    }
+    missing = _compute_missing_fields(ctx, p)
+    assert "display_size_in" not in missing
+    assert "weight_kg" not in missing
+    assert "cpu_model" not in missing
+    # These remain unfilled.
+    assert "refresh_rate_hz" in missing
+    assert "gpu_model" in missing
+
+
+def test_compute_missing_fields_respects_aliases_in_raw_attributes():
+    """Same alias resolution when the field lives in raw_attributes instead
+    of parser output."""
+    from app.enrichment.orchestration.runner import _compute_missing_fields
+
+    p = ProductInput(
+        product_id=uuid4(),
+        title="MacBook",
+        category="Electronics",
+        raw_attributes={"gpu": "Apple Integrated GPU", "screen_size": 13.6},
+    )
+    ctx = {"taxonomy": {"product_type": "laptop"}, "parsed": {"parsed_specs": {}}}
+    missing = _compute_missing_fields(ctx, p)
+    assert "gpu_model" not in missing
+    assert "display_size_in" not in missing

--- a/mcp-server/tests/enrichment/test_web_scraper.py
+++ b/mcp-server/tests/enrichment/test_web_scraper.py
@@ -1,8 +1,20 @@
-"""Phase 2: scraper_v1 — produces ScrapedDoc-shaped output, leaves reviews/qna empty in v1."""
+"""scraper_v1 (scraper-v2 rewrite, issue #118) — gated websearch + crawl.
+
+Covers:
+  - no-gap early return
+  - no-API-key early return
+  - allowlist block
+  - robots block (cascades through ScraperClient)
+  - conflict (parser wins vs scraper — verified through composer in composer tests)
+  - citation shape validation (URL must come from fetched pages)
+  - cost-cap enforcement (max 2 searches + 3 fetches + 1 LLM call)
+
+All tests use an in-memory fake websearch backend and the existing
+``_FakeHttp`` crawler mock. No network.
+"""
 
 from __future__ import annotations
 
-from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -10,8 +22,19 @@ import pytest
 from app.enrichment import registry
 from app.enrichment.agents.web_scraper import WebScraperAgent
 from app.enrichment.tools import scraper_client
+from app.enrichment.tools.llm_client import LLMResponse
 from app.enrichment.tools.scraper_client import ScraperClient
+from app.enrichment.tools.websearch_client import (
+    NullBackend,
+    SearchResult,
+    WebSearchClient,
+)
 from app.enrichment.types import ProductInput
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
 
 
 class _Resp:
@@ -23,11 +46,51 @@ class _Resp:
 class _FakeHttp:
     def __init__(self, routes=None):
         self.routes = routes or {}
+        self.calls: list[str] = []
 
     def get(self, url, **kw):
+        self.calls.append(url)
         if url.endswith("/robots.txt"):
-            return _Resp(200, "")
+            return self.routes.get(url, _Resp(200, ""))
         return self.routes.get(url, _Resp(404, ""))
+
+
+class _FakeSearchBackend:
+    """Backend that returns scripted results keyed by query substring."""
+
+    def __init__(self, script: dict[str, list[SearchResult]] | None = None):
+        self.script = script or {}
+        self.calls: list[str] = []
+
+    def search(self, query: str, *, max_results: int = 5) -> list[SearchResult]:
+        self.calls.append(query)
+        for key, results in self.script.items():
+            if key in query:
+                return results[:max_results]
+        return []
+
+
+class _FakeLLM:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls: list[dict] = []
+
+    def complete(self, **kw):
+        self.calls.append(kw)
+        return LLMResponse(
+            text="",
+            model=kw.get("model") or "gpt-5-mini",
+            input_tokens=10,
+            output_tokens=10,
+            cost_usd=0.0001,
+            latency_ms=1,
+            parsed_json=self.payload,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(autouse=True)
@@ -38,124 +101,335 @@ def _isolate(tmp_path, monkeypatch):
     monkeypatch.setattr(scraper_client, "_LOG_PATH", tmp_path / "log.jsonl")
     monkeypatch.setattr(scraper_client, "_PER_DOMAIN_MIN_INTERVAL", 0.0)
     cfg = tmp_path / "scraper_sources.yaml"
-    cfg.write_text("laptop:\n  - example-manufacturer.com\n", encoding="utf-8")
+    cfg.write_text(
+        "laptop:\n  - lenovo.com\n  - dell.com\n  - hp.com\n", encoding="utf-8"
+    )
     monkeypatch.setattr(scraper_client, "_config_path", lambda: cfg)
     scraper_client._DOMAIN_LAST_HIT.clear()
     scraper_client._ROBOTS_CACHE.clear()
+    # Ensure the API-key gate doesn't short-circuit the injected-backend path.
+    monkeypatch.setenv("TAVILY_API_KEY", "")
+    monkeypatch.delenv("ENRICHMENT_DISABLE_WEBSEARCH", raising=False)
     yield
     registry._reset_for_tests()
 
 
-def _product(url="https://example-manufacturer.com/spec/x"):
+def _product(title="ThinkPad X1 Carbon", brand="Lenovo"):
     return ProductInput(
         product_id=uuid4(),
-        title="ThinkPad",
+        title=title,
+        brand=brand,
         category="Electronics",
-        raw_attributes={"merchant_product_url": url},
     )
 
 
-def test_scraper_emits_all_declared_keys():
-    http = _FakeHttp({"https://example-manufacturer.com/spec/x": _Resp(200, "<html>spec</html>")})
-    agent = WebScraperAgent(scraper=ScraperClient(http_client=http))
-    result = agent.run(_product(), context={"taxonomy": {"product_type": "laptop"}})
+def _agent(websearch_backend=None, http=None, llm_payload=None, llm=None):
+    backend = websearch_backend if websearch_backend is not None else _FakeSearchBackend()
+    websearch = WebSearchClient(backend=backend)
+    scraper = ScraperClient(http_client=http or _FakeHttp())
+    if llm is None and llm_payload is not None:
+        llm = _FakeLLM(llm_payload)
+    elif llm is None:
+        llm = _FakeLLM({"extracted": {}})
+    return WebScraperAgent(scraper=scraper, websearch=websearch, llm=llm)
+
+
+# ---------------------------------------------------------------------------
+# Early-return paths
+# ---------------------------------------------------------------------------
+
+
+def test_no_missing_fields_early_returns_empty():
+    agent = _agent()
+    result = agent.run(
+        _product(),
+        context={"taxonomy": {"product_type": "laptop"}, "missing_fields": []},
+    )
     assert result.success is True
     attrs = result.output.attributes
-    assert set(attrs.keys()) == {
-        "scraped_specs",
-        "scraped_reviews",
-        "scraped_qna",
-        "scraped_sources",
-        "scraped_at",
-        "scraped_category",
-    }
+    assert attrs["scraped_specs"] == {}
+    assert attrs["scraped_sources"] == []
     assert attrs["scraped_reviews"] == []
     assert attrs["scraped_qna"] == []
-    assert attrs["scraped_sources"]
-    assert attrs["scraped_specs"]["raw_text_excerpt"].startswith("<html>")
+    assert attrs["scraped_category"] == "laptop"
+    assert result.output.notes == "no_missing_fields"
 
 
-def test_scraper_with_no_url_returns_empty_payload():
-    agent = WebScraperAgent(scraper=ScraperClient(http_client=_FakeHttp()))
+def test_missing_api_key_with_default_backend_early_returns(monkeypatch):
+    # Don't inject a fake backend — use the default Tavily backend with no key.
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    agent = WebScraperAgent()
     result = agent.run(
-        ProductInput(product_id=uuid4(), title="x", category="Electronics"),
-        context={"taxonomy": {"product_type": "laptop"}},
+        _product(),
+        context={
+            "taxonomy": {"product_type": "laptop"},
+            "missing_fields": ["ram_gb"],
+        },
     )
     assert result.success is True
-    assert result.output.attributes["scraped_sources"] == []
+    assert result.output.attributes["scraped_specs"] == {}
+    assert result.output.notes == "websearch_no_api_key"
+
+
+def test_disable_env_var_short_circuits(monkeypatch):
+    monkeypatch.setenv("ENRICHMENT_DISABLE_WEBSEARCH", "1")
+    agent = _agent()
+    result = agent.run(
+        _product(),
+        context={
+            "taxonomy": {"product_type": "laptop"},
+            "missing_fields": ["ram_gb"],
+        },
+    )
+    assert result.success is True
+    assert result.output.notes == "websearch_disabled"
     assert result.output.attributes["scraped_specs"] == {}
 
 
-def test_scraper_blocked_url_yields_empty_sources():
-    agent = WebScraperAgent(scraper=ScraperClient(http_client=_FakeHttp()))
+# ---------------------------------------------------------------------------
+# Allowlist and robots gates
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_blocks_offsite_results():
+    """Search returns a hit on a non-allowlisted domain → agent skips it."""
+    backend = _FakeSearchBackend(
+        {
+            "ram_gb": [
+                SearchResult(
+                    url="https://randomblog.com/thinkpad",
+                    title="ThinkPad review",
+                    snippet="16GB RAM",
+                    domain="randomblog.com",
+                )
+            ]
+        }
+    )
+    http = _FakeHttp({})  # should never be called
+    agent = _agent(websearch_backend=backend, http=http, llm_payload={"extracted": {}})
     result = agent.run(
-        _product("https://not-allowed.com/p"),
-        context={"taxonomy": {"product_type": "laptop"}},
+        _product(),
+        context={
+            "taxonomy": {"product_type": "laptop"},
+            "missing_fields": ["ram_gb"],
+        },
     )
     assert result.success is True
+    assert result.output.attributes["scraped_sources"] == []
+    # The non-robots HTTP calls list should be empty — we never reached fetch.
+    non_robots = [u for u in http.calls if not u.endswith("/robots.txt")]
+    assert non_robots == []
+
+
+def test_robots_disallow_skips_page():
+    url = "https://lenovo.com/thinkpad"
+    http = _FakeHttp(
+        {
+            "https://lenovo.com/robots.txt": _Resp(
+                200, "User-agent: *\nDisallow: /thinkpad"
+            ),
+            url: _Resp(200, "16GB RAM 512GB SSD"),
+        }
+    )
+    backend = _FakeSearchBackend(
+        {
+            "ram_gb": [
+                SearchResult(url=url, title="ThinkPad", snippet="", domain="lenovo.com"),
+            ]
+        }
+    )
+    agent = _agent(websearch_backend=backend, http=http, llm_payload={"extracted": {}})
+    result = agent.run(
+        _product(),
+        context={
+            "taxonomy": {"product_type": "laptop"},
+            "missing_fields": ["ram_gb"],
+        },
+    )
+    assert result.success is True
+    # Blocked by robots → no source recorded, no LLM call fired.
     assert result.output.attributes["scraped_sources"] == []
 
 
 # ---------------------------------------------------------------------------
-# URL wiring: catalog.link column → ProductInput.link → _pick_url
+# Citation shape validation — URL must come from fetched pages
 # ---------------------------------------------------------------------------
 
-from app.enrichment.agents.web_scraper import _pick_url  # noqa: E402
 
-
-def test_pick_url_uses_product_link_field():
-    """Top-level catalog.link wired via ProductInput.link is the primary source."""
-    p = ProductInput(
-        product_id=uuid4(),
-        title="ThinkPad X1",
-        category="Electronics",
-        link="https://example-manufacturer.com/p123",
+def test_citation_shape_rejects_fabricated_url():
+    url = "https://lenovo.com/x1"
+    http = _FakeHttp({url: _Resp(200, "ThinkPad X1 with 16 GB RAM")})
+    backend = _FakeSearchBackend(
+        {
+            "ram_gb": [
+                SearchResult(url=url, title="X1", snippet="16 GB RAM", domain="lenovo.com")
+            ]
+        }
     )
-    assert _pick_url(p) == "https://example-manufacturer.com/p123"
-
-
-def test_pick_url_prefers_product_link_over_raw_attributes():
-    """ProductInput.link takes precedence over raw_attributes keys."""
-    p = ProductInput(
-        product_id=uuid4(),
-        title="ThinkPad X1",
-        category="Electronics",
-        link="https://example-manufacturer.com/p123",
-        raw_attributes={"merchant_product_url": "https://example-manufacturer.com/other"},
+    # LLM tries to cite a URL we never fetched — should be dropped.
+    llm_payload = {
+        "extracted": {
+            "ram_gb": {
+                "value": 16,
+                "source_url": "https://fabricated.com/page",
+                "snippet": "hallucinated",
+            }
+        }
+    }
+    agent = _agent(websearch_backend=backend, http=http, llm_payload=llm_payload)
+    result = agent.run(
+        _product(),
+        context={
+            "taxonomy": {"product_type": "laptop"},
+            "missing_fields": ["ram_gb"],
+        },
     )
-    assert _pick_url(p) == "https://example-manufacturer.com/p123"
-
-
-def test_pick_url_falls_back_to_raw_attributes_link():
-    """Backward compat: no top-level link but raw_attributes has 'link' key."""
-    p = ProductInput(
-        product_id=uuid4(),
-        title="ThinkPad X1",
-        category="Electronics",
-        raw_attributes={"link": "https://example-manufacturer.com/fallback"},
-    )
-    assert _pick_url(p) == "https://example-manufacturer.com/fallback"
-
-
-def test_pick_url_returns_none_when_no_url_anywhere():
-    p = ProductInput(product_id=uuid4(), title="ThinkPad X1", category="Electronics")
-    assert _pick_url(p) is None
-
-
-def test_scraper_end_to_end_uses_product_link_column():
-    """End-to-end: ProductInput with link= reaches scraper and fetches content."""
-    target_url = "https://example-manufacturer.com/spec/x"
-    http = _FakeHttp({target_url: _Resp(200, "<html>catalog-link-body</html>")})
-    agent = WebScraperAgent(scraper=ScraperClient(http_client=http))
-    product = ProductInput(
-        product_id=uuid4(),
-        title="ThinkPad X1",
-        category="Electronics",
-        link=target_url,
-        # raw_attributes intentionally empty — simulates mocklaptops with no JSONB link
-        raw_attributes={},
-    )
-    result = agent.run(product, context={"taxonomy": {"product_type": "laptop"}})
     assert result.success is True
-    assert result.output.attributes["scraped_sources"]
-    assert "catalog-link-body" in result.output.attributes["scraped_specs"]["raw_text_excerpt"]
+    # Fabricated URL rejected → no spec lands.
+    assert result.output.attributes["scraped_specs"] == {}
+    # We DID reach the allowlisted page; source should be recorded.
+    assert len(result.output.attributes["scraped_sources"]) == 1
+    assert result.output.attributes["scraped_sources"][0]["url"] == url
+
+
+def test_citation_shape_accepts_valid_url():
+    url = "https://lenovo.com/x1"
+    http = _FakeHttp({url: _Resp(200, "ThinkPad X1 16 GB RAM")})
+    backend = _FakeSearchBackend(
+        {
+            "ram_gb": [
+                SearchResult(url=url, title="X1", snippet="16 GB RAM", domain="lenovo.com"),
+            ]
+        }
+    )
+    llm_payload = {
+        "extracted": {
+            "ram_gb": {
+                "value": 16,
+                "source_url": url,
+                "snippet": "ThinkPad X1 16 GB RAM",
+            }
+        }
+    }
+    agent = _agent(websearch_backend=backend, http=http, llm_payload=llm_payload)
+    result = agent.run(
+        _product(),
+        context={
+            "taxonomy": {"product_type": "laptop"},
+            "missing_fields": ["ram_gb"],
+        },
+    )
+    assert result.success is True
+    specs = result.output.attributes["scraped_specs"]
+    assert "ram_gb" in specs
+    entry = specs["ram_gb"]
+    assert entry["value"] == 16
+    assert entry["source_url"] == url
+    assert entry["source_domain"] == "lenovo.com"
+    assert entry["snippet"] == "ThinkPad X1 16 GB RAM"
+    assert "extracted_at" in entry
+
+
+# ---------------------------------------------------------------------------
+# Cost cap enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_cost_caps_limit_searches_and_fetches():
+    """Budget: 2 searches + 3 fetches + 1 LLM call. Many missing fields
+    shouldn't drive spend above those caps."""
+    routes = {
+        f"https://lenovo.com/page{i}": _Resp(200, f"spec page {i}") for i in range(10)
+    }
+    http = _FakeHttp(routes)
+    # Every query returns 5 URLs from the allowlisted domain.
+    results = [
+        SearchResult(
+            url=f"https://lenovo.com/page{i}",
+            title=f"Page {i}",
+            snippet="",
+            domain="lenovo.com",
+        )
+        for i in range(5)
+    ]
+    # Same script matches any missing field substring.
+    backend = _FakeSearchBackend({"": results})
+
+    llm = _FakeLLM({"extracted": {}})
+    agent = _agent(websearch_backend=backend, http=http, llm=llm)
+    context = {
+        "taxonomy": {"product_type": "laptop"},
+        "missing_fields": [
+            "ram_gb",
+            "storage_gb",
+            "cpu_model",
+            "gpu_model",
+            "display_size_in",
+            "refresh_rate_hz",
+            "weight_kg",
+            "battery_life_hours",
+            "os",
+        ],
+    }
+    result = agent.run(_product(), context=context)
+    assert result.success is True
+    budget = context.get("_scraper_budget") or {}
+    assert budget["search_calls"] <= 2
+    assert budget["fetch_calls"] <= 3
+    assert budget["llm_calls"] <= 1
+    # LLM was called exactly once because at least one page fetch succeeded.
+    assert len(llm.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# LLM-failure resilience
+# ---------------------------------------------------------------------------
+
+
+def test_llm_failure_falls_back_to_empty_specs():
+    url = "https://lenovo.com/x1"
+    http = _FakeHttp({url: _Resp(200, "spec body")})
+    backend = _FakeSearchBackend(
+        {
+            "ram_gb": [
+                SearchResult(url=url, title="X1", snippet="", domain="lenovo.com")
+            ]
+        }
+    )
+
+    class _BoomLLM:
+        def complete(self, **kw):
+            raise RuntimeError("llm exploded")
+
+    agent = _agent(websearch_backend=backend, http=http, llm=_BoomLLM())
+    result = agent.run(
+        _product(),
+        context={
+            "taxonomy": {"product_type": "laptop"},
+            "missing_fields": ["ram_gb"],
+        },
+    )
+    assert result.success is True
+    # No specs extracted, but the source we fetched was recorded.
+    assert result.output.attributes["scraped_specs"] == {}
+    assert len(result.output.attributes["scraped_sources"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Null backend (disabled explicitly via WebSearchClient)
+# ---------------------------------------------------------------------------
+
+
+def test_null_backend_returns_no_sources():
+    agent = _agent(websearch_backend=NullBackend(), http=_FakeHttp())
+    result = agent.run(
+        _product(),
+        context={
+            "taxonomy": {"product_type": "laptop"},
+            "missing_fields": ["ram_gb"],
+        },
+    )
+    assert result.success is True
+    # No results from search → no fetches → no specs.
+    assert result.output.attributes["scraped_sources"] == []
+    assert result.output.attributes["scraped_specs"] == {}

--- a/mcp-server/tests/enrichment/test_websearch_client.py
+++ b/mcp-server/tests/enrichment/test_websearch_client.py
@@ -1,0 +1,113 @@
+"""Unit tests for the Tavily websearch wrapper + WebSearchClient facade.
+
+Mocks Tavily with a fake httpx-style client — no network.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.enrichment.tools.websearch_client import (
+    NullBackend,
+    SearchResult,
+    TavilyBackend,
+    WebSearchClient,
+)
+
+
+class _Resp:
+    def __init__(self, status_code=200, body=None):
+        self.status_code = status_code
+        self._body = body or {}
+
+    def json(self):
+        return self._body
+
+
+class _FakeHttp:
+    def __init__(self, response: _Resp):
+        self._resp = response
+        self.calls: list[tuple[str, dict]] = []
+
+    def post(self, url, *, json=None, timeout=None):
+        self.calls.append((url, json))
+        return self._resp
+
+
+def test_tavily_missing_api_key_returns_empty():
+    http = _FakeHttp(_Resp(200, {"results": []}))
+    backend = TavilyBackend(api_key=None, http_client=http)
+    assert backend.search("laptop ram_gb") == []
+    assert http.calls == []
+
+
+def test_tavily_parses_results():
+    http = _FakeHttp(
+        _Resp(
+            200,
+            {
+                "results": [
+                    {
+                        "url": "https://lenovo.com/x1",
+                        "title": "X1",
+                        "content": "Thinkpad X1 has 16 GB RAM",
+                    },
+                    {
+                        "url": "https://example.com/other",
+                        "title": "Other",
+                        "content": "whatever",
+                    },
+                ]
+            },
+        )
+    )
+    backend = TavilyBackend(api_key="sk-test", http_client=http)
+    results = backend.search("x1", max_results=5)
+    assert len(results) == 2
+    assert results[0].url == "https://lenovo.com/x1"
+    assert results[0].domain == "lenovo.com"
+    assert "Thinkpad" in results[0].snippet
+
+
+def test_tavily_bad_status_returns_empty():
+    http = _FakeHttp(_Resp(status_code=500, body={}))
+    backend = TavilyBackend(api_key="sk", http_client=http)
+    assert backend.search("x") == []
+
+
+def test_tavily_respects_max_results():
+    http = _FakeHttp(
+        _Resp(
+            200,
+            {
+                "results": [
+                    {"url": f"https://lenovo.com/{i}", "title": "", "content": ""}
+                    for i in range(10)
+                ]
+            },
+        )
+    )
+    backend = TavilyBackend(api_key="sk", http_client=http)
+    results = backend.search("x", max_results=3)
+    assert len(results) == 3
+
+
+def test_client_disabled_by_env(monkeypatch):
+    http = _FakeHttp(
+        _Resp(200, {"results": [{"url": "https://lenovo.com/x", "title": "", "content": ""}]})
+    )
+    backend = TavilyBackend(api_key="sk", http_client=http)
+    monkeypatch.setenv("ENRICHMENT_DISABLE_WEBSEARCH", "1")
+    client = WebSearchClient(backend=backend)
+    assert client.search("x") == []
+    # Backend was never hit.
+    assert http.calls == []
+
+
+def test_client_empty_query_returns_empty(monkeypatch):
+    monkeypatch.delenv("ENRICHMENT_DISABLE_WEBSEARCH", raising=False)
+    client = WebSearchClient(backend=NullBackend())
+    assert client.search("") == []
+    assert client.search("   ") == []


### PR DESCRIPTION
Closes interactive-decision-support-system/merchant-agent#17 (sub of interactive-decision-support-system/merchant-agent#16 rec interactive-decision-support-system/idss-backend#1).

## Summary

Replaces the no-op `scraper_v1` URL-only scraper with a gated gap-filler that runs post-specialist / pre-composer, queries Tavily for missing per-category spec fields, fetches top allowlisted pages through the existing `ScraperClient` (robots + cache + rate-limit untouched), and extracts values **with citations** in a single LLM call. All output is cited; no bare values.

## Changes

- **`tools/websearch_client.py`** (new) — `WebSearchBackend` protocol + `TavilyBackend` default + `NullBackend` for disabled mode. Honors `ENRICHMENT_DISABLE_WEBSEARCH=1`; warns (no crash) when `TAVILY_API_KEY` is unset.
- **`config/scraper_sources.yaml`** — expanded from 1 domain to per-category curated allowlists (laptop + electronics; Amazon/BestBuy/Newegg + manufacturer sites).
- **`agents/web_scraper.py`** — full rewrite. Early-returns on no-gaps / no-API-key / disabled. Budget caps: 2 searches + 3 fetches + 1 LLM call per product. Emits the cited schema `scraped_specs: {field: {value, source_url, source_domain, snippet, extracted_at}}`. Rejects fabricated URLs post-LLM. `STRATEGY = "scraper_v1"` preserved.
- **`orchestration/runner.py`** — computes `ctx['missing_fields']` from the category gap list minus parser/raw-attribute fills, stamped just before scraper runs.
- **`agents/composer.py`** — pre-flattens the cited `scraped_specs` for the LLM prompt, then re-attaches `ComposerDecision.source = {kind:'scraped', url, domain, snippet}` for any key scraper filled. Works through both LLM and deterministic-fallback paths. Synthesized decisions for scraper-owned keys get upgraded from parametric to scrape.
- **`types.py`** — new `CitationSource` model + optional `source: CitationSource | None` on `ComposerDecision`.
- **`metrics.py`** — adds `scraper_products_gated_in/out`, `scraper_fields_attempted/filled/conflicted_with_parser`, `scraper_search_calls`, `scraper_crawl_calls`, `scraper_allowlist_blocks`, `scraper_robots_blocks`, `scraper_cost_usd` to per-run metrics.

## Decisions (from interactive-decision-support-system/merchant-agent#17 open questions)

Locked as defaults; happy to revisit.

1. **Pipeline position.** Gated, post-specialist, pre-composer (existing slot in `orchestration/fixed.py`).
2. **Websearch provider.** Tavily, behind the `WebSearchBackend` protocol. Env var `TAVILY_API_KEY`. Missing key → agent warns and early-returns empty outputs.
3. **Per-product cost caps.** 2 search calls + 3 page fetches + 1 LLM extraction. Enforced in-agent; surfaced to `ctx['_scraper_budget']` and the run metrics.
4. **`missing_fields` scoping.** Hard-coded per-category list (laptop only for now: `ram_gb, storage_gb, cpu_model, gpu_model, display_size_in, refresh_rate_hz, weight_kg, battery_life_hours, os`). Populated by runner from `parsed_specs` + `raw_attributes`.

## Out of scope (per interactive-decision-support-system/merchant-agent#17)

- `scraped_reviews` / `scraped_qna` stay `[]`.
- No confidence contract changes beyond the missing-fields signal.
- Raw `products` table untouched.

## Tests

New / updated unit tests (157 pass, mocks only, no network):

- `tests/enrichment/test_websearch_client.py` — Tavily request/response shaping, disabled env var, empty query.
- `tests/enrichment/test_web_scraper.py` — rewritten: no-gap early return, no-API-key early return, disabled env short-circuit, allowlist block, robots block, fabricated-URL rejection, valid-URL citation shape, cost-cap enforcement, LLM failure fallback, null backend.
- `tests/enrichment/test_composer.py` — citation attached via LLM path, fallback path, and synthesized-decision path.
- `tests/enrichment/test_metrics.py` — gated-in/out, conflict-with-parser counts.
- `tests/enrichment/test_runner.py` — `_compute_missing_fields` for laptop + unknown category.

`pytest mcp-server/tests/enrichment/` → 157 passed.

## Validation plan (NOT run here — needs live API keys)

1. **200-mocklaptops batch** with the scraper enabled (`TAVILY_API_KEY` set, `ENRICHMENT_DISABLE_WEBSEARCH` unset). Success criteria:
   - **Zero fabrication.** Every `scraped_specs.*.source_url` resolves to a URL in the run's `scraped_sources` list (the in-agent rejection should enforce this, but spot-check the run artifact).
   - Low fill rate is acceptable here — mocklaptops are fake products; the test is "does the scraper refuse to invent data when search returns nothing relevant".
   - Per-product cost stays under ~\$0.03 (1 search + 2-3 fetches + 1 small LLM call).

2. **10-20 real-laptop sample** (e.g. pick real models from existing mocklaptops like "ThinkPad X1", "MacBook Pro 14", "Framework 13"). Success criteria:
   - Measurable fill lift on the per-category gap fields vs. baseline (baseline = same run with `ENRICHMENT_DISABLE_WEBSEARCH=1`).
   - Each filled field has a citation pointing to a plausible manufacturer or retailer page.
   - Conflict rate (scraper vs. parser) reported in `scraper_fields_conflicted_with_parser` — should be small but non-zero.

3. **Langfuse scores** — verify the new `scraper_*` metrics land as run-level scores, not null/missing.

The caller runs this; we stopped at unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)