### PR TITLE
refactor(enrichment): default-off soft_tagger_v1 (#115 pt 2)

### DIFF
--- a/mcp-server/app/enrichment/agents/assessor.py
+++ b/mcp-server/app/enrichment/agents/assessor.py
@@ -35,12 +35,14 @@ _MAX_COMPLETION_TOKENS = 2000
 # about them without circular imports of the agent classes themselves.
 # composer_v1 always runs (single writer of the canonical row — #83); the
 # orchestrator appends it last regardless of assessor filtering.
+# soft_tagger_v1 is opt-in only — default-off per issue #115 point 2
+# (label explosion + 67% of generation spend for a signal with no confirmed
+# downstream consumer). Pass it explicitly in recommended_strategies to enable.
 _AVAILABLE_STRATEGIES = (
     "taxonomy_v1",
     "parser_v1",
     "specialist_v1",
     "scraper_v1",
-    "soft_tagger_v1",
     "composer_v1",
 )
 

--- a/mcp-server/app/enrichment/orchestration/orchestrated.py
+++ b/mcp-server/app/enrichment/orchestration/orchestrated.py
@@ -1,9 +1,9 @@
 """LLMOrchestrator: per product, asks an LLM which subset of strategies to run.
 
 The LLM sees the assessor output + a per-product summary and returns a list of
-strategy labels. taxonomy_v1 is force-included (the specialist needs it);
-soft_tagger_v1 is force-included (cheap and high-value). Everything else is
-the LLM's call.
+strategy labels. taxonomy_v1 is force-included (the specialist needs it).
+Everything else is the LLM's call. soft_tagger_v1 is off by default (#115
+point 2) — opt in by naming it in recommended_strategies upstream.
 """
 
 from __future__ import annotations
@@ -27,21 +27,23 @@ _SYSTEM = (
     "  specialist_v1   adds capabilities + use-case fit + buyer questions. MEDIUM.\n"
     "  scraper_v1      fetches an external page (only useful if a manufacturer "
     "URL is present and the catalog is sparse). EXPENSIVE.\n"
+    "  soft_tagger_v1  emits good_for_* subjective tags. OFF by default — only "
+    "include if the caller has a confirmed downstream consumer of these tags.\n"
     "Rules:\n"
     "  - Always include parser_v1 when the product has a description.\n"
     "  - Skip specialist_v1 when the title is too sparse to enrich meaningfully.\n"
     "  - Skip scraper_v1 unless raw_attributes already lists a merchant_product_url.\n"
+    "  - Skip soft_tagger_v1 unless explicitly requested — default off.\n"
     "  - Output exactly one entry per product_id you were given."
 )
 
 
 class LLMOrchestrator:
-    # taxonomy and soft_tagger are not negotiable — taxonomy gates everything,
-    # soft_tagger is cheap and the KG depends on it. composer_v1 is the single
-    # writer of the canonical row (#83) and must always run last. The LLM only
-    # chooses among the others.
-    _FORCED = ("taxonomy_v1", "soft_tagger_v1")
-    _CHOOSABLE = ("parser_v1", "specialist_v1", "scraper_v1")
+    # taxonomy is not negotiable — it gates everything downstream. composer_v1
+    # is the single writer of the canonical row (#83) and must always run last.
+    # The LLM chooses among the rest; soft_tagger_v1 is opt-in only (#115 pt 2).
+    _FORCED = ("taxonomy_v1",)
+    _CHOOSABLE = ("parser_v1", "specialist_v1", "scraper_v1", "soft_tagger_v1")
     _TRAILING = ("composer_v1",)
 
     def __init__(self, llm: LLMClient | None = None) -> None:

--- a/mcp-server/tests/enrichment/test_orchestration_llm.py
+++ b/mcp-server/tests/enrichment/test_orchestration_llm.py
@@ -1,4 +1,7 @@
-"""Phase 3: LLMOrchestrator — forces taxonomy + soft_tagger, lets LLM choose the rest."""
+"""Phase 3: LLMOrchestrator — forces taxonomy, lets LLM choose the rest.
+
+soft_tagger_v1 is default-off (#115 point 2); it is choosable but not forced.
+"""
 
 from __future__ import annotations
 
@@ -25,7 +28,7 @@ class _FakeLLM:
         )
 
 
-def test_llm_orchestrator_forces_taxonomy_and_soft_tagger():
+def test_llm_orchestrator_forces_taxonomy_only():
     pid = uuid4()
     products = [ProductInput(product_id=pid, title="x")]
     payload = {"per_product": [{"product_id": str(pid), "strategies": ["parser_v1"]}]}
@@ -34,10 +37,23 @@ def test_llm_orchestrator_forces_taxonomy_and_soft_tagger():
     )
     chosen = plan.per_product_agents[pid]
     assert "taxonomy_v1" in chosen  # forced
-    assert "soft_tagger_v1" in chosen  # forced
+    assert "soft_tagger_v1" not in chosen  # default-off since #115 pt 2
     assert "parser_v1" in chosen  # LLM picked
     assert "specialist_v1" not in chosen
     assert "scraper_v1" not in chosen
+
+
+def test_llm_orchestrator_runs_soft_tagger_when_llm_opts_in():
+    pid = uuid4()
+    products = [ProductInput(product_id=pid, title="x")]
+    payload = {
+        "per_product": [{"product_id": str(pid), "strategies": ["soft_tagger_v1"]}]
+    }
+    plan = LLMOrchestrator(llm=_FakeLLM(payload)).plan(
+        products, AssessorOutput(catalog_size=1)
+    )
+    chosen = plan.per_product_agents[pid]
+    assert "soft_tagger_v1" in chosen
 
 
 def test_llm_orchestrator_filters_unknown_strategies():
@@ -63,7 +79,7 @@ def test_llm_orchestrator_falls_back_to_forced_only_on_planning_failure():
     chosen = plan.per_product_agents[pid]
     # composer_v1 always trails — it is the single writer of the canonical
     # row (#83) and must run even when LLM planning fails.
-    assert chosen == ["taxonomy_v1", "soft_tagger_v1", "composer_v1"]
+    assert chosen == ["taxonomy_v1", "composer_v1"]
 
 
 def test_llm_orchestrator_empty_products():

--- a/mcp-server/tests/enrichment/test_runner.py
+++ b/mcp-server/tests/enrichment/test_runner.py
@@ -173,14 +173,14 @@ def test_fixed_run_writes_one_row_per_strategy_per_product(patched_runtime):
         dry_run=False,
     )
     assert result.summary.products_processed == 3
-    # 6 strategies × 3 products = 18 outputs (composer_v1 runs last as the
-    # single writer of the canonical row — #83).
+    # 5 strategies × 3 products = 15 outputs. soft_tagger_v1 is default-off
+    # since #115 pt 2; composer_v1 runs last as the single writer of the
+    # canonical row — #83.
     expected_strategies = {
         "taxonomy_v1",
         "parser_v1",
         "specialist_v1",
         "scraper_v1",
-        "soft_tagger_v1",
         "composer_v1",
     }
     assert set(result.summary.strategies_invoked.keys()) == expected_strategies
@@ -215,15 +215,16 @@ def test_run_reports_avg_keys_filled(patched_runtime):
     result = runner.run_enrichment(db=None, mode="fixed", limit=2, dry_run=True)
     avg = result.summary.to_dict()["avg_keys_filled_per_product"]
     # Each successful agent contributes substantive (non-empty) values only.
-    # taxonomy(3) + parser(3) + specialist(4) + scraper(2) + soft_tagger(2)
-    # + composer(4: composed_fields, composer_decisions, composed_at, incomplete_decisions) = 18.
+    # taxonomy(3) + parser(3) + specialist(4) + scraper(2)
+    # + composer(4: composed_fields, composer_decisions, composed_at, incomplete_decisions) = 16.
+    # soft_tagger_v1 is default-off since #115 pt 2 (was previously 2).
     # scraper drops from 6 → 2 because scraped_specs={}, scraped_reviews=[],
     # scraped_qna=[], scraped_sources=[] are all empty containers and no longer
     # count — the fixture products have no URL, so the scraper produces nothing
     # useful for those four keys. scraped_at and scraped_category remain.
     # composer gains incomplete_decisions=True (PR #97: 1:1 reconciler synthesizes
     # decisions for storage_gb and product_type which the scripted LLM omitted).
-    assert avg == 18.0
+    assert avg == 16.0
 
 
 def test_avg_keys_filled_treats_empty_container_as_unfilled(monkeypatch):
@@ -266,11 +267,12 @@ def test_avg_keys_filled_treats_empty_container_as_unfilled(monkeypatch):
 def test_orchestrated_run_skips_scraper_when_no_url(patched_runtime):
     # The LLMOrchestrator should opt out of scraper_v1 since no products have URLs.
     # Our scripted LLM doesn't return a per_product plan for the orchestrator,
-    # so it falls back to forced-only (taxonomy + soft_tagger). Verify.
+    # so it falls back to forced-only (taxonomy + composer). soft_tagger_v1 is
+    # default-off since #115 pt 2 — not forced and not in the fallback set.
     result = runner.run_enrichment(db=None, mode="orchestrated", limit=2, dry_run=True)
     assert result.summary.strategies_invoked.get("scraper_v1", 0) == 0
     assert result.summary.strategies_invoked["taxonomy_v1"] == 2
-    assert result.summary.strategies_invoked["soft_tagger_v1"] == 2
+    assert result.summary.strategies_invoked.get("soft_tagger_v1", 0) == 0
 
 
 def test_run_with_no_products_returns_empty_result(monkeypatch):


### PR DESCRIPTION
## Summary

- Implements interactive-decision-support-system/merchant-agent#16 point 2: removes \`soft_tagger_v1\` from the default enrichment strategy set.
- Default-off, not deleted — agent, runner wiring, composer fallback, KG projection rules all stay inert and reachable via explicit \`recommended_strategies\`. Reversible if downstream regressions surface.
- Per the audit, soft_tagger produced 67% of all generated values yet 42% of new columns were filled on a single product (label explosion). No confirmed downstream consumer of \`good_for_*\` today.

## Changes

- \`assessor.py\`: drop \`soft_tagger_v1\` from \`_AVAILABLE_STRATEGIES\`.
- \`orchestrated.py\` (LLMOrchestrator): \`_FORCED\` now taxonomy-only; soft_tagger moved to \`_CHOOSABLE\`. System prompt updated to describe it as off-by-default.
- Tests: \`test_orchestration_llm.py\` asserts taxonomy-only forced + adds opt-in regression; \`test_runner.py\` expected strategies down to 5 (15 rows / 3 products), \`avg_keys_filled\` 18 → 16.

## Smoke run (10 mocklaptops, fixed mode, dry-run)

| metric | before (audit 200) | after (smoke 10) |
|---|---:|---:|
| strategies invoked | 6 | **5** (no soft_tagger) |
| avg keys filled / product | ~18 | **15.9** |
| cost / product | \$0.077 | **\$0.066** (~14% drop) |

All 10 products succeeded; no failed strategies.

## Test plan

- [x] \`pytest mcp-server/tests/enrichment/ mcp-server/tests/test_kg_contract.py\` → 148 passed
- [x] 10-product dry-run smoke on \`mocklaptops\` — output in \`runs/smoke_soft_tagger/run.json\`
- [ ] Monitor search/ranking for any regression before considering a follow-up that deletes the inert plumbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)